### PR TITLE
add cbridge tooltip

### DIFF
--- a/src/components/YieldsPage/shared.tsx
+++ b/src/components/YieldsPage/shared.tsx
@@ -259,6 +259,8 @@ export const columns = [
 				<AutoRow sx={{ width: '100%', justifyContent: 'flex-end' }}>
 					{rowValues.project === 'Osmosis' ? (
 						<QuestionHelper text={`${rowValues.id.split('-').slice(-1)} lock`} />
+					) : rowValues.project === 'cBridge' ? (
+						<QuestionHelper text={'Your deposit can be moved to another chain with a different APY'} />
 					) : null}
 					{formattedPercent(value, true)}
 				</AutoRow>


### PR DESCRIPTION
based on this:

"Your liquidity may be moved around to different chains as users make cross-chain transfers with your liquidity. As a result, your enrolled liquidity in each mining session might change as well. For example, suppose there are two mining sessions, one for the USDT pool on BNB Chain, with an APY of 50%; the other is for the USDT pool on Polygon, with an APY of 30%. Initially, you added 1,000 USDT liquidity to BNB Chain targeting the 50% APY.
Later, as users conduct cross-chain transfers, your liquidity distribution becomes 600 USDT on BNB Chain and 400 USDT on Polygon. In this case, the 600 USDT will automatically enroll in the 50% APY mining session and 400 USDT will enroll in the 30% APY mining session. A strategy for LPs to maximize their farming yield is to rebalance the liquidity across different chains themselves"

we add a tooltip to cbridge pools