### PR TITLE
Add padding to align TVL th on chains table

### DIFF
--- a/src/containers/ChainsContainer/index.tsx
+++ b/src/containers/ChainsContainer/index.tsx
@@ -110,6 +110,10 @@ const StyledTable = styled(FullTable)<ITable>`
   }
 
   // TVL
+  tr > th:nth-child(6) {
+    padding-right: 20px;
+  }
+
   tr > :nth-child(6) {
     & > div {
       padding-right: 20px;


### PR DESCRIPTION
This small style change makes the chain table more uniform and consistent, fixing the TVL header that was out of alignment.

## Before:

<img width="404" alt="Screenshot 2022-06-08 at 20 02 50" src="https://user-images.githubusercontent.com/9802152/172687408-0a1f1c0b-b664-4cf1-b497-2fd9256998db.png">
<img width="1532" alt="Screenshot 2022-06-08 at 20 02 30" src="https://user-images.githubusercontent.com/9802152/172687414-72e2a3f9-0309-4b3e-9c71-78f9d91ce204.png">

## After:

<img width="396" alt="Screenshot 2022-06-08 at 20 01 41" src="https://user-images.githubusercontent.com/9802152/172687610-667ba861-2762-4960-af0a-9acfe3c32d08.png">
<img width="1688" alt="Screenshot 2022-06-08 at 20 01 10" src="https://user-images.githubusercontent.com/9802152/172687612-5fd63870-8d1b-4e67-962a-c854cb3d1e08.png">


