### PR TITLE
remove simple-statistics package

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
 		"react-window": "^1.8.7",
 		"rebass": "^4.0.7",
 		"recharts": "^2.1.10",
-		"simple-statistics": "^7.7.5",
 		"styled-components": "^5.3.5",
 		"swagger-ui": "^4.12.0",
 		"swr": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3498,11 +3498,6 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-simple-statistics@^7.7.5:
-  version "7.7.5"
-  resolved "https://registry.yarnpkg.com/simple-statistics/-/simple-statistics-7.7.5.tgz#b34ad7dc18f4dea7bce2cbd376c467147062e839"
-  integrity sha512-CYq683Yg2mb7M4mklQ6FtxEdsYeziGa2giaLvqXobfK1qVqZDKd7BIqLnngnKQSw9GsfNinbiScbfjc3IRWdQA==
-
 sirv@^1.0.7:
   version "1.0.19"
   resolved "https://registry.yarnpkg.com/sirv/-/sirv-1.0.19.tgz#1d73979b38c7fe91fcba49c85280daa9c2363b49"


### PR DESCRIPTION
no longer required as aggregations related code is living on yield-server instead