### PR TITLE
fix: roundup format

### DIFF
--- a/src/pages/roundup.tsx
+++ b/src/pages/roundup.tsx
@@ -70,7 +70,7 @@ export default function Chains({ messages }: { messages?: string }) {
 	const text =
 		messages
 			?.replace(/(.*)\n(http.*)/g, '[$1]($2)') // merge title + link into markdown links
-			?.replace(/(\w+)\s*(\p{Emoji}\uFE0F|\p{Extended_Pictographic})\n/gu, '## $1 $2\n') // Watch📺 -> ## Watch 📺
+			?.replace(/(\d\/\d\s?)?(\w+)\s*(\p{Emoji}\uFE0F|\p{Extended_Pictographic})\n/gu, '## $2 $3\n') // {Watch📺, 1/2 Watch📺} -> ## Watch 📺
 			?.replace(
 				/(\d\/\d\s?)?\*\*(\d\/\d\s?)?([\w\s'".&,?!;:]+)\*\*\s*(\p{Emoji}\uFE0F|\p{Extended_Pictographic})/gu,
 				'### $3 $4'


### PR DESCRIPTION
missed also removing segment indicators (e.g. 1/2) in non-bold headers in the previous pr https://github.com/DefiLlama/defillama-app/pull/973