### PR TITLE
refactor: move `fathom-client` for a hook

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -6,6 +6,7 @@ export { default as useFetchInfiniteScroll } from './useFetchInfiniteScroll'
 export { default as useProtocolColor } from './useProtocolColor'
 export { default as useResize } from './useResize'
 export * from './useBreakpoints'
+export * from './useAnalytics'
 
 export function useCopyClipboard(timeout = 500) {
   const [isCopied, setIsCopied] = useState(false)

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import * as Fathom from 'fathom-client'
+
+export const useAnalytics = () => {
+  const router = useRouter()
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production') {
+      Fathom.load('OANJVQNZ', {
+        includedDomains: ['defillama.com', 'www.defillama.com'],
+        url: 'https://gold-six.llama.fi/script.js',
+      })
+    }
+
+    const onRouteChangeComplete = () => {
+      Fathom.trackPageview()
+    }
+
+    // Record a pageview when route changes
+    router.events.on('routeChangeComplete', onRouteChangeComplete)
+
+    // Unassign event listener
+    return () => {
+      router.events.off('routeChangeComplete', onRouteChangeComplete)
+    }
+  }, [router.events])
+}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,28 +1,8 @@
-import { useEffect } from 'react'
-import { useRouter } from 'next/router'
-import * as Fathom from 'fathom-client'
-import LocalStorageContextProvider, { Updater as LocalStorageContextUpdater } from '../contexts/LocalStorage'
+import LocalStorageContextProvider, { Updater as LocalStorageContextUpdater } from 'contexts/LocalStorage'
+import { useAnalytics } from "hooks";
 
 function App({ Component, pageProps }) {
-  const router = useRouter()
-
-  useEffect(() => {
-    Fathom.load('OANJVQNZ', {
-      includedDomains: ['defillama.com', 'www.defillama.com'],
-      url: 'https://gold-six.llama.fi/script.js',
-    })
-
-    function onRouteChangeComplete() {
-      Fathom.trackPageview()
-    }
-    // Record a pageview when route changes
-    router.events.on('routeChangeComplete', onRouteChangeComplete)
-
-    // Unassign event listener
-    return () => {
-      router.events.off('routeChangeComplete', onRouteChangeComplete)
-    }
-  }, [])
+  useAnalytics()
 
   return (
     <LocalStorageContextProvider>


### PR DESCRIPTION
Created a hook called `useAnalytics` to separate the code in `_app.js`.