### PR TITLE
Redirect for CEXs page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -56,6 +56,11 @@ const nextConfig = {
 				source: '/aggregator',
 				destination: 'https://swap.defillama.com/',
 				permanent: true
+			},
+			{
+				source: '/protocols/cex',
+				destination: '/cexs',
+				permanent: true
 			}
 		]
 	},


### PR DESCRIPTION
Since it's the only standing out category we don't need to change categories logic everywhere and can use redirect instead. Fixes #1116

Places where we still have categories: 
<img width="274" alt="image" src="https://user-images.githubusercontent.com/6696080/203017250-2b44407d-7b80-46ca-9716-34f22363b3a6.png">
