### PR TITLE
fix: set `null` in `messages` prop for roundup page

### DIFF
--- a/src/pages/roundup.tsx
+++ b/src/pages/roundup.tsx
@@ -44,7 +44,7 @@ export async function getStaticProps() {
     data = await response.json()
   }
 
-  const index = data?.findIndex((d) => d.content.startsWith('Daily news round-up with the')) ?? null
+  const index = data.findIndex((d) => d.content.startsWith('Daily news round-up with the')) ?? null
 
   const raw = Number.isNaN(index) ? [] : data.slice(0, index + 1)
 
@@ -57,7 +57,7 @@ export async function getStaticProps() {
 
   return {
     props: {
-      messages: splitLlama[1],
+      messages: splitLlama[1] || null,
     },
     revalidate: revalidate(),
   }


### PR DESCRIPTION
This PR will fix these errors:

![Screenshot from 2022-05-28 10-57-26](https://user-images.githubusercontent.com/1894191/170829062-f00e92b2-1f72-403c-88fd-842e70a2b828.png)
![Screenshot from 2022-05-28 11-04-55](https://user-images.githubusercontent.com/1894191/170829065-d915abaa-7ef6-44db-a15f-26fad0da4ddc.png)
