### PR TITLE
feat: listing date formatting

### DIFF
--- a/src/components/RecentProtocols/index.tsx
+++ b/src/components/RecentProtocols/index.tsx
@@ -178,9 +178,6 @@ export function RecentProtocols({ title, name, header, protocols, chainList, for
 	const toHideForkedProtocols = hideForks && typeof hideForks === 'string' && hideForks === 'true' ? true : false
 
 	const { selectedChains, data } = useMemo(() => {
-		const currentTimestamp = Date.now() / 1000
-		const secondsInDay = 3600 * 24
-
 		const selectedChains = getSelectedChainFilters(chain, chainList)
 
 		const _chainsToSelect = selectedChains.map((t) => t.toLowerCase())
@@ -255,15 +252,14 @@ export function RecentProtocols({ title, name, header, protocols, chainList, for
 					tvlPrevMonth,
 					change_1d: getPercentChange(tvl, tvlPrevDay),
 					change_7d: getPercentChange(tvl, tvlPrevWeek),
-					change_1m: getPercentChange(tvl, tvlPrevMonth),
-					listedAt: Number(((currentTimestamp - p.listedAt) / secondsInDay).toFixed(2))
+					change_1m: getPercentChange(tvl, tvlPrevMonth)
 				}
 			})
 
 		return { data, selectedChains }
 	}, [protocols, chain, chainList, forkedList, toHideForkedProtocols])
 
-	const protocolsData = useCalcStakePool2Tvl(data, 'listedAt', 'asc')
+	const protocolsData = useCalcStakePool2Tvl(data, 'listedAt', 'desc')
 
 	const { pathname } = useRouter()
 

--- a/src/components/Table/Columns.tsx
+++ b/src/components/Table/Columns.tsx
@@ -2,8 +2,9 @@ import IconsRow from '~/components/IconsRow'
 import QuestionHelper from '~/components/QuestionHelper'
 import { Name, NameFees } from './Name'
 import type { IColumnProps, TColumns } from './types'
-import { formattedNum, formattedPercent } from '~/utils'
+import { formattedNum, formattedPercent, toNiceDayAndHour, toNiceDaysAgo } from '~/utils'
 import { useDefiManager } from '~/contexts/LocalStorage'
+import Tooltip from '../Tooltip'
 
 type AllColumns = Record<TColumns, IColumnProps>
 
@@ -59,7 +60,7 @@ export const allColumns: AllColumns = {
 		disableSortBy: true,
 		Cell: ({ value, rowValues, rowIndex = null, rowType }) => (
 			<NameFees
-				type={rowValues.logo ? "fees" : "chain"}
+				type={rowValues.logo ? 'fees' : 'chain'}
 				value={value}
 				symbol={rowType === 'child' ? '-' : rowValues.symbol}
 				index={rowIndex !== null && rowIndex + 1}
@@ -110,12 +111,12 @@ export const allColumns: AllColumns = {
 		accessor: 'change_1m',
 		Cell: ({ value }) => <>{formattedPercent(value)}</>
 	},
-	'fees': {
+	fees: {
 		header: 'Fees (24h)',
 		accessor: 'total1dFees',
 		Cell: ({ value }) => <>{'$' + formattedNum(value)}</>
 	},
-	'revenue': {
+	revenue: {
 		header: 'Revenue (24h)',
 		accessor: 'total1dRevenue',
 		Cell: ({ value }) => <>{'$' + formattedNum(value)}</>
@@ -172,7 +173,11 @@ export const allColumns: AllColumns = {
 	listedAt: {
 		header: 'Listed',
 		accessor: 'listedAt',
-		Cell: ({ value }) => <span style={{ whiteSpace: 'nowrap' }}>{value} days ago</span>
+		Cell: ({ value: listingDate }: { value: Date }) => (
+			<Tooltip as="span" content={`at ${toNiceDayAndHour(listingDate)}`} style={{ whiteSpace: 'nowrap' }}>
+				{toNiceDaysAgo(listingDate)}
+			</Tooltip>
+		)
 	},
 	protocols: {
 		header: 'Protocols',
@@ -182,7 +187,7 @@ export const allColumns: AllColumns = {
 		header: 'Name',
 		accessor: 'name',
 		disableSortBy: true,
-		Cell: ({ value, rowValues, rowIndex = null, rowType, showRows }) => (
+		Cell: ({ value, rowIndex = null, rowType, showRows }) => (
 			<Name
 				type="dex"
 				value={value}

--- a/src/components/Table/Columns.tsx
+++ b/src/components/Table/Columns.tsx
@@ -174,7 +174,7 @@ export const allColumns: AllColumns = {
 		header: 'Listed',
 		accessor: 'listedAt',
 		Cell: ({ value: listingDate }: { value: Date }) => (
-			<Tooltip as="span" content={`at ${toNiceDayAndHour(listingDate)}`} style={{ whiteSpace: 'nowrap' }}>
+			<Tooltip as="span" content={`at ${toNiceDayAndHour(listingDate)}`}>
 				{toNiceDaysAgo(listingDate)}
 			</Tooltip>
 		)

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -3,11 +3,11 @@ import styled from 'styled-components'
 import { Button } from 'ariakit/button'
 import { Tooltip as AriaTooltip, TooltipAnchor, useTooltipState } from 'ariakit/tooltip'
 
-interface ITooltip<As = any> {
+interface ITooltip<RenderAs = any> {
 	content: string | null
 	style?: {}
 	children: React.ReactNode
-	as?: As
+	as?: RenderAs
 }
 
 const TooltipTrigger = styled(Button)`
@@ -29,14 +29,14 @@ const TooltipPopover = styled(AriaTooltip)`
 	max-width: 228px;
 `
 
-export default function Tooltip({ content, children, as: asFromProps, ...props }: ITooltip) {
+export default function Tooltip({ content, children, as = TooltipTrigger, ...props }: ITooltip) {
 	const tooltip = useTooltipState()
 
 	if (!content || content === '') return <>{children}</>
 
 	return (
 		<>
-			<TooltipAnchor state={tooltip} as={asFromProps ?? TooltipTrigger}>
+			<TooltipAnchor state={tooltip} as={as}>
 				{children}
 			</TooltipAnchor>
 			<TooltipPopover state={tooltip} {...props}>

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -3,10 +3,11 @@ import styled from 'styled-components'
 import { Button } from 'ariakit/button'
 import { Tooltip as AriaTooltip, TooltipAnchor, useTooltipState } from 'ariakit/tooltip'
 
-interface ITooltip {
+interface ITooltip<As = any> {
 	content: string | null
 	style?: {}
 	children: React.ReactNode
+	as?: As
 }
 
 const TooltipTrigger = styled(Button)`
@@ -16,7 +17,7 @@ const TooltipTrigger = styled(Button)`
 	padding: 0;
 `
 
-const TooltipPopver = styled(AriaTooltip)`
+const TooltipPopover = styled(AriaTooltip)`
 	font-size: 0.85rem;
 	padding: 1em;
 	color: ${({ theme }) => (theme.mode === 'dark' ? 'hsl(0, 0%, 100%)' : 'hsl(204, 10%, 10%)')};
@@ -28,19 +29,19 @@ const TooltipPopver = styled(AriaTooltip)`
 	max-width: 228px;
 `
 
-export default function Tooltip({ content, children, ...props }: ITooltip) {
+export default function Tooltip({ content, children, as: asFromProps, ...props }: ITooltip) {
 	const tooltip = useTooltipState()
 
 	if (!content || content === '') return <>{children}</>
 
 	return (
 		<>
-			<TooltipAnchor state={tooltip} as={TooltipTrigger}>
+			<TooltipAnchor state={tooltip} as={asFromProps ?? TooltipTrigger}>
 				{children}
 			</TooltipAnchor>
-			<TooltipPopver state={tooltip} {...props}>
+			<TooltipPopover state={tooltip} {...props}>
 				{content}
-			</TooltipPopver>
+			</TooltipPopover>
 		</>
 	)
 }

--- a/src/hooks/data/index.tsx
+++ b/src/hooks/data/index.tsx
@@ -110,7 +110,7 @@ type BridgeInfo = {
 export const useCalcStakePool2Tvl = (
 	filteredProtocols: Readonly<IProtocol[]>,
 	defaultSortingColumn?: string,
-	dir?: 'asc',
+	dir?: 'asc' | 'desc',
 	applyLqAndDc = false
 ) => {
 	const [extraTvlsEnabled] = useDefiManager()

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { BigNumber } from 'bignumber.js'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
+import relativeTime from 'dayjs/plugin/relativeTime'
 import { Text } from 'rebass'
 import Numeral from 'numeral'
 import { timeframeOptions } from '~/constants'
@@ -9,6 +10,7 @@ export * from './blockExplorers'
 
 BigNumber.set({ EXPONENTIAL_AT: 50 })
 dayjs.extend(utc)
+dayjs.extend(relativeTime)
 
 export function getTimeframe(timeWindow) {
 	const utcEndTime = dayjs.utc()
@@ -59,6 +61,9 @@ export const toNiceCsvDate = (date) => {
 }
 
 export const toNiceDateYear = (date) => dayjs.utc(dayjs.unix(date)).format('MMMM DD, YYYY')
+
+/** gives output like `5 days ago` or `17 hours ago` from a timestamp, https://day.js.org/docs/en/plugin/relative-time */
+export const toNiceDaysAgo = (date) => dayjs().to(dayjs.utc(dayjs.unix(date)))
 
 export const toK = (num) => {
 	return Numeral(num).format('0.[00]a')


### PR DESCRIPTION
**closes**: https://github.com/DefiLlama/defillama-app/issues/631

before the listings used to be like:
`1.08 days ago`
`0.77 days ago`

now we use dayjs/RelativeTime, so now it's:
`1 day ago`
`14 hours ago`

also, this PR includes a tooltip with exact date of listing
`at 1 Sep, 14:57`

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/19791699/188167658-18bae2b3-eff7-4fc0-97a5-8808c0865027.png) | ![image](https://user-images.githubusercontent.com/19791699/188167844-138920b5-a794-4594-8d99-ad6e2bef9b49.png) |

Tooltip demo:

https://user-images.githubusercontent.com/19791699/188168416-1b303cc8-6bb0-4edc-8372-9364cd08c8c8.mp4
