### PR TITLE
fix: make sure the logo is not a svg image in `getColor` function

### DIFF
--- a/src/pages/nfts/collection/[...collection].js
+++ b/src/pages/nfts/collection/[...collection].js
@@ -1,4 +1,4 @@
-import getColor from 'utils/getColor'
+import { getColor } from 'utils/getColor'
 import NFTCollectionPage from '../../../components/NFTCollectionPage'
 import {
   getNFTCollection,
@@ -16,7 +16,7 @@ export async function getStaticProps({
   const collection = await getNFTCollection(slug)
   const chart = await getNFTCollectionChartData(slug)
   const statistics = await getNFTStatistics(chart)
-  const backgroundColor = await getColor({ protocol: collection.slug, logo: collection.logo })
+  const backgroundColor = await getColor(collection.slug, collection.logo)
 
   return {
     props: {

--- a/src/pages/protocol/[...protocol].tsx
+++ b/src/pages/protocol/[...protocol].tsx
@@ -1,7 +1,7 @@
 import ProtocolContainer from 'containers/ProtocolContainer'
 import { standardizeProtocolName } from 'utils'
 import { getProtocols, getProtocol, fuseProtocolData, revalidate } from 'utils/dataApi'
-import getColor from 'utils/getColor'
+import { getColor } from 'utils/getColor'
 import { InferGetStaticPropsType, GetStaticProps } from 'next'
 
 type PageParams = {
@@ -33,7 +33,7 @@ export const getStaticProps: GetStaticProps<PageParams> = async ({
 
   const protocolData = fuseProtocolData(protocolRes)
 
-  const backgroundColor = await getColor({ protocol, logo: protocolData.logo })
+  const backgroundColor = await getColor(protocol, protocolData.logo)
 
   return {
     props: {

--- a/src/utils/getColor.ts
+++ b/src/utils/getColor.ts
@@ -4,35 +4,36 @@ import { hex } from 'wcag-contrast'
 import { primaryColor } from 'constants/colors'
 import { tokenIconUrl } from 'utils'
 
-export default async function getColor({ protocol, logo }) {
-    let color = primaryColor;
+export const getColor = async (protocol?: string, logo?: string) => {
+  let color = primaryColor
 
-    try {
-        if (protocol) {
-            let path = tokenIconUrl(protocol)
-            if (logo) {
-                //replace twt image by actual logo
-                path = logo
+  try {
+    if (protocol) {
+      let path = `https://defillama.com${tokenIconUrl(protocol)}`
+
+      if (!logo?.match(/\.svg$/)) {
+        path = logo
+      }
+
+      if (path.match(/\.(jpg|jpeg|png)$/)) {
+        await Vibrant.from(path).getPalette((_err, palette) => {
+          if (palette?.Vibrant) {
+            let detectedHex = palette.Vibrant.hex
+            let AAscore = hex(detectedHex, '#FFF')
+
+            while (AAscore < 3) {
+              detectedHex = shade(0.005, detectedHex)
+              AAscore = hex(detectedHex, '#FFF')
             }
 
-            if (path) {
-                await Vibrant.from(path).getPalette((err, palette) => {
-                    if (palette && palette.Vibrant) {
-                        let detectedHex = palette.Vibrant.hex
-                        let AAscore = hex(detectedHex, '#FFF')
-                        while (AAscore < 3) {
-                            detectedHex = shade(0.005, detectedHex)
-                            AAscore = hex(detectedHex, '#FFF')
-                        }
-
-                        color = detectedHex
-                    }
-                })
-            }
-        }
-    } catch (error) {
-        console.log(error)
-    } finally {
-        return color
+            color = detectedHex
+          }
+        })
+      }
     }
+  } catch (error) {
+    console.log(error)
+  } finally {
+    return color
+  }
 }


### PR DESCRIPTION
This PR fixes the error message:

```
Generating static pages (102/202)Error: Could not find MIME for Buffer <null>
```

This error happens because the [getColor](https://github.com/DefiLlama/defillama-app/blob/main/src/utils/getColor.ts#L19) function tries to get the color of a logo of type `svg`.

The `node-vibrant` package uses [Jimp](https://github.com/oliver-moran/jimp#readme), but it only supports image types: [bmp](https://github.com/oliver-moran/jimp/blob/master/packages/type-bmp), [gif](https://github.com/oliver-moran/jimp/blob/master/packages/type-gif), [jpeg](https://github.com/oliver-moran/jimp/blob/master/packages/type-jpeg), [png](https://github.com/oliver-moran/jimp/blob/master/packages/type-png) and [tiff](https://github.com/oliver-moran/jimp/blob/master/packages/type-tiff).