### PR TITLE
replace circulating w/ market caps on peggedassets

### DIFF
--- a/src/components/PeggedList/index.js
+++ b/src/components/PeggedList/index.js
@@ -139,8 +139,8 @@ function AllPeggedsPage({
   const { percentChange, totalMcapCurrent } = useMemo(() => {
     const chartCurrent = chartData[chartData.length - 1] ?? null
     const chartPrevDay = chartData[chartData.length - 2] ?? null
-    const totalMcapCurrent = chartCurrent.mcap ?? 0
-    const totalMcapPrevDay = chartPrevDay.mcap ?? 0
+    const totalMcapCurrent = chartCurrent?.mcap
+    const totalMcapPrevDay = chartPrevDay?.mcap
     const percentChange = getPercentChange(totalMcapCurrent, totalMcapPrevDay)?.toFixed(2)
     return { percentChange, totalMcapCurrent }
   }, [chartData])
@@ -150,9 +150,9 @@ function AllPeggedsPage({
   let topToken = { name: 'Tether', mcap: 0 }
   if (peggedTotals.length > 0) {
     const topTokenData = peggedTotals[0]
-    topToken.name = topTokenData?.name
-    const topCirculating = peggedTotals[0]?.circulating
-    const topPrice = topTokenData?.price
+    topToken.name = topTokenData.name
+    const topCirculating = peggedTotals[0].circulating
+    const topPrice = topTokenData.price
     topToken.mcap = topPrice * topCirculating
   }
 

--- a/src/components/PeggedList/index.js
+++ b/src/components/PeggedList/index.js
@@ -13,7 +13,6 @@ import {
   formattedNum,
   formattedPegggedPrice,
   getPercentChange,
-  getPrevCirculatingFromChart,
   getPeggedDominance,
 } from 'utils'
 import { useCalcCirculating, useCalcGroupExtraPeggedByDay } from 'hooks/data'
@@ -21,7 +20,6 @@ import { useLg } from 'hooks/useBreakpoints'
 import { TYPE } from 'Theme'
 import Table, { columnsToShow, isOfTypePeggedCategory } from 'components/Table'
 import { PeggedChainPieChart, PeggedChainDominanceChart } from 'components/Charts'
-import { categoryToPegType, getPeggedPrices } from 'utils/dataApi'
 import Filters, { FiltersWrapper } from 'components/Filters'
 
 export const BreakpointPanels = styled.div`

--- a/src/components/PeggedList/index.js
+++ b/src/components/PeggedList/index.js
@@ -90,9 +90,9 @@ function AllPeggedsPage({
     },
     ...columnsToShow('1dChange', '7dChange', '1mChange'),
     {
-      header: 'Total Circulating',
-      accessor: 'circulating',
-      Cell: ({ value }) => <>{value && formattedNum(value)}</>,
+      header: 'Market Cap',
+      accessor: 'mcap',
+      Cell: ({ value }) => <>{value && formattedNum(value, true)}</>,
     },
   ]
 
@@ -129,36 +129,36 @@ function AllPeggedsPage({
   const { data: stackedData, daySum } = useCalcGroupExtraPeggedByDay(stackedDataset)
 
   if (!title) {
-    title = `Circulating`
+    title = `Market Cap`
     if (category) {
-      title = `${capitalizeFirstLetter(category)} Circulating`
+      title = `${capitalizeFirstLetter(category)} Market Cap`
     }
     if (selectedChain !== 'All') {
-      title = `${capitalizeFirstLetter(selectedChain)} ${capitalizeFirstLetter(category)} Circulating`
+      title = `${capitalizeFirstLetter(selectedChain)} ${capitalizeFirstLetter(category)} Market Cap`
     }
   }
 
-  const { circulating, percentChange } = useMemo(() => {
-    const circulating = getPrevCirculatingFromChart(chartData, 0, 'totalCirculating', categoryToPegType[category])
-    const circulatingPrevDay = getPrevCirculatingFromChart(
-      chartData,
-      1,
-      'totalCirculating',
-      categoryToPegType[category]
-    )
-    const percentChange = getPercentChange(circulating, circulatingPrevDay)?.toFixed(2)
-    return { circulating, percentChange }
-  }, [chartData, category])
+  const { percentChange, totalMcapCurrent } = useMemo(() => {
+    const chartCurrent = chartData[chartData.length - 1] ?? null
+    const chartPrevDay = chartData[chartData.length - 2] ?? null
+    const totalMcapCurrent = chartCurrent.mcap ?? 0
+    const totalMcapPrevDay = chartPrevDay.mcap ?? 0
+    const percentChange = getPercentChange(totalMcapCurrent, totalMcapPrevDay)?.toFixed(2)
+    return { percentChange, totalMcapCurrent }
+  }, [chartData])
 
-  const circulatingToDisplay = formattedNum(circulating, false)
+  const mcapToDisplay = formattedNum(totalMcapCurrent, true)
 
-  const topToken = { name: 'Tether', circulating: 0 }
+  let topToken = { name: 'Tether', mcap: 0 }
   if (peggedTotals.length > 0) {
-    topToken.name = peggedTotals[0]?.name
-    topToken.circulating = peggedTotals[0]?.circulating
+    const topTokenData = peggedTotals[0]
+    topToken.name = topTokenData?.name
+    const topCirculating = peggedTotals[0]?.circulating
+    const topPrice = topTokenData?.price
+    topToken.mcap = topPrice * topCirculating
   }
 
-  const dominance = getPeggedDominance(topToken, circulating)
+  const dominance = getPeggedDominance(topToken, totalMcapCurrent)
 
   const panels = (
     <>
@@ -169,7 +169,7 @@ function AllPeggedsPage({
           </RowBetween>
           <RowBetween style={{ marginTop: '4px', marginBottom: '-6px' }} align="flex-end">
             <TYPE.main fontSize={'33px'} lineHeight={'39px'} fontWeight={600} color={'#4f8fea'}>
-              {circulatingToDisplay}
+              {mcapToDisplay}
             </TYPE.main>
           </RowBetween>
         </AutoColumn>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -47,7 +47,7 @@ export const NFT_SEARCH_API = 'https://ybrjmu6r60.execute-api.eu-west-2.amazonaw
 export const PEGGEDS_API = 'https://uemu821wp6.execute-api.us-east-1.amazonaws.com/dev/peggeds'
 export const PEGGED_API = 'https://uemu821wp6.execute-api.us-east-1.amazonaws.com/dev/pegged'
 export const PEGGEDCHART_API = 'https://uemu821wp6.execute-api.us-east-1.amazonaws.com/dev/peggedcharts'
-export const PEGGEDPRICES_API = 'https://cocoahomology-datasets.s3.amazonaws.com/peggedPrices.json'
+export const PEGGEDPRICES_API = 'https://uemu821wp6.execute-api.us-east-1.amazonaws.com/dev/peggedprices'
 
 export const YIELD_POOLS_API = 'https://1rwmj4tky9.execute-api.eu-central-1.amazonaws.com/poolsEnriched'
 export const YIELD_CHART_API = 'https://1rwmj4tky9.execute-api.eu-central-1.amazonaws.com/chart'

--- a/src/hooks/data.tsx
+++ b/src/hooks/data.tsx
@@ -55,17 +55,24 @@ interface GroupChainPegged extends IPegged {
 
 interface IPegged {
   circulating: number
+  minted: number
   unreleased: number
+  mcap: number
+  name: string
+  symbol: string
+  gecko_id: string
+  price: number
   change_1d: number | null
   change_7d: number | null
   change_1m: number | null
+  circulatingPrevDay: number
+  circulatingPrevWeek: number
+  circulatingPrevMonth: number
   bridgeInfo: {
     bridge: string
     link?: string
   }
   bridgedAmount: number | string
-  name: string
-  symbol: string
 }
 
 // TODO update types in localstorage file and refer them here
@@ -407,7 +414,7 @@ export const useCalcCirculating = (filteredPeggedAssets: IPegged[], defaultSorti
     })
 
     if (defaultSortingColumn === undefined) {
-      return updatedPeggedAssets.sort((a, b) => b.circulating - a.circulating)
+      return updatedPeggedAssets.sort((a, b) => b.mcap - a.mcap)
     } else {
       return updatedPeggedAssets.sort((a, b) => {
         if (dir === 'asc') {

--- a/src/pages/peggedassets.js
+++ b/src/pages/peggedassets.js
@@ -9,11 +9,12 @@ import { capitalizeFirstLetter } from 'utils'
 
 export async function getStaticProps() {
   const peggedAssets = await getPeggedAssets()
-  const prices = await getPeggedPrices()
+  const priceChart = await getPeggedPrices()
+  const currentPrices = priceChart[priceChart.length - 1] ?? null
   let categories = {}
   peggedAssets.peggedAssets.forEach((p) => {
     const pegType = p.pegType
-    const price = prices[p.gecko_id]
+    const price = currentPrices.prices[p.gecko_id]
     const cat = p.category
     if (categories[cat] === undefined) {
       categories[cat] = { peggedAssets: 0, mcap: 0 }

--- a/src/utils/dataApi.ts
+++ b/src/utils/dataApi.ts
@@ -75,8 +75,10 @@ export const peggedPropertiesToKeep = [
   'circulating',
   'minted',
   'unreleased',
+  'mcap',
   'name',
   'symbol',
+  'gecko_id',
   'chains',
   'price',
   'change_1d',
@@ -216,11 +218,13 @@ const formatPeggedAssetsData = ({
     pegged.change_7d = getPercentChange(pegged.circulating, pegged.circulatingPrevWeek)
     pegged.change_1m = getPercentChange(pegged.circulating, pegged.circulatingPrevMonth)
 
+    pegged.mcap = pegged.price * pegged.circulating
+
     return keepNeededProperties(pegged, peggedAssetProps)
   })
 
   if (chain) {
-    filteredPeggedAssets = filteredPeggedAssets.sort((a, b) => b.circulating - a.circulating)
+    filteredPeggedAssets = filteredPeggedAssets.sort((a, b) => b.mcap - a.mcap)
   }
 
   return filteredPeggedAssets
@@ -290,10 +294,10 @@ export async function getPeggedsPageData(category, chain) {
     chartDataByPeggedAsset.reduce((total: IStackedDataset, charts, i) => {
       charts.forEach((chart) => {
         const peggedName = peggedAssetNames[i]
-        const circulating = chart.totalCirculating[pegType]
+        const circulating = chart.mcap  // should rename this variable; useCalcGroupExtraPeggedByDay accesses it
         const date = chart.date
         if (date < 1596248105) return
-        if ((currentTimestamp - secondsInYear / 2 < date) && !(circulating == null)) {
+        if (currentTimestamp - secondsInYear / 2 < date && !(circulating == null)) {
           // only show data from previous 6 months
           if (total[date] == undefined) {
             total[date] = {}
@@ -323,7 +327,7 @@ export async function getPeggedsPageData(category, chain) {
     })
   })
 
-  let filteredPeggedAssets = formatPeggedAssetsData({ category, peggedAssets, chain })
+  const filteredPeggedAssets = formatPeggedAssetsData({ category, peggedAssets, chain })
 
   return {
     peggedcategory: category,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -459,8 +459,8 @@ export const getTokenDominance = (topToken, totalVolume) => {
   } else return 100
 }
 
-export const getPeggedDominance = (topToken, totalCirculating) => {
-  const dominance = topToken.circulating && totalCirculating && (topToken.circulating / totalCirculating) * 100.0
+export const getPeggedDominance = (topToken, totalMcap) => {
+  const dominance = topToken.mcap && totalMcap && (topToken.mcap / totalMcap) * 100.0
 
   if (dominance < 100) {
     return dominance.toFixed(2)


### PR DESCRIPTION
showing all data on peggedassets pages as market caps instead of total circulating, I think it is better UX (total circulating messes up the rankings when asset becomes de-pegged)