### PR TITLE
Add chains to search bar

### DIFF
--- a/src/pages/ComparisonPage.js
+++ b/src/pages/ComparisonPage.js
@@ -131,7 +131,7 @@ const TokenComparisonSearch = ({ protocolAorB, tokenValid, tokenSymbol, logo, ad
     {tokenValid ?
       <DisplayToken tokenSymbol={tokenSymbol} logo={logo} address={address} price={price} resetDisplay={customOnLinkClick(protocolAorB)} />
       :
-      <Search linkPath={handleLinkPath(protocolAorB)} customOnLinkClick={customOnLinkClick(protocolAorB)} />
+      <Search linkPath={handleLinkPath(protocolAorB)} customOnLinkClick={customOnLinkClick(protocolAorB)} includeChains={false} />
     }
   </Column>
 )

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -419,6 +419,22 @@ export function rawPercent(percentRaw) {
   return percent.toFixed(0) + '%'
 }
 
+export function getChainsFromAllTokenData(data) {
+  const chainsUniqueSet = new Set()
+  Object.values(data).forEach(token => {
+    if (token.category === 'Chain') return
+    token.chains.forEach(chain => {
+      chainsUniqueSet.add(chain)
+    })
+  })
+  const chainsUnique = Array.from(chainsUniqueSet)
+  return chainsUnique.map(name => ({
+    logo: chainIconUrl(name),
+    isChain: true,
+    name
+  }))  
+}
+
 export function chainIconUrl(chain) {
   return `https://icons.llama.fi/chains/rsz_${chain.toLowerCase()}.jpg`
 }


### PR DESCRIPTION
This PR adds chains to the Search component by filtering them out of allTokenData, given that the includeChains prop is true (passed true by default, it seems the only place where this is not wanted is the comparison page).