### PR TITLE
fix: render roundup page even if env_token is not set

### DIFF
--- a/src/pages/roundup.tsx
+++ b/src/pages/roundup.tsx
@@ -94,15 +94,21 @@ export async function getStaticProps() {
   const headers = new Headers()
   headers.append('Authorization', `Bot ${process.env.ROUND_UP_BOT_TOKEN}`)
 
+  let data = []
+
   const response = await fetch('https://discordapp.com/api/channels/965023197365960734/messages', {
     method: 'GET',
     headers: headers,
     redirect: 'follow',
-  }).then((res) => res.json())
+  })
 
-  const index = response?.findIndex((r) => r.content.startsWith('Daily news round-up with the')) ?? null
+  if (response.ok) {
+    data = await response.json()
+  }
 
-  const raw = Number.isNaN(index) ? [] : response.slice(0, index + 1)
+  const index = data?.findIndex((d) => d.content.startsWith('Daily news round-up with the')) ?? null
+
+  const raw = Number.isNaN(index) ? [] : data.slice(0, index + 1)
 
   const messages = raw
     .reverse()


### PR DESCRIPTION
This PR will fix the roundup page to render even if the env_token is not set.

The page is returning the error in `development` mode and on the `build`:

![Screenshot from 2022-05-22 15-40-56](https://user-images.githubusercontent.com/1894191/169712889-a6e40448-49d1-4ace-92a1-163aa38eddaa.png)

![Screenshot from 2022-05-22 15-34-38](https://user-images.githubusercontent.com/1894191/169712890-7498f2ed-fcdb-4d13-beeb-c24dd258fdb5.png)
