### PR TITLE
fix: name react component (`ProtocolChart`) to avoid ESLint errors

### DIFF
--- a/src/components/TokenChart/ProtocolChart.tsx
+++ b/src/components/TokenChart/ProtocolChart.tsx
@@ -20,7 +20,14 @@ interface IProps {
   bobo?: boolean
 }
 
-export default function ({ protocol, tvlChartData, color, historicalChainTvls, chains = [], bobo = false }: IProps) {
+export default function ProtocolChart({
+  protocol,
+  tvlChartData,
+  color,
+  historicalChainTvls,
+  chains = [],
+  bobo = false
+}: IProps) {
   const router = useRouter()
 
   const extraTvlEnabled = useGetExtraTvlEnabled()
@@ -41,7 +48,7 @@ export default function ({ protocol, tvlChartData, color, historicalChainTvls, c
     return d
   }, [chains])
 
-  const { data: denominationHistory, loading } = useDenominationPriceHistory({
+  const { data: denominationHistory } = useDenominationPriceHistory({
     geckoId: DENOMINATIONS.find((d) => d.symbol === denomination)?.geckoId,
     utcStartTime: 0,
   })


### PR DESCRIPTION
This PR fixes the error below:

```
ESLint: Cannot read properties of null (reading 'name') Occurred while linting defillama-app/src/components/TokenChart/ProtocolChart.tsx:23
```