### PR TITLE
Fix isValidProtocol incorrectly matching protocol names with dashes

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -434,7 +434,7 @@ export function getChainsFromAllTokenData(data) {
     logo: chainIconUrl(name),
     isChain: true,
     name
-  }))  
+  }))
 }
 
 export function chainIconUrl(chain) {
@@ -532,7 +532,7 @@ export function isEquivalent(a, b) {
 export function isValidProtocol(tokensObject, protocol) {
   try {
     const tokens = Object.values(tokensObject)
-    const isValid = tokens.some(token => token.name.toLowerCase().split(' ').join('').split('-').join('') === protocol.split('-').join(''))
+    const isValid = tokens.some(token => (protocol.includes('-') && token.name.includes('-') && (token.name.toLowerCase().split(' ').join('').split('-').join('') === protocol.split('-').join(''))) || token.name.toLowerCase().split(' ').join('') === protocol)
     return isValid
   } catch (error) {
     return false

--- a/src/utils/utils.spec.js
+++ b/src/utils/utils.spec.js
@@ -1,0 +1,19 @@
+import { isValidProtocol } from './index'
+
+describe('utils/index', () => {
+    describe('isValidProtocol', () => {
+
+        const tokensObject = { 0: { name: 'uniswap' }, 1: { name: 'defi-protocol' } }
+
+        it('returns true if protocol exactly matches a name in tokens dictionary', () => {
+            expect(isValidProtocol(tokensObject, 'uniswap')).toBe(true)
+            expect(isValidProtocol(tokensObject, 'defi-protocol')).toBe(true)
+        })
+
+        it('returns false if protocol doesnt exactly match a name in tokens dictionary', () => {
+            expect(isValidProtocol(tokensObject, 'defiprotocol')).toBe(false)
+            expect(isValidProtocol(tokensObject, 'uni-swap')).toBe(false)
+            expect(isValidProtocol(tokensObject, 'llama')).toBe(false)
+        })
+    })
+})


### PR DESCRIPTION
Ran into issue where evolution-land was matching to evolutionland, resulting in a blank page not redirecting correctly.
Our page requires the exact pattern evolutionland in order to query data properly.