### PR TITLE
Add infinite scroll for NFTList

### DIFF
--- a/src/components/NFTList/index.js
+++ b/src/components/NFTList/index.js
@@ -11,7 +11,7 @@ import Row from '../Row'
 import { Divider } from '..'
 
 import { formattedNum, } from '../../utils'
-import { useInfiniteScroll } from '../../hooks'
+import { useFetchedInfiniteScroll } from '../../hooks'
 import { useMedia } from 'react-use'
 import { withRouter } from 'react-router-dom'
 import FormattedName from '../FormattedName'
@@ -106,6 +106,8 @@ const SORT_FIELD = {
 function NFTList({ tokens, itemMax = 100, displayUsd = false }) {
 
   // sorting
+  const [page, setPage] = useState(0)
+  const [collections, setCollections] = useState(tokens)
   const [sortDirection, setSortDirection] = useState(true)
   const [sortedColumn, setSortedColumn] = useState("dailyVolume")
 
@@ -117,8 +119,8 @@ function NFTList({ tokens, itemMax = 100, displayUsd = false }) {
 
   const filteredList = useMemo(() => {
     return (
-      tokens &&
-      tokens
+      collections &&
+      collections
         .sort((a, b) => {
           if (sortedColumn === SORT_FIELD.NAME) {
             return a[sortedColumn] > b[sortedColumn] ? (sortDirection ? -1 : 1) * 1 : (sortDirection ? -1 : 1) * -1
@@ -128,7 +130,7 @@ function NFTList({ tokens, itemMax = 100, displayUsd = false }) {
             : (sortDirection ? -1 : 1) * -1
         })
     )
-  }, [tokens, sortDirection, sortedColumn])
+  }, [collections, sortDirection, sortedColumn])
 
   const ListItem = ({ item, index }) => {
     return (
@@ -174,7 +176,7 @@ function NFTList({ tokens, itemMax = 100, displayUsd = false }) {
   const { LoadMoreButton,
     dataLength,
     hasMore,
-    next } = useInfiniteScroll({ list: filteredList });
+    next } = useFetchedInfiniteScroll({ list: filteredList, page, setPage, setCollections });
 
   return (
     <ListWrapper>

--- a/src/components/NFTList/index.js
+++ b/src/components/NFTList/index.js
@@ -15,6 +15,8 @@ import { useFetchedInfiniteScroll } from '../../hooks'
 import { useMedia } from 'react-use'
 import { withRouter } from 'react-router-dom'
 import FormattedName from '../FormattedName'
+import { fetchAPI } from 'contexts/API'
+import { NFT_COLLECTIONS_API } from '../../constants'
 
 dayjs.extend(utc)
 
@@ -176,7 +178,14 @@ function NFTList({ tokens, itemMax = 100, displayUsd = false }) {
   const { LoadMoreButton,
     dataLength,
     hasMore,
-    next } = useFetchedInfiniteScroll({ list: filteredList, page, setPage, setCollections });
+    next } = useFetchedInfiniteScroll({
+      list: filteredList,
+      page,
+      setPage,
+      setList: setCollections,
+      fetch: fetchAPI,
+      fetchEndpoint: NFT_COLLECTIONS_API
+    });
 
   return (
     <ListWrapper>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -6,6 +6,7 @@ import { hex } from 'wcag-contrast'
 import { getTokenLogoPathFromAddress } from '../utils'
 import copy from 'copy-to-clipboard'
 export { default as useInfiniteScroll } from './useInfiniteScroll'
+export { default as useFetchedInfiniteScroll } from './useFetchedInfiniteScroll'
 export { default as useResize } from './useResize'
 
 export function useColor(tokenAddress, token, _path = undefined) {

--- a/src/hooks/useFetchedInfiniteScroll.jsx
+++ b/src/hooks/useFetchedInfiniteScroll.jsx
@@ -1,0 +1,68 @@
+import React, { useState, useEffect, } from 'react'
+import { ChevronsUp } from 'react-feather'
+import { Button } from 'rebass'
+import { fetchAPI } from 'contexts/API'
+import { NFT_COLLECTIONS_API } from '../constants'
+
+export default function useFetchedInfiniteScroll({ list = [], page = 0, limit = 100, setPage = () => { }, setCollections = () => {}, filters = [] }) {
+
+    const [dataLength, setDatalength] = useState(limit)
+    const [hasMore, setHasMore] = useState(true)
+    const [displayScrollToTopButton, setDisplayScrollToTopButton] = useState(false)
+
+    useEffect(() => {
+        window.addEventListener("scroll", () => {
+            if (window.scrollY > 200) {
+                setDisplayScrollToTopButton(true);
+            } else {
+                setDisplayScrollToTopButton(false);
+            }
+        });
+    }, [])
+
+    // Reset when category changes or else might be limited if one category is smaller than the other
+    const stringifyFilters = JSON.stringify(filters)
+    useEffect(() => {
+        setHasMore(true)
+        setDatalength(limit)
+    }, [stringifyFilters, limit])
+
+    const handleScrollToTop = () => {
+        window.scrollTo({
+            top: 0,
+            behavior: 'smooth'
+        });
+    }
+
+    const next = async () => {
+        const totalRows = dataLength + limit
+        const collections = await fetchAPI(`${NFT_COLLECTIONS_API}?page=${page + 1}&limit=${limit}`)
+        setCollections([...list, ...collections])
+
+        if (collections.length < limit) {
+            setDatalength(list.length)
+            setHasMore(false)
+        } else {
+            setDatalength(totalRows)
+            setPage(page + 1)
+        }
+    }
+
+    const LoadMoreButton = (
+        <Button displayScrollToTopButton={displayScrollToTopButton} onClick={handleScrollToTop} sx={{
+            borderRadius: '50%', padding: 0, color: 'inherit', width: 36, height: 36, position: 'fixed',
+            zIndex: 1, left: '50%', transform: 'translateX(-50%)', bottom: '2rem', opacity: 0.2, cursor: 'Pointer',
+            display: displayScrollToTopButton ? "inline" : 'none',
+        }
+        }>
+            <ChevronsUp />
+        </Button>
+    )
+
+    return {
+        dataLength,
+        hasMore,
+        LoadMoreButton,
+        next
+    }
+}

--- a/src/hooks/useFetchedInfiniteScroll.jsx
+++ b/src/hooks/useFetchedInfiniteScroll.jsx
@@ -1,10 +1,17 @@
 import React, { useState, useEffect, } from 'react'
 import { ChevronsUp } from 'react-feather'
 import { Button } from 'rebass'
-import { fetchAPI } from 'contexts/API'
-import { NFT_COLLECTIONS_API } from '../constants'
 
-export default function useFetchedInfiniteScroll({ list = [], page = 0, limit = 100, setPage = () => { }, setCollections = () => {}, filters = [] }) {
+export default function useFetchedInfiniteScroll({
+    list = [],
+    page = 0,
+    limit = 100,
+    setPage = () => { },
+    setList = () => { },
+    fetch = () => { },
+    fetchEndpoint = "",
+    filters = [] 
+}) {
 
     const [dataLength, setDatalength] = useState(limit)
     const [hasMore, setHasMore] = useState(true)
@@ -36,10 +43,10 @@ export default function useFetchedInfiniteScroll({ list = [], page = 0, limit = 
 
     const next = async () => {
         const totalRows = dataLength + limit
-        const collections = await fetchAPI(`${NFT_COLLECTIONS_API}?page=${page + 1}&limit=${limit}`)
-        setCollections([...list, ...collections])
+        const data = await fetch(`${fetchEndpoint}?page=${page + 1}&limit=${limit}`)
+        setList([...list, ...data])
 
-        if (collections.length < limit) {
+        if (data.length < limit) {
             setDatalength(list.length)
             setHasMore(false)
         } else {


### PR DESCRIPTION
This adds infinite scroll to the list in the NFT dashboard page with a modified useInfiniteScroll hook. Might be useful for future infinite scrolled lists where not all the data is fetched at once.