### PR TITLE
fix wrong label on forks page nav

### DIFF
--- a/src/pages/forks/[fork].js
+++ b/src/pages/forks/[fork].js
@@ -65,7 +65,7 @@ const PageView = ({ chartData, tokenLinks, token, filteredProtocols, parentToken
 
 	return (
 		<>
-			<ProtocolsChainsSearch step={{ category: 'Oracles', name: token, route: 'forks' }} />
+			<ProtocolsChainsSearch step={{ category: 'Forks', name: token, route: 'forks' }} />
 
 			<ChartAndValuesWrapper>
 				<BreakpointPanels>


### PR DESCRIPTION
on https://defillama.com/forks/Uniswap and other subpages, the top nav bar says Oracles when it should be Forks (the link was already correct though)