### PR TITLE
fix(filtersbychain): make toggleAll actually toggle all chains

### DIFF
--- a/src/components/Filters/shared/FiltersByChain.tsx
+++ b/src/components/Filters/shared/FiltersByChain.tsx
@@ -47,17 +47,31 @@ export function FiltersByChain({ chainList = [], selectedChains, pathname }: IFi
 	}
 
 	const toggleAll = () => {
-		router.push(
-			{
-				pathname,
-				query: {
-					...queries,
-					chain: 'All'
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
+		if (!chain || chain === 'All') {
+			router.push(
+				{
+					pathname,
+					query: {
+						...queries,
+						chain: 'None'
+					}
+				},
+				undefined,
+				{ shallow: true }
+			)
+		} else {
+			router.push(
+				{
+					pathname,
+					query: {
+						...queries,
+						chain: 'All'
+					}
+				},
+				undefined,
+				{ shallow: true }
+			)
+		}
 	}
 
 	const clear = () => {


### PR DESCRIPTION
Toggle All on the Chains filter was just making all chains selected.

This actually toggles all of them

If the url Chain parameter does not exist it will set it all to "None" (No chain parameter seems to imply that all chains are selected)

If the url Chain parameter is set to "All" it will set it all to "None"

In any other case it remains with the functionality it has right now by setting all chains selected