### PR TITLE
Fix unstyled "download data" link

### DIFF
--- a/src/components/Nav/shared.tsx
+++ b/src/components/Nav/shared.tsx
@@ -86,7 +86,7 @@ const FooterWrapper = styled.section`
 	gap: 8px;
 	margin-top: auto;
 
-	& > a {
+	& a {
 		display: inline-block;
 		color: ${({ theme }) => theme.white};
 		opacity: 0.8;


### PR DESCRIPTION
The Download Data link text is incorrectly colored when in light mode and viewing any of the DeFi pages *(yields are unaffected)*:
<img width="200" src="https://user-images.githubusercontent.com/96636207/180653537-b458fc54-9d4b-4854-96f3-d366f50b7655.png" />

This is due to the change introduced in a6bc573 combined with the `& > a` css rule that only applies to links that are direct children of the parent element (in this case FooterWrapper).
This pull request changes it so that all links within the footer wrapper are styled, not just its direct children.