### PR TITLE
refactor: use the `useCopyToClipboard` hook from `react-use`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@radix-ui/react-tooltip": "^0.1.7",
     "@reach/portal": "^0.10.3",
     "bignumber.js": "^9.0.0",
-    "copy-to-clipboard": "^3.3.1",
     "dayjs": "^1.8.16",
     "decimal.js-light": "^2.5.0",
     "fathom-client": "^3.2.0",

--- a/src/components/Copy/index.js
+++ b/src/components/Copy/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
-import { useCopyClipboard } from '../../hooks'
 import { CheckCircle, Copy } from 'react-feather'
+import { useCopyToClipboard } from 'react-use'
 import { StyledIcon } from '..'
 
 const CopyIcon = styled.div`
@@ -26,11 +26,11 @@ const TransactionStatusText = styled.span`
 `
 
 export default function CopyHelper({ toCopy }) {
-  const [isCopied, setCopied] = useCopyClipboard()
+  const [{ value }, setCopied] = useCopyToClipboard()
 
   return (
     <CopyIcon onClick={() => setCopied(toCopy)}>
-      {isCopied ? (
+      {value ? (
         <TransactionStatusText>
           <StyledIcon>
             <CheckCircle size={'14'} />

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,34 +1,10 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useRouter } from 'next/router'
-import copy from 'copy-to-clipboard'
 export { default as useInfiniteScroll } from './useInfiniteScroll'
 export { default as useFetchInfiniteScroll } from './useFetchInfiniteScroll'
 export { default as useProtocolColor } from './useProtocolColor'
 export { default as useResize } from './useResize'
 export * from './useBreakpoints'
-
-export function useCopyClipboard(timeout = 500) {
-  const [isCopied, setIsCopied] = useState(false)
-
-  const staticCopy = useCallback((text) => {
-    const didCopy = copy(text)
-    setIsCopied(didCopy)
-  }, [])
-
-  useEffect(() => {
-    if (isCopied) {
-      const hide = setTimeout(() => {
-        setIsCopied(false)
-      }, timeout)
-
-      return () => {
-        clearTimeout(hide)
-      }
-    }
-  }, [isCopied, setIsCopied, timeout])
-
-  return [isCopied, staticCopy]
-}
 
 export const useOutsideClick = (ref, ref2, callback) => {
   const handleClick = (e) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1542,7 +1542,7 @@ cookie@~0.4.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
-copy-to-clipboard@^3, copy-to-clipboard@^3.1.0, copy-to-clipboard@^3.3.1:
+copy-to-clipboard@^3, copy-to-clipboard@^3.1.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
   integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==


### PR DESCRIPTION
Since `react-use` has a hook for [**copy to clipboard**](https://github.com/streamich/react-use/blob/master/src/useCopyToClipboard.ts), it is not necessary to have a hook for this in `hooks/index.ts`.