### PR TITLE
Add chain filters to protocol

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -64,12 +64,13 @@ function App() {
                 <Route
                   exacts
                   strict
-                  path="/protocols/:category"
+                  path="/protocols/:category/:chain?"
                   render={({ match }) => {
                     const category = match.params.category
+                    const chain = match.params.chain
                     if (Object.values(allTokens).some(protocol => (protocol.category || '').toLowerCase() === category.toLowerCase())) {
                       return (<LayoutWrapper savedOpen={savedOpen} setSavedOpen={setSavedOpen}>
-                        <AllTokensPage category={category} categoryName={category} />
+                      <AllTokensPage category={category} selectedChain={chain} />
                       </LayoutWrapper>)
                     } else {
                       return <Redirect to="/protocols" />

--- a/src/components/TokenList/index.js
+++ b/src/components/TokenList/index.js
@@ -110,7 +110,7 @@ const SORT_FIELD = {
 
 
 // @TODO rework into virtualized list
-function TokenList({ tokens }) {
+function TokenList({ tokens, filters }) {
 
   const below1080 = useMedia('(max-width: 1080px)')
   const below680 = useMedia('(max-width: 680px)')
@@ -122,7 +122,7 @@ function TokenList({ tokens }) {
 
 
   const filteredList = useMemo(() => {
-    if (!tokens) {
+    if (!tokens || !tokens.length) {
       return tokens
     }
     let sortedTokens = tokens
@@ -146,7 +146,7 @@ function TokenList({ tokens }) {
   const { LoadMoreButton,
     dataLength,
     hasMore,
-    next } = useInfiniteScroll({ list: filteredList });
+    next } = useInfiniteScroll({ list: filteredList, filters });
 
 
   const ListItem = ({ item, index }) => {

--- a/src/constants/chainTokens.js
+++ b/src/constants/chainTokens.js
@@ -302,3 +302,4 @@ export const chainCoingeckoIds = {
 
 export const basicChainOptions = ['All', 'Ethereum', 'Solana', 'Polygon', 'Fantom', 'Avalanche']
 export const extraChainOptions = ['Terra', 'Arbitrum', 'Binance', 'Celo', 'Harmony']
+export const priorityDropdownOptions = ["Tron", "Waves", "Heco", "Celo"]

--- a/src/constants/chainTokens.js
+++ b/src/constants/chainTokens.js
@@ -302,4 +302,4 @@ export const chainCoingeckoIds = {
 
 export const basicChainOptions = ['All', 'Ethereum', 'Solana', 'Polygon', 'Fantom', 'Avalanche']
 export const extraChainOptions = ['Terra', 'Arbitrum', 'Binance', 'Celo', 'Harmony']
-export const priorityDropdownOptions = ["Tron", "Waves", "Heco", "Celo"]
+export const priorityDropdownOptions = ["Tron", "Waves", "Heco"]

--- a/src/constants/chainTokens.js
+++ b/src/constants/chainTokens.js
@@ -299,3 +299,6 @@ export const chainCoingeckoIds = {
     cmcId: "5802",
   },
 }
+
+export const basicChainOptions = ['All', 'Ethereum', 'Solana', 'Polygon', 'Fantom', 'Avalanche']
+export const extraChainOptions = ['Terra', 'Arbitrum', 'Binance', 'Celo', 'Harmony']

--- a/src/hooks/useInfiniteScroll.jsx
+++ b/src/hooks/useInfiniteScroll.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, } from 'react'
 import { ChevronsUp } from 'react-feather'
 import { Button } from 'rebass'
 
-export default function useInfiniteScroll({ list = [], numInView = 25 }) {
+export default function useInfiniteScroll({ list = [], numInView = 25, filters = [] }) {
 
     const [dataLength, setDatalength] = useState(numInView)
     const [hasMore, setHasMore] = useState(true)
@@ -17,8 +17,14 @@ export default function useInfiniteScroll({ list = [], numInView = 25 }) {
                 setDisplayScrollToTopButton(false);
             }
         });
-
     }, [])
+
+    // Reset when category changes or else might be limited if one category is smaller than the other
+    const stringifyFilters = JSON.stringify(filters)
+    useEffect(() => {
+        setHasMore(true)
+        setDatalength(numInView)
+    }, [stringifyFilters, numInView])
 
     const handleScrollToTop = () => {
         window.scrollTo({

--- a/src/pages/AllTokensPage.js
+++ b/src/pages/AllTokensPage.js
@@ -1,33 +1,95 @@
-import React, { useEffect } from 'react'
-
-import TokenList from '../components/TokenList'
-import { TYPE } from '../Theme'
-import Panel from '../components/Panel'
-import { useAllTokenData } from '../contexts/TokenData'
-import { PageWrapper, FullWrapper } from '../components'
-import { RowBetween } from '../components/Row'
-import Search from '../components/Search'
+import React, { useEffect, useMemo, useState } from 'react'
+import styled from 'styled-components'
 import { useMedia } from 'react-use'
 
-function AllTokensPage(props) {
-  const { category, categoryName } = props
-  let allTokens = Object.values(useAllTokenData()).map(token => ({
-    ...token,
-    mcaptvl: (token.tvl !== 0 && token.mcap) ? token.mcap / token.tvl : null,
-    fdvtvl: (token.tvl !== 0 && token.fdv) ? token.fdv / token.tvl : null,
-  }))
+import DropdownSelect from 'components/DropdownSelect'
+import TokenList from 'components/TokenList'
+import Panel from 'components/Panel'
+import { useAllTokenData } from 'contexts/TokenData'
+import { PageWrapper, FullWrapper } from 'components'
+import { AutoRow, RowBetween, RowFlat } from 'components/Row'
+import Search from 'components/Search'
+import { ButtonLight, ButtonDark } from 'components/ButtonStyled'
 
+import { TYPE } from 'Theme'
+
+import { basicChainOptions, extraChainOptions } from 'constants/chainTokens'
+
+const ListOptions = styled(AutoRow)`
+  height: 40px;
+  width: 100%;
+  font-size: 1.25rem;
+  font-weight: 600;
+
+  @media screen and (max-width: 640px) {
+    font-size: 1rem;
+  }
+`
+
+function AllTokensPage({ category, categoryName }) {
+  const below600 = useMedia('(max-width: 600px)')
+  const below800 = useMedia('(max-width: 800px)')
+  const below1400 = useMedia('(max-width: 1400px)')
+
+  const [selectedChain, setSelectedChain] = useState('All')
+
+  const setActive = (chain) => () => {setSelectedChain(chain)}
+
+
+  const chainsSet = new Set([])
+  let chainOptions = []
+  if (below800) {
+    chainOptions = [basicChainOptions[0], 'Others']
+  } else if (below1400) {
+    chainOptions = [...basicChainOptions, 'Others']
+  } else {
+    chainOptions = [...basicChainOptions, ...extraChainOptions, 'Others']
+  }
+  chainOptions.forEach(chain => chainsSet.delete(chain))
+  const otherChains = Array.from(chainsSet)
+
+  let allTokens = Object.values(useAllTokenData())
   if (category) {
     allTokens = allTokens.filter((token) => (token.category || '').toLowerCase() === category.toLowerCase() && token.category !== "Chain")
   } else {
     allTokens = allTokens.filter((token) => token.category !== "Chain")
   }
 
+  allTokens = allTokens.map(token => {
+      // Populate chain dropdown options
+     token.chains.forEach(chain => {
+        chainsSet.add(chain)
+      })
+      if (selectedChain !== 'All') {
+        const chainTvl = token.chainTvls[selectedChain]
+
+        if (chainTvl === undefined) {
+          return null
+        }
+        
+        if (token.chains.length > 1) {
+          // do not return mcap/tvl for specific chain since tvl is spread accross chains
+          return {
+            ...token,
+            tvl: chainTvl
+          }
+        }
+      }
+      // if only chain return the full mcap/tvl or All selected
+      return {
+        ...token,
+        mcaptvl: (token.tvl !== 0 && token.mcap) ? token.mcap / token.tvl : null,
+        fdvtvl: (token.tvl !== 0 && token.fdv) ? token.fdv / token.tvl : null,
+      }
+  }).filter(token => token !== null)
+
   useEffect(() => {
     window.scrollTo(0, 0)
-  }, [])
+  }, [category])
 
-  const below600 = useMedia('(max-width: 800px)')
+  console.log(allTokens)
+
+
   let title = `TVL Rankings`
   if (categoryName) {
     title = `${categoryName} TVL Rankings`
@@ -41,8 +103,27 @@ function AllTokensPage(props) {
           <TYPE.largeHeader>{title}</TYPE.largeHeader>
           {!below600 && <Search small={true} />}
         </RowBetween>
+        <ListOptions gap="10px" style={{ marginTop: '2rem', marginBottom: '.5rem' }}>
+            <RowBetween>
+              <RowFlat>
+                  {chainOptions.map((name, i) => {
+                    if (name === "Others") {
+                      return <DropdownSelect key={name} options={otherChains.reduce((acc, item) => ({
+                        ...acc,
+                        [item]: item
+                      }), {})} active={(chainOptions.includes(selectedChain) || selectedChain === undefined) ? 'Other' : selectedChain} setActive={setSelectedChain} />
+                    }
+                    if (selectedChain === name) {
+                      return <ButtonDark style={{ margin: '0.2rem' }} key={name} onClick={setActive(name)} >{name}</ButtonDark>
+                    } else {
+                      return <ButtonLight style={{ margin: '0.2rem' }} key={name} onClick={setActive(name)} >{name}</ButtonLight>
+                    }
+                  })}
+              </RowFlat>
+            </RowBetween>
+          </ListOptions>
         <Panel style={{ marginTop: '6px', padding: below600 && '1rem 0 0 0 ' }}>
-          <TokenList tokens={allTokens} />
+          <TokenList tokens={allTokens} filters={[category, selectedChain]} />
         </Panel>
       </FullWrapper>
     </PageWrapper>

--- a/src/pages/AllTokensPage.js
+++ b/src/pages/AllTokensPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, } from 'react'
+import React, { useEffect } from 'react'
 import styled from 'styled-components'
 import { useMedia } from 'react-use'
 import { withRouter } from 'react-router-dom'
@@ -37,10 +37,10 @@ function AllTokensPage({ category, selectedChain = 'All', history }) {
     if (chain === 'All') return `/protocols/${category}`
     if (!category) {
       return `/chains/${chain}`
-    } 
+    }
     return `/protocols/${category}/${chain}`
   }
-  const setSelectedChain = (newSelectedChain) => history.push(handleRouting(newSelectedChain))
+  const setSelectedChain = newSelectedChain => history.push(handleRouting(newSelectedChain))
 
   const chainsSet = new Set([])
   let chainOptions = []
@@ -54,14 +54,17 @@ function AllTokensPage({ category, selectedChain = 'All', history }) {
 
   let allTokens = Object.values(useAllTokenData())
   if (category) {
-    allTokens = allTokens.filter((token) => (token.category || '').toLowerCase() === category.toLowerCase() && token.category !== "Chain")
+    allTokens = allTokens.filter(
+      token => (token.category || '').toLowerCase() === category.toLowerCase() && token.category !== 'Chain'
+    )
   } else {
-    allTokens = allTokens.filter((token) => token.category !== "Chain")
+    allTokens = allTokens.filter(token => token.category !== 'Chain')
   }
 
-  allTokens = allTokens.map(token => {
+  allTokens = allTokens
+    .map(token => {
       // Populate chain dropdown options
-     token.chains.forEach(chain => {
+      token.chains.forEach(chain => {
         chainsSet.add(chain)
       })
       if (selectedChain !== 'All') {
@@ -70,7 +73,7 @@ function AllTokensPage({ category, selectedChain = 'All', history }) {
         if (chainTvl === undefined) {
           return null
         }
-        
+
         if (token.chains.length > 1) {
           // do not return mcap/tvl for specific chain since tvl is spread accross chains
           return {
@@ -82,12 +85,13 @@ function AllTokensPage({ category, selectedChain = 'All', history }) {
       // if only chain return the full mcap/tvl or All selected
       return {
         ...token,
-        mcaptvl: (token.tvl !== 0 && token.mcap) ? token.mcap / token.tvl : null,
-        fdvtvl: (token.tvl !== 0 && token.fdv) ? token.fdv / token.tvl : null,
+        mcaptvl: token.tvl !== 0 && token.mcap ? token.mcap / token.tvl : null,
+        fdvtvl: token.tvl !== 0 && token.fdv ? token.fdv / token.tvl : null
       }
-  }).filter(token => token !== null)
+    })
+    .filter(token => token !== null)
 
-  // remove duplicate chains 
+  // remove duplicate chains
   chainOptions.concat(priorityDropdownOptions).forEach(chain => chainsSet.delete(chain))
   const otherChains = [...priorityDropdownOptions, ...Array.from(chainsSet)]
 
@@ -99,7 +103,7 @@ function AllTokensPage({ category, selectedChain = 'All', history }) {
   if (category) {
     title = `${category} TVL Rankings`
   }
-  document.title = `${title} - Defi Llama`;
+  document.title = `${title} - Defi Llama`
 
   return (
     <PageWrapper>
@@ -109,26 +113,44 @@ function AllTokensPage({ category, selectedChain = 'All', history }) {
           {!below600 && <Search small={true} />}
         </RowBetween>
         <ListOptions gap="10px" style={{ marginTop: '2rem', marginBottom: '.5rem' }}>
-            <RowBetween>
-              <RowFlat>
-                  {chainOptions.map((chain, i) => {
-                    if (chain === "Others") {
-                      return <DropdownSelect key={chain} options={otherChains.reduce((acc, item) => ({
-                        ...acc,
-                        [item]: item
-                      }), {})} active={(chainOptions.includes(selectedChain) || selectedChain === undefined) ? 'Other' : selectedChain} setActive={setSelectedChain} />
-                    }
-                    if (selectedChain === chain) {
-                      return <ButtonDark style={{ margin: '0.2rem' }} key={chain}>{chain}</ButtonDark>
-                    } else {
-                      return <BasicLink to={handleRouting(chain)} key={chain}>
-                        <ButtonLight style={{ margin: '0.2rem' }}>{chain}</ButtonLight>
-                      </BasicLink>
-                    }
-                  })}
-              </RowFlat>
-            </RowBetween>
-          </ListOptions>
+          <RowBetween>
+            <RowFlat>
+              {chainOptions.map((chain, i) => {
+                if (chain === 'Others') {
+                  return (
+                    <DropdownSelect
+                      key={chain}
+                      options={otherChains.reduce(
+                        (acc, item) => ({
+                          ...acc,
+                          [item]: item
+                        }),
+                        {}
+                      )}
+                      active={
+                        chainOptions.includes(selectedChain) || selectedChain === undefined ? 'Other' : selectedChain
+                      }
+                      setActive={setSelectedChain}
+                    />
+                  )
+                }
+                if (selectedChain === chain) {
+                  return (
+                    <ButtonDark style={{ margin: '0.2rem' }} key={chain}>
+                      {chain}
+                    </ButtonDark>
+                  )
+                } else {
+                  return (
+                    <BasicLink to={handleRouting(chain)} key={chain}>
+                      <ButtonLight style={{ margin: '0.2rem' }}>{chain}</ButtonLight>
+                    </BasicLink>
+                  )
+                }
+              })}
+            </RowFlat>
+          </RowBetween>
+        </ListOptions>
         <Panel style={{ marginTop: '6px', padding: below600 && '1rem 0 0 0 ' }}>
           <TokenList tokens={allTokens} filters={[category, selectedChain]} />
         </Panel>

--- a/src/pages/GlobalPage.js
+++ b/src/pages/GlobalPage.js
@@ -1,35 +1,34 @@
 import React, { useEffect, useState, useMemo, lazy, Suspense } from 'react'
-import { withRouter } from 'react-router-dom'
-import styled from 'styled-components'
-
-import { AutoRow, RowBetween, RowFlat } from '../components/Row'
-import Loader from '../components/LocalLoader'
-import { AutoColumn } from '../components/Column'
-import TokenList from '../components/TokenList'
-import Search from '../components/Search'
-import { ButtonLight, ButtonDark } from '../components/ButtonStyled'
-
-import { useGlobalData } from '../contexts/GlobalData'
+import { withRouter, Redirect } from 'react-router-dom'
 import { useMedia } from 'react-use'
-import Panel from '../components/Panel'
-import { useAllTokenData } from '../contexts/TokenData'
-import { formattedNum } from '../utils'
-import { TYPE, ThemedBackground } from '../Theme'
+import styled from 'styled-components'
 import { transparentize } from 'polished'
-import { CustomLink, BasicLink } from '../components/Link'
 
-import { PageWrapper, ContentWrapper } from '../components'
-import { fetchAPI } from '../contexts/API'
-import { CHART_API } from '../constants'
-import DropdownSelect from '../components/DropdownSelect'
-import { Redirect } from 'react-router-dom'
-import RightSettings from '../components/RightSettings'
-import { useStakingManager, usePool2Manager } from '../contexts/LocalStorage'
-import { OptionToggle, CheckMarks } from '../components/SettingsModal'
+import { AutoRow, RowBetween, RowFlat } from 'components/Row'
+import Loader from 'components/LocalLoader'
+import { AutoColumn } from 'components/Column'
+import TokenList from 'components/TokenList'
+import Search from 'components/Search'
+import { ButtonLight, ButtonDark } from 'components/ButtonStyled'
+import Panel from 'components/Panel'
+import { CustomLink, BasicLink } from 'components/Link'
+import { PageWrapper, ContentWrapper } from 'components'
+import DropdownSelect from 'components/DropdownSelect'
+import RightSettings from 'components/RightSettings'
+import {  CheckMarks } from 'components/SettingsModal'
 
-const ProtocolChart = lazy(() => import('../components/ProtocolChart'));
-const GlobalChart = lazy(() => import('../components/GlobalChart'));
+import { TYPE, ThemedBackground } from 'Theme'
 
+import { useGlobalData } from 'contexts/GlobalData'
+import { useAllTokenData } from 'contexts/TokenData'
+import { useStakingManager, usePool2Manager } from 'contexts/LocalStorage'
+import { fetchAPI } from 'contexts/API'
+import { CHART_API } from 'constants/index'
+import { basicChainOptions, extraChainOptions } from 'constants/chainTokens'
+import { formattedNum } from 'utils'
+
+const ProtocolChart = lazy(() => import('components/ProtocolChart'));
+const GlobalChart = lazy(() => import('components/GlobalChart'));
 
 const ListOptions = styled(AutoRow)`
   height: 40px;
@@ -41,9 +40,6 @@ const ListOptions = styled(AutoRow)`
     font-size: 1rem;
   }
 `
-
-const basicChainOptions = ['All', 'Ethereum', 'Solana', 'Polygon', 'Fantom', 'Avalanche']
-const extraChainOptions = ['Terra', 'Arbitrum', 'Binance', 'Celo', 'Harmony']
 
 function GlobalPage({ chain, denomination, history }) {
   // get data for lists and totals

--- a/yarn.lock
+++ b/yarn.lock
@@ -4572,7 +4572,7 @@ core-js@^2.4.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
-core-js@^3.1.3, core-js@^3.6.5:
+core-js@^3.6.5:
   version "3.18.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.18.3.tgz#86a0bba2d8ec3df860fefcc07a8d119779f01509"
   integrity sha512-tReEhtMReZaPFVw7dajMx0vlsz3oOb8ajgPoHVYGxr8ErnZ6PcYEvvmjGmXlfpnxpkYSdOQttjB+MvVbCGfvLw==
@@ -6110,14 +6110,6 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
-
-feather-icons@^4.24.1:
-  version "4.28.0"
-  resolved "https://registry.yarnpkg.com/feather-icons/-/feather-icons-4.28.0.tgz#e1892a401fe12c4559291770ff6e68b0168e760f"
-  integrity sha512-gRdqKESXRBUZn6Nl0VBq2wPHKRJgZz7yblrrc2lYsS6odkNFDnA4bqvrlEVRUPjE1tFax+0TdbJKZ31ziJuzjg==
-  dependencies:
-    classnames "^2.2.5"
-    core-js "^3.1.3"
 
 figgy-pudding@^3.5.1:
   version "3.5.2"


### PR DESCRIPTION
- Fixed bug where infinite scroll wasn't updating new length on protocol/:category pages because wasn't hard reload
- Added filter chain filters to protocol/:category pages, if just general /protocol page instead route to /chains/:chainName?


Todo:
revamp dropdown and filters