### PR TITLE
fix dexs page preview

### DIFF
--- a/src/components/DexPage/index.js
+++ b/src/components/DexPage/index.js
@@ -55,7 +55,7 @@ const columns = columnsToShow(
 function GlobalPage({ dex }) {
 	return (
 		<>
-			<SEO cardName={dex.name} chain={dex.name} tvl={dex.total1dVolume} volumeChange={volumeChange} />
+			<SEO cardName={dex.name} chain={dex.name} tvl={dex.total1dVolume} volumeChange={volumeChange} dexsPage />
 
 			<DexsSearch
 				step={{


### PR DESCRIPTION
look in code should be easy to understand

this preview shows total value locked because the dexsPage for SEO tag is not set, I believe.
![image](https://user-images.githubusercontent.com/12869664/189868147-b13830fe-c46a-4c83-a1a7-6b5af545b903.png)
