### PR TITLE
improve search

### DIFF
--- a/src/pages/borrow.tsx
+++ b/src/pages/borrow.tsx
@@ -11,14 +11,17 @@ export async function getStaticProps() {
 		props: { pools, ...data }
 	} = await getLendBorrowData()
 
-	const searchData = await getAllCGTokensList()
+	let searchData = await getAllCGTokensList()
+	// filter searchData array to include only tokens for which we have lending data
+	const uniqueSymbols = [...new Set(pools.map((p) => p.symbol.split(' ')[0]?.toLowerCase()))]
+	searchData = searchData?.flat().filter((s) => uniqueSymbols.includes(s.symbol?.toLowerCase())) ?? []
 
 	const compressed = compressPageProps({
 		// lend & borrow from query are uppercase only. symbols in pools are mixed case though -> without
 		// setting to uppercase, we only show subset of available pools when applying `findOptimzerPools`
 		pools: pools.map((p) => ({ ...p, symbol: p.symbol.toUpperCase() })),
 		yieldsList: [],
-		searchData: searchData?.flat() ?? [],
+		searchData,
 		...data
 	})
 


### PR DESCRIPTION
pre filter cc searchdata to include only symbols for which we have lending/borrow data