### PR TITLE
Add Dollar Sign to Token Symbol

### DIFF
--- a/src/containers/ProtocolContainer/index.js
+++ b/src/containers/ProtocolContainer/index.js
@@ -164,7 +164,7 @@ function ProtocolContainer({ protocolData, protocol, denomination, selectedChain
                 <TYPE.main fontSize={['1.5rem', '1.5rem', '2rem']} fontWeight={500} style={{ margin: '0 1rem' }}>
                   <RowFixed gap="6px">
                     <FormattedName text={name ? name + ' ' : ''} maxCharacters={16} style={{ marginRight: '6px' }} />{' '}
-                    {symbol}
+                    {"$" + symbol}
                   </RowFixed>
                 </TYPE.main>{' '}
               </RowFixed>


### PR DESCRIPTION
On a protocol page there is no way to differentiate  between Protocol name and token symbol. This looks especially weird for protocols where the name is equal to the token symbol. To alleviate that I'd suggest adding a dollar sign in front of the token symbol, thereby displaying at as a recognizable and easily understandable cashtag.

Before:

<img width="1328" alt="image" src="https://user-images.githubusercontent.com/12869664/147933845-fa5baa01-76f2-4f27-ab14-ee735f934a0a.png">

After:

<img width="1328" alt="image" src="https://user-images.githubusercontent.com/12869664/147935006-4d14001b-ab84-4253-bbf9-28ab59da6b5c.png">



