### PR TITLE
change to faster config endpoint for table pages

### DIFF
--- a/src/api/categories/yield/client.ts
+++ b/src/api/categories/yield/client.ts
@@ -1,7 +1,7 @@
 import useSWR from 'swr'
 import { fetcher, arrayFetcher, retrySWR } from '~/utils/useSWR'
 import { getCGMarketsDataURLs } from '~/api'
-import { CONFIG_API, YIELD_CHART_API, YIELD_POOLS_API, YIELD_POOLS_LAMBDA_API } from '~/constants'
+import { CONFIG_API, YIELD_CONFIG_API, YIELD_CHART_API, YIELD_POOLS_API, YIELD_POOLS_LAMBDA_API } from '~/constants'
 
 interface IResponseCGMarketsAPI {
 	ath: number
@@ -64,7 +64,7 @@ export const useFetchYieldsList = () => {
 }
 
 export const useYieldPageData = () => {
-	const { data, error } = useSWR('/pools-and-config', () => arrayFetcher([YIELD_POOLS_API, CONFIG_API]))
+	const { data, error } = useSWR('/pools-and-config', () => arrayFetcher([YIELD_POOLS_API, YIELD_CONFIG_API]))
 
 	return {
 		data,

--- a/src/api/categories/yield/index.ts
+++ b/src/api/categories/yield/index.ts
@@ -1,10 +1,10 @@
-import { CONFIG_API, YIELD_POOLS_API } from '~/constants'
+import { YIELD_CONFIG_API, YIELD_POOLS_API } from '~/constants'
 import { arrayFetcher } from '~/utils/useSWR'
 import { formatYieldsPageData } from './utils'
 
 export async function getYieldPageData() {
 	try {
-		let poolsAndConfig = await arrayFetcher([YIELD_POOLS_API, CONFIG_API])
+		let poolsAndConfig = await arrayFetcher([YIELD_POOLS_API, YIELD_CONFIG_API])
 
 		const data = formatYieldsPageData(poolsAndConfig)
 

--- a/src/api/categories/yield/utils.ts
+++ b/src/api/categories/yield/utils.ts
@@ -3,13 +3,6 @@ export function formatYieldsPageData(poolsAndConfig: any) {
 	let _config = poolsAndConfig[1]?.protocols ?? []
 
 	// add projectName and audit fields from config to pools array
-	_config = _config.reduce(
-		(all, c) => ({
-			...all,
-			[c.name.toLowerCase().replace(/\s/g, '-')]: { name: c.name, audits: c.audits }
-		}),
-		{}
-	)
 	_pools = _pools.map((p) => ({ ...p, projectName: _config[p.project]?.name, audits: _config[p.project]?.audits }))
 	// remove potential undefined on projectName
 	const data = _pools.filter((p) => p.projectName)

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -52,6 +52,7 @@ export const PEGGEDDOMINANCE_API = 'https://stablecoins.llama.fi/stablecoindomin
 export const YIELD_POOLS_API = 'https://yields.llama.fi/pools'
 export const YIELD_POOLS_LAMBDA_API = 'https://yields.llama.fi/poolsEnriched'
 export const YIELD_CHART_API = 'https://yields.llama.fi/chart'
+export const YIELD_CONFIG_API = 'https://api.llama.fi/config/yields'
 
 export const CG_TOKEN_API =
 	'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=100&page=<PLACEHOLDER>'


### PR DESCRIPTION
Changing config endpoint from `https://api.llama.fi/config` to faster `https://api.llama.fi/config/yields`