### PR TITLE
change from raw confidence score to binned confidence

### DIFF
--- a/src/components/YieldsPage/index.js
+++ b/src/components/YieldsPage/index.js
@@ -84,7 +84,7 @@ const TableWrapper = styled(Table)`
     display: none;
   }
 
-  // PROBABILITY
+  // CONFIDENCE
   tr > *:nth-child(9) {
     display: none;
   }
@@ -96,7 +96,7 @@ const TableWrapper = styled(Table)`
     }
   }
 
-  // PROBABILITY
+  // CONFIDENCE
   tr > th:nth-child(9) {
     & > div {
       margin-left: auto;
@@ -166,7 +166,7 @@ const TableWrapper = styled(Table)`
       display: revert;
     }
 
-    // PROBABILITY
+    // CONFIDENCE
     tr > *:nth-child(9) {
       display: revert;
     }
@@ -258,10 +258,10 @@ const YieldPage = ({ pools, chainList }) => {
       Cell: ({ value }) => <>{value}</>,
     },
     {
-      header: 'Probability',
-      accessor: 'probability',
-      helperText: 'Predicted probability of outlook',
-      Cell: ({ value }) => <>{value === null ? null : value.toFixed(2) + '%'}</>,
+      header: 'Confidence',
+      accessor: 'confidence',
+      helperText: 'Predicted confidence of outlook: 1 = Low, 2 = Medium, 3 = High',
+      Cell: ({ value }) => <>{value === null ? null : value}</>,
     },
   ]
 
@@ -311,7 +311,7 @@ const YieldPage = ({ pools, chainList }) => {
           change1d: t.apyPct1D,
           change7d: t.apyPct7D,
           outlook: t.predictions.predictedClass,
-          probability: t.predictions.predictedProbability,
+          confidence: t.predictions.binnedConfidence,
         }))}
         columns={columns}
       />

--- a/src/pages/yields/pool/[pool].js
+++ b/src/pages/yields/pool/[pool].js
@@ -77,7 +77,7 @@ const PageView = () => {
 
   const tvlUsd = toK(poolData.tvlUsd ?? 0)
 
-  const probability = poolData.predictions?.predictedProbability ?? null
+  const confidence = poolData.predictions?.binnedConfidence ?? null
   const predictedDirection = poolData.predictions?.predictedClass === 'Down' ? '' : 'not'
 
   const audits = poolData.audits ?? ''
@@ -127,10 +127,8 @@ const PageView = () => {
             color={'#46acb7'}
             style={{ marginTop: '4px', marginBottom: '-6px' }}
           >
-            {probability !== null
-              ? `The algorithm predicts the current APY of ${apy}% to ${predictedDirection} fall below ${apyDelta20pct}% within the next 4 weeks. Probability: ${probability.toFixed(
-                2
-              )}%.`
+            {confidence !== null
+              ? `The algorithm predicts the current APY of ${apy}% to ${predictedDirection} fall below ${apyDelta20pct}% within the next 4 weeks. Confidence Score: ${confidence}`
               : 'No outlook available'}
           </TYPE.main>
         </AutoColumn>

--- a/src/pages/yields/token/[token].js
+++ b/src/pages/yields/token/[token].js
@@ -81,10 +81,10 @@ const YieldPage = () => {
       Cell: ({ value }) => <>{value}</>,
     },
     {
-      header: 'Probability',
-      accessor: 'probability',
-      helperText: 'Predicted probability of outlook',
-      Cell: ({ value }) => <>{value === null ? null : value.toFixed(2) + '%'}</>,
+      header: 'Confidence',
+      accessor: 'confidence',
+      helperText: 'Predicted confidence of outlook: 1 = Low, 2 = Medium, 3 = High',
+      Cell: ({ value }) => <>{value === null ? null : value}</>,
     },
   ]
 
@@ -135,7 +135,7 @@ const YieldPage = () => {
             change1d: t.apyPct1D,
             change7d: t.apyPct7D,
             outlook: t.predictions.predictedClass,
-            probability: t.predictions.predictedProbability,
+            confidence: t.predictions.binnedConfidence,
           }))}
           secondColumnAlign="start"
           columns={columns}


### PR DESCRIPTION
Instead of displaying raw predict proba model output as "probabilities", we bin those values and display them as confidence scores

looks like this now:

<img width="1416" alt="Screenshot 2022-05-25 at 20 41 16" src="https://user-images.githubusercontent.com/74533329/170354058-c01e51d3-9e6c-439c-b732-0993f625c409.png">
