### PR TITLE
[WIP] Rewrite cache control logics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
 	"editor.formatOnSave": true,
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
-	"editor.tabSize": 2
+	"editor.tabSize": 2,
+	"[shellscript]": {
+		"editor.defaultFormatter": "foxundermoon.shell-format"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"analyze": "ANALYZE=true yarn build",
 		"dev": "next dev",
 		"format": "prettier --write .",
-		"build": "next build",
+		"build": "next build && ./scripts/post_build.sh",
 		"start": "next start",
 		"lint": "next lint"
 	},

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"react-switch": "^6.0.0",
 		"rebass": "^4.0.7",
 		"recharts": "^2.1.10",
+		"sharp": "^0.31.2",
 		"styled-components": "^5.3.5",
 		"swagger-ui": "^4.12.0",
 		"swr": "^1.3.0",

--- a/scripts/post_build.sh
+++ b/scripts/post_build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# test to see if both env vars CF_PURGE_CACHE_AUTH and CF_ZONE is set
+if [ -z "$CF_PURGE_CACHE_AUTH" ] || [ -z "$CF_ZONE" ]; then
+  echo "CF_PURGE_CACHE_AUTH or CF_ZONE is not set. Skipping cache purge."
+  exit 0
+fi
+
+curl -X POST "https://api.cloudflare.com/client/v4/zones/$CF_ZONE/purge_cache" \
+  -H "Authorization: Bearer $CF_PURGE_CACHE_AUTH" \
+  -H "Content-Type: application/json" \
+  --data '{"purge_everything":true}'

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,4 @@
+import { ServerResponse } from 'http'
 import useSWR from 'swr'
 import { CG_TOKEN_API } from '~/constants/index'
 import { arrayFetcher, retrySWR } from '~/utils/useSWR'
@@ -74,4 +75,9 @@ export function maxAgeForNext(minutesForRollover: number[]) {
 	const nextMinute = minutesForRollover.find((m) => m > currentMinute) ?? Math.min(...minutesForRollover) + 60
 	const maxAge = nextMinute * 60 - currentMinute * 60 - currentSecond
 	return maxAge
+}
+
+export function addMaxAgeHeaderForNext(res: ServerResponse, minutesForRollover: number[], swr = 1200) {
+	res.setHeader('CDN-Cache-Control', `max-age=${maxAgeForNext(minutesForRollover)}, stale-while-revalidate=${swr}`)
+	res.setHeader('Cache-Control', `public, s-maxage=${maxAgeForNext(minutesForRollover)}, stale-while-revalidate=${swr}`)
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -66,3 +66,12 @@ export function revalidate(minutesForRollover: number = 22) {
 	const secondsTillRevalidation = Math.ceil((next22Minutedate(minutesForRollover).getTime() - current) / 1000)
 	return secondsTillRevalidation > 0 ? secondsTillRevalidation : 3600
 }
+
+export function maxAgeForNext(minutesForRollover: number[]) {
+	// minutesForRollover is an array of minutes in the hour that we want to revalidate
+	const currentMinute = new Date().getMinutes()
+	const currentSecond = new Date().getSeconds()
+	const nextMinute = minutesForRollover.find((m) => m > currentMinute) ?? Math.min(...minutesForRollover) + 60
+	const maxAge = nextMinute * 60 - currentMinute * 60 - currentSecond
+	return maxAge
+}

--- a/src/containers/Defi/Chains/index.tsx
+++ b/src/containers/Defi/Chains/index.tsx
@@ -28,9 +28,7 @@ const AreaChart = dynamic(() => import('~/components/ECharts/AreaChart'), {
 export const getServerSideProps: GetServerSideProps = async ({ res }) => {
 	const data = await getChainsPageData('All')
 	addMaxAgeHeaderForNext(res, [22], 3600)
-	return {
-		props: data.props
-	}
+	return data.notFound ? { notFound: data.notFound } : { props: data.props }
 }
 
 const ChartsWrapper = styled(Panel)`

--- a/src/containers/Defi/Chains/index.tsx
+++ b/src/containers/Defi/Chains/index.tsx
@@ -9,12 +9,13 @@ import { ProtocolsChainsSearch } from '~/components/Search'
 import { RowLinksWithDropdown, RowLinksWrapper } from '~/components/Filters'
 import { GroupChains } from '~/components/MultiSelect'
 import { toNiceCsvDate, download } from '~/utils'
-import { revalidate } from '~/api'
 import { getChainsPageData, getNewChainsPageData } from '~/api/categories/protocols'
 import type { IChartProps, IPieChartProps } from '~/components/ECharts/types'
 import { formatDataWithExtraTvls, groupDataWithTvlsByDay } from '~/hooks/data/defi'
 import { useDefiManager } from '~/contexts/LocalStorage'
 import { useGroupChainsByParent } from '~/hooks/data'
+import { addMaxAgeHeaderForNext } from '~/api'
+import { GetServerSideProps } from 'next'
 
 const PieChart = dynamic(() => import('~/components/ECharts/PieChart'), {
 	ssr: false
@@ -24,11 +25,11 @@ const AreaChart = dynamic(() => import('~/components/ECharts/AreaChart'), {
 	ssr: false
 }) as React.FC<IChartProps>
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
 	const data = await getChainsPageData('All')
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	return {
-		...data,
-		revalidate: revalidate()
+		props: data.props
 	}
 }
 
@@ -108,9 +109,9 @@ export default function ChainsContainer({
 		}, [chainTvls, extraTvlsEnabled, stackedDataset, tvlTypes])
 
 	const downloadCsv = async () => {
-		window.alert("Data download might take up to 1 minute, click OK to proceed")
+		window.alert('Data download might take up to 1 minute, click OK to proceed')
 		const rows = [['Timestamp', 'Date', ...chainsUnique]]
-		const {props} = await getNewChainsPageData("All")
+		const { props } = await getNewChainsPageData('All')
 		const { chainsWithExtraTvlsByDay } = groupDataWithTvlsByDay({
 			chains: props.stackedDataset,
 			tvlTypes,

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -5,8 +5,9 @@ import Layout from '~/layout'
 import { Divider, Panel } from '~/components'
 import { RowBetween } from '~/components/Row'
 import Link from '~/components/Link'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getChainPageData } from '~/api/categories/protocols'
+import { GetServerSideProps } from 'next'
 
 const DashGrid = styled.div`
 	display: grid;
@@ -106,7 +107,8 @@ function AboutPage({ chains, protocols }) {
 	)
 }
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const data = await getChainPageData()
 
 	const chains = data?.props?.chainsSet?.length ?? null
@@ -116,8 +118,7 @@ export async function getStaticProps() {
 		props: {
 			chains,
 			protocols
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 

--- a/src/pages/airdrops.tsx
+++ b/src/pages/airdrops.tsx
@@ -1,8 +1,9 @@
 import { RecentProtocols } from '~/components/RecentProtocols'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getSimpleProtocolsPageData } from '~/api/categories/protocols'
 import { basicPropertiesToKeep } from '~/api/categories/protocols/utils'
 import { FORK_API, RAISES_API } from '~/constants'
+import { GetServerSideProps } from 'next'
 
 const exclude = [
 	'DeerFi',
@@ -60,7 +61,8 @@ const exclude = [
 	'Spartacus Exchange'
 ]
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const [protocolsRaw, { forks }, { raises }] = await Promise.all([
 		getSimpleProtocolsPageData([...basicPropertiesToKeep, 'extraTvl', 'listedAt', 'chainTvls', 'defillamaId']),
 		fetch(FORK_API).then((r) => r.json()),
@@ -98,8 +100,7 @@ export async function getStaticProps() {
 			protocols,
 			chainList: protocolsRaw.chains,
 			forkedList
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 

--- a/src/pages/borrow.tsx
+++ b/src/pages/borrow.tsx
@@ -2,11 +2,13 @@ import Layout from '~/layout'
 import YieldPageOptimizer from '~/components/YieldsPage/indexOptimizer'
 import Announcement from '~/components/Announcement'
 import { disclaimer } from '~/components/YieldsPage/utils'
-import { getAllCGTokensList, revalidate } from '~/api'
+import { addMaxAgeHeaderForNext, getAllCGTokensList } from '~/api'
 import { getLendBorrowData } from '~/api/categories/yield'
 import { compressPageProps, decompressPageProps } from '~/utils/compress'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [23], 3600)
 	const {
 		props: { pools, ...data }
 	} = await getLendBorrowData()
@@ -26,8 +28,7 @@ export async function getStaticProps() {
 	})
 
 	return {
-		props: { compressed },
-		revalidate: revalidate(23)
+		props: { compressed }
 	}
 }
 

--- a/src/pages/bridge-transactions.tsx
+++ b/src/pages/bridge-transactions.tsx
@@ -1,25 +1,22 @@
 import Layout from '~/layout'
 import BridgeTransactionsPage from '~/components/BridgesPage/Transactions'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getBridges } from '~/api/categories/bridges'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
-	const {
-		bridges
-	} = await getBridges()
-
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
+	const { bridges } = await getBridges()
 
 	return {
-		props: { bridges },
-		revalidate: revalidate()
+		props: { bridges }
 	}
 }
 
 export default function BridgeTransactions({ bridges }) {
-
 	return (
 		<Layout title={`Bridge Transactions - DefiLlama Bridges`} defaultSEO>
-			<BridgeTransactionsPage  bridges={bridges} />
+			<BridgeTransactionsPage bridges={bridges} />
 		</Layout>
 	)
 }

--- a/src/pages/bridge/[...bridge].js
+++ b/src/pages/bridge/[...bridge].js
@@ -1,24 +1,18 @@
 import * as React from 'react'
 import BridgeContainer from '~/containers/BridgeContainer'
-import { standardizeProtocolName } from '~/utils'
-import { revalidate } from '~/api'
-import { getBridgePageData, getBridges } from '~/api/categories/bridges'
+import { addMaxAgeHeaderForNext } from '~/api'
+import { getBridgePageData } from '~/api/categories/bridges'
 
-export async function getStaticProps({
+export const getServerSideProps = async ({
 	params: {
 		bridge: [bridge]
-	}
-}) {
+	},
+	res
+}) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const data = await getBridgePageData(bridge)
-	const {
-		displayName,
-		logo,
-		chains,
-		defaultChain,
-		chainToChartDataIndex,
-		bridgeChartDataByChain,
-		prevDayDataByChain
-	} = data
+	const { displayName, logo, chains, defaultChain, chainToChartDataIndex, bridgeChartDataByChain, prevDayDataByChain } =
+		data
 	/*
 	const backgroundColor = await getPeggedColor({
 		peggedAsset: peggedAssetData.name
@@ -34,19 +28,8 @@ export async function getStaticProps({
 			bridgeChartDataByChain,
 			prevDayDataByChain
 			// backgroundColor
-		},
-		revalidate: revalidate()
+		}
 	}
-}
-
-export async function getStaticPaths() {
-	const res = await getBridges()
-
-	const paths = res.bridges.map(({ displayName }) => ({
-		params: { bridge: [standardizeProtocolName(displayName)] }
-	}))
-
-	return { paths, fallback: 'blocking' }
 }
 
 export default function Bridge(props) {

--- a/src/pages/bridges.js
+++ b/src/pages/bridges.js
@@ -1,9 +1,10 @@
 import Layout from '~/layout'
-import { revalidate } from '~/api'
-import BridgeList from "~/components/BridgesPage/BridgeList"
+import { addMaxAgeHeaderForNext } from '~/api'
+import BridgeList from '~/components/BridgesPage/BridgeList'
 import { getBridgeOverviewPageData } from '~/api/categories/bridges'
 
-export async function getStaticProps({}) {
+export const getServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const props = await getBridgeOverviewPageData(null)
 
 	/*
@@ -13,10 +14,9 @@ export async function getStaticProps({}) {
 	*/
 	return {
 		props: {
-			...props,
+			...props
 			// backgroundColor
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 

--- a/src/pages/bridges/[...chain].js
+++ b/src/pages/bridges/[...chain].js
@@ -1,13 +1,15 @@
 import Layout from '~/layout'
-import { revalidate } from '~/api'
-import BridgeList from "~/components/BridgesPage/BridgeList"
-import { getBridgeOverviewPageData, getBridges } from '~/api/categories/bridges'
+import { addMaxAgeHeaderForNext } from '~/api'
+import BridgeList from '~/components/BridgesPage/BridgeList'
+import { getBridgeOverviewPageData } from '~/api/categories/bridges'
 
-export async function getStaticProps({
+export const getServerSideProps = async ({
 	params: {
 		chain: [chain]
-	}
-}) {
+	},
+	res
+}) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const props = await getBridgeOverviewPageData(chain)
 
 	if (!props.filteredBridges || props.filteredBridges?.length === 0) {
@@ -22,20 +24,9 @@ export async function getStaticProps({
 	*/
 	return {
 		props: {
-			...props,
-		},
-		revalidate: revalidate()
+			...props
+		}
 	}
-}
-
-export async function getStaticPaths() {
-	const { chains } = await getBridges()
-
-	const paths = chains.slice(0, 20).map((chain) => ({
-		params: { chain: [chain.name] }
-	}))
-
-	return { paths, fallback: 'blocking' }
 }
 
 export default function Bridges({

--- a/src/pages/bridges/chains.js
+++ b/src/pages/bridges/chains.js
@@ -1,26 +1,22 @@
 import Layout from '~/layout'
 import BridgeChainsOverview from '~/components/BridgesPage/BridgeChainsOverview'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getBridgeChainsPageData } from '~/api/categories/bridges'
 
-export async function getStaticProps() {
+export const getServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const props = await getBridgeChainsPageData()
 
-	if (!props.filteredChains || props.filteredChains?.length === 0) { // TODO: Remove
-		throw new Error("getBridgeChainsPageData() broken")
+	if (!props.filteredChains || props.filteredChains?.length === 0) {
+		// TODO: Remove
+		throw new Error('getBridgeChainsPageData() broken')
 	}
 	return {
-		props,
-		revalidate: revalidate()
+		props
 	}
 }
 
-export default function BridgeChains({
-	chains,
-	filteredChains,
-	chainToChartDataIndex,
-	formattedVolumeChartData
-}) {
+export default function BridgeChains({ chains, filteredChains, chainToChartDataIndex, formattedVolumeChartData }) {
 	return (
 		<Layout title={`Bridges - DefiLlama`} defaultSEO>
 			<BridgeChainsOverview

--- a/src/pages/categories.tsx
+++ b/src/pages/categories.tsx
@@ -6,16 +6,18 @@ import Layout from '~/layout'
 import { Panel } from '~/components'
 import { ProtocolsCategoriesTable } from '~/components/Table'
 import { ProtocolsChainsSearch } from '~/components/Search'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getCategoriesPageData, getProtocolsRaw } from '~/api/categories/protocols'
 import { useCalcGroupExtraTvlsByDay } from '~/hooks/data'
 import type { IChartProps } from '~/components/ECharts/types'
+import { GetServerSideProps } from 'next'
 
 const AreaChart = dynamic(() => import('~/components/ECharts/AreaChart'), {
 	ssr: false
 }) as React.FC<IChartProps>
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const protocols = await getProtocolsRaw()
 	const chartAndColorsData = await getCategoriesPageData()
 
@@ -39,8 +41,7 @@ export async function getStaticProps() {
 		props: {
 			categories: formattedCategories.sort((a, b) => b.tvl - a.tvl),
 			...chartAndColorsData
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 
@@ -76,7 +77,7 @@ export const descriptions = {
 	'Liquid Staking':
 		'Protocols that allow you to stake assets in exchange of a reward, plus the receipt for the staking position is tradeable and liquid',
 	Oracle: 'Protocols that connect data from the outside world (off-chain) with the blockchain world (on-chain)',
-	'Undercollateralized Lending': "Lending with no collateral backing loans",
+	'Undercollateralized Lending': 'Lending with no collateral backing loans'
 }
 
 export default function Protocols({ categories, chartData, categoryColors, uniqueCategories }) {

--- a/src/pages/cexs/index.tsx
+++ b/src/pages/cexs/index.tsx
@@ -1,7 +1,8 @@
 import Layout from '~/layout'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext, revalidate } from '~/api'
 import { Header } from '~/Theme'
 import { CEXTable } from '~/components/Table/Defi'
+import { GetServerSideProps } from 'next'
 
 const cexData = [
 	{
@@ -23,7 +24,7 @@ const cexData = [
 		coin: null,
 		walletsLink: 'https://github.com/bitfinexcom/pub/blob/main/wallets.txt'
 	},
-		{
+	{
 		name: 'Huobi',
 		slug: 'Huobi',
 		coin: 'HT',
@@ -179,7 +180,8 @@ const cexData = [
 	}
 ]
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const cexs = await Promise.all(
 		cexData.map(async (c) => {
 			if (c.slug === undefined) {
@@ -199,8 +201,7 @@ export async function getStaticProps() {
 	return {
 		props: {
 			cexs
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 

--- a/src/pages/chain/[chain].js
+++ b/src/pages/chain/[chain].js
@@ -1,26 +1,13 @@
 import ChainPage from '~/components/ChainPage'
-import { PROTOCOLS_API } from '~/constants/index'
 import Layout from '~/layout'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getChainPageData } from '~/api/categories/protocols'
 
-export async function getStaticProps({ params }) {
+export const getServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const chain = params.chain
 	const data = await getChainPageData(chain)
-	return {
-		...data,
-		revalidate: revalidate()
-	}
-}
-
-export async function getStaticPaths() {
-	const res = await fetch(PROTOCOLS_API)
-
-	const paths = (await res.json()).chains.slice(0, 20).map((chain) => ({
-		params: { chain }
-	}))
-
-	return { paths, fallback: 'blocking' }
+	return { ...data }
 }
 
 export default function Chain({ chain, ...props }) {

--- a/src/pages/chains.js
+++ b/src/pages/chains.js
@@ -1,22 +1,22 @@
 import * as React from 'react'
 import Layout from '~/layout'
 import ChainsContainer from '~/containers/Defi/Chains'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getNewChainsPageData } from '~/api/categories/protocols'
 
-export async function getStaticProps() {
-	const {props:data} = await getNewChainsPageData('All')
-	const sampledData= []
+export const getServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
+	const { props: data } = await getNewChainsPageData('All')
+	const sampledData = []
 	const dataLength = data.stackedDataset.length
-	for(let i=0; i< dataLength; i++){
-		if(i % 2 === 0 || i === (dataLength-1)){
+	for (let i = 0; i < dataLength; i++) {
+		if (i % 2 === 0 || i === dataLength - 1) {
 			sampledData.push(data.stackedDataset[i])
 		}
 	}
-	data.stackedDataset = sampledData;
+	data.stackedDataset = sampledData
 	return {
-		props: data,
-		revalidate: revalidate()
+		props: data
 	}
 }
 

--- a/src/pages/chains/[...category].js
+++ b/src/pages/chains/[...category].js
@@ -1,45 +1,18 @@
 import * as React from 'react'
 import Layout from '~/layout'
 import ChainsContainer from '~/containers/Defi/Chains'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getNewChainsPageData } from '~/api/categories/protocols'
-import { CONFIG_API } from '~/constants/index'
 
-export async function getStaticProps({
+export const getServerSideProps = async ({
 	params: {
 		category: [category]
-	}
-}) {
+	},
+	res
+}) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const data = await getNewChainsPageData(category)
-	return {
-		...data,
-		revalidate: revalidate()
-	}
-}
-
-export async function getStaticPaths() {
-	const { chainCoingeckoIds = {} } = await fetch(CONFIG_API).then((res) => res.json())
-
-	const categories = ['All', 'Non-EVM']
-	for (const chain in chainCoingeckoIds) {
-		chainCoingeckoIds[chain].categories?.forEach((category) => {
-			if (!categories.includes(category)) {
-				categories.push(category)
-			}
-		})
-
-		const parentChain = chainCoingeckoIds[chain].parent?.chain
-
-		if (parentChain && !categories.includes(parentChain)) {
-			categories.push(parentChain)
-		}
-	}
-
-	const paths = categories.map((category) => ({
-		params: { category: [category] }
-	}))
-
-	return { paths, fallback: 'blocking' }
+	return { ...data }
 }
 
 export default function Chains(props) {

--- a/src/pages/comparison.tsx
+++ b/src/pages/comparison.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic'
 import useSWR from 'swr'
 import styled from 'styled-components'
 import Layout from '~/layout'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getSimpleProtocolsPageData } from '~/api/categories/protocols'
 import { IChartProps } from '~/components/ECharts/types'
 import { arrayFetcher } from '~/utils/useSWR'
@@ -16,12 +16,14 @@ import { ProtocolsChainsSearch } from '~/components/Search'
 import { useDefiManager } from '~/contexts/LocalStorage'
 import { formatProtocolsTvlChartData } from '~/components/ECharts/ProtocolChart/ProtocolChart'
 import { fuseProtocolData } from '~/api/categories/protocols'
+import { GetServerSideProps } from 'next'
 
 const AreaChart = dynamic(() => import('~/components/ECharts/AreaChart'), {
 	ssr: false
 }) as React.FC<IChartProps>
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const { protocols } = await getSimpleProtocolsPageData(['name', 'logo'])
 
 	const stackColors = await Promise.allSettled(
@@ -40,8 +42,7 @@ export async function getStaticProps() {
 		props: {
 			protocols: protocols.map((p) => p.name),
 			stackColors: colors
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 

--- a/src/pages/directory.tsx
+++ b/src/pages/directory.tsx
@@ -1,5 +1,5 @@
 import Layout from '~/layout'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getSimpleProtocolsPageData } from '~/api/categories/protocols'
 import { tokenIconUrl } from '~/utils'
 import styled from 'styled-components'
@@ -7,8 +7,10 @@ import { useComboboxState } from 'ariakit'
 import { Input } from '~/components/Search/Base/Input'
 import { DesktopResults } from '~/components/Search/Base/Results/Desktop'
 import Announcement from '~/components/Announcement'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const { protocols } = await getSimpleProtocolsPageData(['name', 'logo', 'url'])
 	return {
 		props: {
@@ -17,8 +19,7 @@ export async function getStaticProps() {
 				logo: tokenIconUrl(protocol.name),
 				route: protocol.url
 			}))
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 

--- a/src/pages/donations.tsx
+++ b/src/pages/donations.tsx
@@ -6,32 +6,37 @@ import { Divider, Panel } from '~/components'
 import { RowBetween } from '~/components/Row'
 import Link from '~/components/Link'
 import { DashGrid } from './press'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getSimpleProtocolsPageData } from '~/api/categories/protocols'
 import { tokenIconUrl } from '~/utils'
+import { GetServerSideProps } from 'next'
 
-function Section({title, children}){
-	return <><TYPE.largeHeader>{title}</TYPE.largeHeader>
-	<TYPE.main>{children}</TYPE.main>
-	</>
+function Section({ title, children }) {
+	return (
+		<>
+			<TYPE.largeHeader>{title}</TYPE.largeHeader>
+			<TYPE.main>{children}</TYPE.main>
+		</>
+	)
 }
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const { protocols } = await getSimpleProtocolsPageData(['name', 'logo', 'url', 'referralUrl'])
 	return {
 		props: {
-			protocols: protocols.filter(p=>p.referralUrl !== undefined).map((protocol) => ({
-				name: protocol.name,
-				logo: tokenIconUrl(protocol.name),
-				url: protocol.referralUrl
-			}))
-		},
-		revalidate: revalidate()
+			protocols: protocols
+				.filter((p) => p.referralUrl !== undefined)
+				.map((protocol) => ({
+					name: protocol.name,
+					logo: tokenIconUrl(protocol.name),
+					url: protocol.referralUrl
+				}))
+		}
 	}
 }
 
-
-function PressPage({protocols}) {
+function PressPage({ protocols }) {
 	return (
 		<Layout title="Donations - DefiLlama" defaultSEO>
 			<RowBetween>
@@ -40,49 +45,64 @@ function PressPage({protocols}) {
 			<Panel style={{ marginTop: '6px' }}>
 				<DashGrid style={{ height: 'fit-content', padding: '0 0 1rem 0' }}>
 					<Section title="Why donate?">
-						DefiLlama is an open-source project that runs no ads and provides all data for free. We have no revenue and are supported by donations.
+						DefiLlama is an open-source project that runs no ads and provides all data for free. We have no revenue and
+						are supported by donations.
 					</Section>
 
 					<Divider />
 
 					<Section title="Gitcoin">
-					Donations on gitcoin get matched with donations from a quadratic funding pool, so a small 1$ donation can get heavily amplified.
-					<br /><br />
-					DefiLlama has the following grants:
-					<ul>
-					{[
-						["LlamaPay (preferred)", "https://gitcoin.co/grants/7077/llamapay"],
-						["DefiLlama", "https://gitcoin.co/grants/3591/defillama"],
-						["DefiLlama APIs", "https://gitcoin.co/grants/7087/defillama-apis"],
-					].map(el=><li key={el[0]}><Link href={el[1]} external>{el[0]}</Link></li>)}
-					</ul>
+						Donations on gitcoin get matched with donations from a quadratic funding pool, so a small 1$ donation can
+						get heavily amplified.
+						<br />
+						<br />
+						DefiLlama has the following grants:
+						<ul>
+							{[
+								['LlamaPay (preferred)', 'https://gitcoin.co/grants/7077/llamapay'],
+								['DefiLlama', 'https://gitcoin.co/grants/3591/defillama'],
+								['DefiLlama APIs', 'https://gitcoin.co/grants/7087/defillama-apis']
+							].map((el) => (
+								<li key={el[0]}>
+									<Link href={el[1]} external>
+										{el[0]}
+									</Link>
+								</li>
+							))}
+						</ul>
 					</Section>
 
 					<Divider />
 
-					<Section title="Affiliate links" >
-					DefiLlama has referral links for all these protocols, using them with our referral sends us some rewards:
-					<ul>
-					{protocols.map(p=><li key={p.name}><Link href={p.url} external>{p.name}</Link></li>)}
-					</ul>
+					<Section title="Affiliate links">
+						DefiLlama has referral links for all these protocols, using them with our referral sends us some rewards:
+						<ul>
+							{protocols.map((p) => (
+								<li key={p.name}>
+									<Link href={p.url} external>
+										{p.name}
+									</Link>
+								</li>
+							))}
+						</ul>
 					</Section>
 
 					<Divider />
 
-					<Section title="Direct donation" >
-					You can send us any token, on any network, to the following address: 0x08a3c2A819E3de7ACa384c798269B3Ce1CD0e437
+					<Section title="Direct donation">
+						You can send us any token, on any network, to the following address:
+						0x08a3c2A819E3de7ACa384c798269B3Ce1CD0e437
 					</Section>
 
 					<Divider />
 
-					<Section title="Use of funds" >
-					Funds are only used for 2 purposes:
-					<ul>
-						<li>Pay the llamas working on DefiLlama</li>
-						<li>Cover costs associated with running defillama (this is mostly server costs)</li>
-					</ul>
+					<Section title="Use of funds">
+						Funds are only used for 2 purposes:
+						<ul>
+							<li>Pay the llamas working on DefiLlama</li>
+							<li>Cover costs associated with running defillama (this is mostly server costs)</li>
+						</ul>
 					</Section>
-
 				</DashGrid>
 			</Panel>
 		</Layout>

--- a/src/pages/forks.tsx
+++ b/src/pages/forks.tsx
@@ -26,9 +26,7 @@ export const getServerSideProps: GetServerSideProps = async ({ params, res }) =>
 	addMaxAgeHeaderForNext(res, [22], 3600)
 	const data = await getForkPageData()
 
-	return {
-		props: data.props
-	}
+	return data.notFound ? { notFound: data.notFound } : { props: data.props }
 }
 
 const ChartsWrapper = styled(Panel)`

--- a/src/pages/forks.tsx
+++ b/src/pages/forks.tsx
@@ -8,10 +8,11 @@ import { ForksTable } from '~/components/Table'
 import { ProtocolsChainsSearch } from '~/components/Search'
 import { RowLinksWithDropdown, RowLinksWrapper } from '~/components/Filters'
 import { useCalcGroupExtraTvlsByDay, useCalcStakePool2Tvl } from '~/hooks/data'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getForkPageData } from '~/api/categories/protocols'
 
 import type { IChartProps, IPieChartProps } from '~/components/ECharts/types'
+import { GetServerSideProps } from 'next'
 
 const PieChart = dynamic(() => import('~/components/ECharts/PieChart'), {
 	ssr: false
@@ -21,12 +22,12 @@ const AreaChart = dynamic(() => import('~/components/ECharts/AreaChart'), {
 	ssr: false
 }) as React.FC<IChartProps>
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const data = await getForkPageData()
 
 	return {
-		...data,
-		revalidate: revalidate()
+		props: data.props
 	}
 }
 

--- a/src/pages/forks/[fork].js
+++ b/src/pages/forks/[fork].js
@@ -7,34 +7,18 @@ import { ProtocolsChainsSearch } from '~/components/Search'
 import { RowLinksWithDropdown, RowLinksWrapper } from '~/components/Filters'
 import { useCalcExtraTvlsByDay, useCalcStakePool2Tvl } from '~/hooks/data'
 import { formattedNum, getPercentChange, getPrevTvlFromChart, getTokenDominance } from '~/utils'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getForkPageData } from '~/api/categories/protocols'
 
 const Chart = dynamic(() => import('~/components/GlobalChart'), {
 	ssr: false
 })
 
-export async function getStaticProps({ params: { fork } }) {
+export const getServerSideProps = async ({ params: { fork }, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const data = await getForkPageData(fork)
 
-	return {
-		...data,
-		revalidate: revalidate()
-	}
-}
-
-export async function getStaticPaths() {
-	const { forks = {} } = await getForkPageData()
-
-	const forksList = Object.keys(forks)
-
-	const paths = forksList.slice(0, 10).map((fork) => {
-		return {
-			params: { fork }
-		}
-	})
-
-	return { paths, fallback: 'blocking' }
+	return { ...data }
 }
 
 const PageView = ({ chartData, tokenLinks, token, filteredProtocols, parentTokens }) => {

--- a/src/pages/hacks.tsx
+++ b/src/pages/hacks.tsx
@@ -1,9 +1,11 @@
+import { GetServerSideProps } from 'next'
 import * as React from 'react'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import HacksContainer from '~/containers/Hacks'
 import { formattedNum, toYearMonth } from '~/utils'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const data = (await fetch('https://defi-hacks-api.herokuapp.com/').then((r) => r.json())).map((h) => ({
 		chains: h.chain,
 		classification: h.classification,
@@ -13,7 +15,7 @@ export async function getStaticProps() {
 		name: h.name,
 		technique: h.technique,
 		bridge: h.bridge_multichain_application,
-		link:h.link,
+		link: h.link
 	}))
 
 	const monthlyHacks = {}
@@ -22,7 +24,7 @@ export async function getStaticProps() {
 		const monthlyDate = toYearMonth(r.date)
 		monthlyHacks[monthlyDate] = (monthlyHacks[monthlyDate] ?? 0) + r.amount
 	})
-	
+
 	const totalHacked = formattedNum(
 		data.map((hack) => hack.amount).reduce((acc, amount) => acc + amount, 0) / 1000,
 		true
@@ -51,13 +53,12 @@ export async function getStaticProps() {
 			totalHacked,
 			totalHackedDefi,
 			totalRugs
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 
 const Raises = ({ data, monthlyHacks, ...props }) => {
-	return <HacksContainer data={data} monthlyHacks={monthlyHacks} {...props as any} />
+	return <HacksContainer data={data} monthlyHacks={monthlyHacks} {...(props as any)} />
 }
 
 export default Raises

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,6 @@
 import Layout from '~/layout'
 import ChainPage from '~/components/ChainPage'
-import { addMaxAgeHeaderForNext, revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getChainPageData } from '~/api/categories/protocols'
 
 export const getServerSideProps = async ({ params, res }) => {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,13 +1,13 @@
 import Layout from '~/layout'
 import ChainPage from '~/components/ChainPage'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext, revalidate } from '~/api'
 import { getChainPageData } from '~/api/categories/protocols'
 
-export async function getStaticProps() {
+export const getServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const data = await getChainPageData()
 	return {
-		...data,
-		revalidate: revalidate()
+		...data
 	}
 }
 

--- a/src/pages/languages.tsx
+++ b/src/pages/languages.tsx
@@ -5,8 +5,9 @@ import { AreaChart } from '~/components/Charts'
 import { ChainDominanceChart } from '~/components/Charts'
 import { ProtocolsChainsSearch } from '~/components/Search'
 import { toNiceMonthlyDate, getRandomColor } from '~/utils'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { LANGS_API } from '~/constants'
+import { GetServerSideProps } from 'next'
 
 function formatDataForChart(langs) {
 	const langsUnique = new Set()
@@ -28,7 +29,8 @@ function formatDataForChart(langs) {
 	}
 }
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const data = await fetch(LANGS_API).then((r) => r.json())
 	const { unique: langsUnique, formatted: formattedLangs, daySum: langsDaySum } = formatDataForChart(data.chart)
 	const {
@@ -45,8 +47,7 @@ export async function getStaticProps() {
 			osUnique,
 			osLangs,
 			osDaySum
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 

--- a/src/pages/liquidations/[symbol].tsx
+++ b/src/pages/liquidations/[symbol].tsx
@@ -53,10 +53,13 @@ export const getServerSideProps: GetServerSideProps = async ({ params, res }) =>
 	const { assets: options } = await getAvailableAssetsList()
 	const data = await getLatestChartData(symbol, 100)
 	const prevData = (await getPrevChartData(symbol, 100, 3600 * 24)) ?? data
-	res.setHeader('CDN-Cache-Control', `max-age=${maxAgeForNext([0, 10, 20, 30, 40, 50, 60])}`)
+	res.setHeader(
+		'CDN-Cache-Control',
+		`max-age=${maxAgeForNext([0, 10, 20, 30, 40, 50, 60])}, stale-while-revalidate=1200`
+	)
 	res.setHeader(
 		'Cache-Control',
-		`public, s-maxage=${maxAgeForNext([0, 10, 20, 30, 40, 50, 60])}, stale-while-revalidate=10`
+		`public, s-maxage=${maxAgeForNext([0, 10, 20, 30, 40, 50, 60])}, stale-while-revalidate=1200`
 	)
 	return {
 		props: { data, prevData, options }

--- a/src/pages/liquidations/[symbol].tsx
+++ b/src/pages/liquidations/[symbol].tsx
@@ -15,7 +15,7 @@ import { TableSwitch } from '~/components/LiquidationsPage/TableSwitch'
 import { PositionsTable, SmolHints } from '~/components/LiquidationsPage/PositionsTable'
 import { LIQS_SETTINGS, useLiqsManager } from '~/contexts/LocalStorage'
 import type { ISearchItem } from '~/components/Search/types'
-import { maxAgeForNext, revalidate } from '~/api'
+import { addMaxAgeHeaderForNext, maxAgeForNext, revalidate } from '~/api'
 import { assetIconUrl } from '~/utils'
 import {
 	ChartData,
@@ -26,41 +26,12 @@ import {
 } from '~/utils/liquidations'
 import { LiquidationsContext } from '~/components/LiquidationsPage/context'
 
-// export const getStaticProps: GetStaticProps<{ data: ChartData; prevData: ChartData }> = async ({ params }) => {
-// 	const symbol = (params.symbol as string).toLowerCase()
-// 	const { assets: options } = await getAvailableAssetsList()
-// 	const data = await getLatestChartData(symbol, 100)
-// 	const prevData = (await getPrevChartData(symbol, 100, 3600 * 24)) ?? data
-// 	return {
-// 		props: { data, prevData, options },
-// 		revalidate: revalidate(5)
-// 	}
-// }
-
-// export const getStaticPaths: GetStaticPaths = async () => {
-// 	const { assets } = await getAvailableAssetsList()
-// 	const paths = assets
-// 		.map((x) => (x.route as string).split('/').pop())
-// 		.map((x) => ({
-// 			params: { symbol: x.toLowerCase() }
-// 		}))
-
-// 	return { paths: paths.slice(0, 5), fallback: 'blocking' }
-// }
-
 export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
 	const symbol = (params.symbol as string).toLowerCase()
 	const { assets: options } = await getAvailableAssetsList()
 	const data = await getLatestChartData(symbol, 100)
 	const prevData = (await getPrevChartData(symbol, 100, 3600 * 24)) ?? data
-	res.setHeader(
-		'CDN-Cache-Control',
-		`max-age=${maxAgeForNext([0, 10, 20, 30, 40, 50, 60])}, stale-while-revalidate=1200`
-	)
-	res.setHeader(
-		'Cache-Control',
-		`public, s-maxage=${maxAgeForNext([0, 10, 20, 30, 40, 50, 60])}, stale-while-revalidate=1200`
-	)
+	addMaxAgeHeaderForNext(res, [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55], 1200)
 	return {
 		props: { data, prevData, options }
 	}

--- a/src/pages/liquidations/[symbol].tsx
+++ b/src/pages/liquidations/[symbol].tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars*/
 // eslint sucks at types
-import { NextPage, GetStaticProps, GetStaticPaths } from 'next'
+import { NextPage, GetStaticProps, GetStaticPaths, GetServerSideProps } from 'next'
 import * as React from 'react'
 import styled from 'styled-components'
 import { Clock } from 'react-feather'
@@ -15,7 +15,7 @@ import { TableSwitch } from '~/components/LiquidationsPage/TableSwitch'
 import { PositionsTable, SmolHints } from '~/components/LiquidationsPage/PositionsTable'
 import { LIQS_SETTINGS, useLiqsManager } from '~/contexts/LocalStorage'
 import type { ISearchItem } from '~/components/Search/types'
-import { revalidate } from '~/api'
+import { maxAgeForNext, revalidate } from '~/api'
 import { assetIconUrl } from '~/utils'
 import {
 	ChartData,
@@ -26,26 +26,41 @@ import {
 } from '~/utils/liquidations'
 import { LiquidationsContext } from '~/components/LiquidationsPage/context'
 
-export const getStaticProps: GetStaticProps<{ data: ChartData; prevData: ChartData }> = async ({ params }) => {
+// export const getStaticProps: GetStaticProps<{ data: ChartData; prevData: ChartData }> = async ({ params }) => {
+// 	const symbol = (params.symbol as string).toLowerCase()
+// 	const { assets: options } = await getAvailableAssetsList()
+// 	const data = await getLatestChartData(symbol, 100)
+// 	const prevData = (await getPrevChartData(symbol, 100, 3600 * 24)) ?? data
+// 	return {
+// 		props: { data, prevData, options },
+// 		revalidate: revalidate(5)
+// 	}
+// }
+
+// export const getStaticPaths: GetStaticPaths = async () => {
+// 	const { assets } = await getAvailableAssetsList()
+// 	const paths = assets
+// 		.map((x) => (x.route as string).split('/').pop())
+// 		.map((x) => ({
+// 			params: { symbol: x.toLowerCase() }
+// 		}))
+
+// 	return { paths: paths.slice(0, 5), fallback: 'blocking' }
+// }
+
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
 	const symbol = (params.symbol as string).toLowerCase()
 	const { assets: options } = await getAvailableAssetsList()
 	const data = await getLatestChartData(symbol, 100)
 	const prevData = (await getPrevChartData(symbol, 100, 3600 * 24)) ?? data
+	res.setHeader('CDN-Cache-Control', `max-age=${maxAgeForNext([0, 10, 20, 30, 40, 50, 60])}`)
+	res.setHeader(
+		'Cache-Control',
+		`public, s-maxage=${maxAgeForNext([0, 10, 20, 30, 40, 50, 60])}, stale-while-revalidate=10`
+	)
 	return {
-		props: { data, prevData, options },
-		revalidate: revalidate(5)
+		props: { data, prevData, options }
 	}
-}
-
-export const getStaticPaths: GetStaticPaths = async () => {
-	const { assets } = await getAvailableAssetsList()
-	const paths = assets
-		.map((x) => (x.route as string).split('/').pop())
-		.map((x) => ({
-			params: { symbol: x.toLowerCase() }
-		}))
-
-	return { paths: paths.slice(0, 5), fallback: 'blocking' }
 }
 
 const LiquidationsProvider = ({ children }) => {

--- a/src/pages/liquidations/[symbol].tsx
+++ b/src/pages/liquidations/[symbol].tsx
@@ -31,7 +31,7 @@ export const getServerSideProps: GetServerSideProps = async ({ params, res }) =>
 	const { assets: options } = await getAvailableAssetsList()
 	const data = await getLatestChartData(symbol, 100)
 	const prevData = (await getPrevChartData(symbol, 100, 3600 * 24)) ?? data
-	addMaxAgeHeaderForNext(res, [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55], 1200)
+	addMaxAgeHeaderForNext(res, [5, 25, 45], 1200)
 	return {
 		props: { data, prevData, options }
 	}

--- a/src/pages/nfts.js
+++ b/src/pages/nfts.js
@@ -1,8 +1,9 @@
 import NFTDashboardPage from '~/components/NFTDashboardPage'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getNFTChainsData, getNFTData } from '~/api/categories/nfts'
 
-export async function getStaticProps() {
+export const getServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const data = await getNFTData()
 	const chainData = await getNFTChainsData()
 
@@ -10,8 +11,7 @@ export async function getStaticProps() {
 		props: {
 			...data,
 			chainData
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 

--- a/src/pages/nfts/chain/[...chain].js
+++ b/src/pages/nfts/chain/[...chain].js
@@ -1,5 +1,5 @@
 import NFTDashboardPage from '~/components/NFTDashboardPage'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import {
 	getNFTChainChartData,
 	getNFTChainsData,
@@ -7,11 +7,13 @@ import {
 	getNFTStatistics
 } from '~/api/categories/nfts'
 
-export async function getStaticProps({
+export const getServerSideProps = async ({
 	params: {
 		chain: [chainName]
-	}
-}) {
+	},
+	res
+}) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const collections = await getNFTCollectionsByChain(chainName)
 	const chartData = await getNFTChainChartData(chainName)
 	const chainData = await getNFTChainsData()
@@ -27,23 +29,8 @@ export async function getStaticProps({
 			statistics,
 			chainData,
 			displayName
-		},
-		revalidate: revalidate()
+		}
 	}
-}
-
-// export async function getStaticPaths() {
-// 	const chainData = await getNFTChainsData()
-
-// 	const paths = chainData.slice(0, 5).map(({ chain: chainName }) => ({
-// 		params: { chain: [chainName] }
-// 	}))
-
-// 	return { paths, fallback: 'blocking' }
-// }
-
-export async function getStaticPaths() {
-	return { paths: [], fallback: 'blocking' }
 }
 
 export default function Chain({ displayName, ...props }) {

--- a/src/pages/nfts/chains.js
+++ b/src/pages/nfts/chains.js
@@ -7,10 +7,11 @@ import SEO from '~/components/SEO'
 import { ChainPieChart, ChainDominanceChart } from '~/components/Charts'
 import { NftChainsTable } from '~/components/Table'
 import { getRandomColor } from '~/utils'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getNFTChainChartData, getNFTChainsData } from '~/api/categories/nfts'
 
-export async function getStaticProps() {
+export const getServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const chainData = await getNFTChainsData()
 
 	const currentData = chainData.reduce((acc, curr) => {
@@ -53,8 +54,7 @@ export async function getStaticProps() {
 			chainsUnique: chainsUnique || null,
 			stackedDataset: stackedDataset || null,
 			daySum: daySum || null
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 

--- a/src/pages/nfts/collection/[...collection].js
+++ b/src/pages/nfts/collection/[...collection].js
@@ -1,13 +1,15 @@
 import NFTCollectionPage from '~/components/NFTCollectionPage'
 import { getColor } from '~/utils/getColor'
-import { revalidate } from '~/api'
-import { getNFTCollection, getNFTCollections, getNFTCollectionChartData, getNFTStatistics } from '~/api/categories/nfts'
+import { addMaxAgeHeaderForNext } from '~/api'
+import { getNFTCollection, getNFTCollectionChartData, getNFTStatistics } from '~/api/categories/nfts'
 
-export async function getStaticProps({
+export const getServerSideProps = async ({
 	params: {
 		collection: [slug]
-	}
-}) {
+	},
+	res
+}) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const collection = await getNFTCollection(slug)
 	const chart = await getNFTCollectionChartData(slug)
 	const statistics = await getNFTStatistics(chart)
@@ -20,22 +22,8 @@ export async function getStaticProps({
 			statistics,
 			title: collection ? `${collection.name} - DefiLlama` : `DefiLlama - NFT Dashboard`,
 			backgroundColor
-		},
-		revalidate: revalidate()
+		}
 	}
-}
-
-// export async function getStaticPaths() {
-// 	const collections = await getNFTCollections()
-// 	const paths = collections.slice(0, 20).map(({ slug }) => ({
-// 		params: { collection: [slug] }
-// 	}))
-
-// 	return { paths, fallback: 'blocking' }
-// }
-
-export async function getStaticPaths() {
-	return { paths: [], fallback: 'blocking' }
 }
 
 export default function Collection(props) {

--- a/src/pages/nfts/marketplace/[...marketplace].js
+++ b/src/pages/nfts/marketplace/[...marketplace].js
@@ -1,5 +1,5 @@
 import NFTDashboardPage from '~/components/NFTDashboardPage'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import {
 	getNFTMarketplaceChartData,
 	getNFTMarketplacesData,
@@ -7,11 +7,13 @@ import {
 	getNFTStatistics
 } from '~/api/categories/nfts'
 
-export async function getStaticProps({
+export async function getServerSideProps({
 	params: {
 		marketplace: [marketplaceName]
-	}
+	},
+	res
 }) {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const collections = await getNFTCollectionsByMarketplace(marketplaceName)
 	const chartData = await getNFTMarketplaceChartData(marketplaceName)
 	const marketplaceData = await getNFTMarketplacesData()
@@ -25,23 +27,8 @@ export async function getStaticProps({
 			statistics,
 			marketplaceData,
 			displayName
-		},
-		revalidate: revalidate()
+		}
 	}
-}
-
-// export async function getStaticPaths() {
-// 	const marketplaceData = await getNFTMarketplacesData()
-
-// 	const paths = marketplaceData.slice(0, 5).map(({ marketplace: marketplaceName }) => ({
-// 		params: { marketplace: [marketplaceName] }
-// 	}))
-
-// 	return { paths, fallback: 'blocking' }
-// }
-
-export async function getStaticPaths() {
-	return { paths: [], fallback: 'blocking' }
 }
 
 export default function Marketplace({ displayName, ...props }) {

--- a/src/pages/nfts/marketplaces.js
+++ b/src/pages/nfts/marketplaces.js
@@ -7,10 +7,11 @@ import SEO from '~/components/SEO'
 import { ChainPieChart, ChainDominanceChart } from '~/components/Charts'
 import { NftMarketplacesTable } from '~/components/Table'
 import { getRandomColor } from '~/utils'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getNFTMarketplacesData, getNFTMarketplaceChartData } from '~/api/categories/nfts'
 
-export async function getStaticProps() {
+export const getServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const marketplaceData = await getNFTMarketplacesData()
 
 	const currentData = marketplaceData.reduce((acc, curr) => {
@@ -53,8 +54,7 @@ export async function getStaticProps() {
 			marketplacesUnique: marketplacesUnique || null,
 			stackedDataset: stackedDataset || null,
 			daySum: daySum || null
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 

--- a/src/pages/oracles.tsx
+++ b/src/pages/oracles.tsx
@@ -8,10 +8,11 @@ import { OraclesTable } from '~/components/Table'
 import { ProtocolsChainsSearch } from '~/components/Search'
 import { RowLinksWithDropdown, RowLinksWrapper } from '~/components/Filters'
 import { useCalcGroupExtraTvlsByDay } from '~/hooks/data'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getOraclePageData } from '~/api/categories/protocols'
 
 import type { IChartProps, IPieChartProps } from '~/components/ECharts/types'
+import { GetServerSideProps } from 'next'
 
 const PieChart = dynamic(() => import('~/components/ECharts/PieChart'), {
 	ssr: false
@@ -21,13 +22,11 @@ const AreaChart = dynamic(() => import('~/components/ECharts/AreaChart'), {
 	ssr: false
 }) as React.FC<IChartProps>
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const data = await getOraclePageData()
 
-	return {
-		...data,
-		revalidate: revalidate()
-	}
+	return data.notFound ? { notFound: data.notFound } : { props: data.props }
 }
 
 const ChartsWrapper = styled(Panel)`

--- a/src/pages/oracles/[oracle].js
+++ b/src/pages/oracles/[oracle].js
@@ -7,34 +7,20 @@ import { ProtocolsChainsSearch } from '~/components/Search'
 import { RowLinksWithDropdown, RowLinksWrapper } from '~/components/Filters'
 import { useCalcExtraTvlsByDay, useCalcStakePool2Tvl } from '~/hooks/data'
 import { formattedNum, getPercentChange, getPrevTvlFromChart, getTokenDominance } from '~/utils'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getOraclePageData } from '~/api/categories/protocols'
 
 const Chart = dynamic(() => import('~/components/GlobalChart'), {
 	ssr: false
 })
 
-export async function getStaticProps({ params: { oracle } }) {
+export const getServerSideProps = async ({ params: { oracle }, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const data = await getOraclePageData(oracle)
 
 	return {
-		...data,
-		revalidate: revalidate()
+		...data
 	}
-}
-
-export async function getStaticPaths() {
-	const { oracles = {} } = await getOraclePageData()
-
-	const oraclesList = Object.keys(oracles)
-
-	const paths = oraclesList.slice(0, 10).map((oracle) => {
-		return {
-			params: { oracle }
-		}
-	})
-
-	return { paths, fallback: 'blocking' }
 }
 
 const PageView = ({ chartData, tokenLinks, token, filteredProtocols }) => {

--- a/src/pages/protocol/[...protocol].tsx
+++ b/src/pages/protocol/[...protocol].tsx
@@ -81,16 +81,6 @@ export const getStaticProps: GetStaticProps<PageParams> = async ({
 	}
 }
 
-export async function getStaticPaths() {
-	const res = await getProtocols()
-
-	const paths: string[] = res.protocols.slice(0, 30).map(({ name }) => ({
-		params: { protocol: [standardizeProtocolName(name)] }
-	}))
-
-	return { paths, fallback: 'blocking' }
-}
-
 export default function Protocols({ protocolData, ...props }: InferGetStaticPropsType<typeof getStaticProps>) {
 	return (
 		<ProtocolContainer

--- a/src/pages/protocols.tsx
+++ b/src/pages/protocols.tsx
@@ -1,16 +1,17 @@
 import Layout from '~/layout'
 import ProtocolList from '~/components/ProtocolList'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getSimpleProtocolsPageData } from '~/api/categories/protocols'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const { protocols } = await getSimpleProtocolsPageData()
 
 	return {
 		props: {
 			protocols
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 

--- a/src/pages/protocols/[...category].tsx
+++ b/src/pages/protocols/[...category].tsx
@@ -1,15 +1,17 @@
 import Layout from '~/layout'
 import ProtocolList from '~/components/ProtocolList'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getProtocolsPageData } from '~/api/categories/protocols'
-import { PROTOCOLS_API } from '~/constants/index'
 import { capitalizeFirstLetter } from '~/utils'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps({
+export const getServerSideProps: GetServerSideProps = async ({
 	params: {
 		category: [category, chain]
-	}
-}) {
+	},
+	res
+}) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const props = await getProtocolsPageData(category, chain)
 
 	if (props.filteredProtocols.length === 0) {
@@ -17,20 +19,7 @@ export async function getStaticProps({
 			notFound: true
 		}
 	}
-	return {
-		props,
-		revalidate: revalidate()
-	}
-}
-
-export async function getStaticPaths() {
-	const res = await fetch(PROTOCOLS_API)
-
-	const paths = (await res.json()).protocolCategories.slice(0, 10).map((category) => ({
-		params: { category: [category.toLowerCase()] }
-	}))
-
-	return { paths, fallback: 'blocking' }
+	return { props }
 }
 
 export default function Protocols({ category, ...props }) {

--- a/src/pages/raises.tsx
+++ b/src/pages/raises.tsx
@@ -1,12 +1,14 @@
+import { GetServerSideProps } from 'next'
 import * as React from 'react'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getRaisesFiltersList } from '~/api/categories/raises'
 import { RAISES_API } from '~/constants'
 import RaisesContainer from '~/containers/Raises'
 import { toYearMonth } from '~/utils'
 import { compressPageProps, decompressPageProps } from '~/utils/compress'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const data = await fetch(RAISES_API).then((r) => r.json())
 
 	const monthlyInvestment = {}
@@ -37,8 +39,7 @@ export async function getStaticProps() {
 	})
 
 	return {
-		props: { compressed },
-		revalidate: revalidate()
+		props: { compressed }
 	}
 }
 

--- a/src/pages/raises/[...investorName].tsx
+++ b/src/pages/raises/[...investorName].tsx
@@ -1,16 +1,19 @@
+import { GetServerSideProps } from 'next'
 import * as React from 'react'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext, revalidate } from '~/api'
 import { getRaisesFiltersList } from '~/api/categories/raises'
 import { RAISES_API } from '~/constants'
 import RaisesContainer from '~/containers/Raises'
 import { slug, toYearMonth } from '~/utils'
 import { compressPageProps, decompressPageProps } from '~/utils/compress'
 
-export async function getStaticProps({
+export const getServerSideProps: GetServerSideProps = async ({
 	params: {
 		investorName: [name]
-	}
-}) {
+	},
+	res
+}) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const data = await fetch(RAISES_API).then((r) => r.json())
 
 	const raises = []
@@ -78,13 +81,6 @@ export async function getStaticProps({
 			compressed
 		},
 		revalidate: revalidate()
-	}
-}
-
-export async function getStaticPaths() {
-	return {
-		paths: [],
-		fallback: 'blocking'
 	}
 }
 

--- a/src/pages/recent.tsx
+++ b/src/pages/recent.tsx
@@ -1,10 +1,12 @@
 import { RecentProtocols } from '~/components/RecentProtocols'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getSimpleProtocolsPageData } from '~/api/categories/protocols'
 import { basicPropertiesToKeep } from '~/api/categories/protocols/utils'
 import { FORK_API } from '~/constants'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const protocolsRaw = await getSimpleProtocolsPageData([...basicPropertiesToKeep, 'extraTvl', 'listedAt', 'chainTvls'])
 	const { forks } = await fetch(FORK_API).then((r) => r.json())
 
@@ -22,8 +24,7 @@ export async function getStaticProps() {
 			protocols,
 			chainList: protocolsRaw.chains,
 			forkedList
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 

--- a/src/pages/roundup.tsx
+++ b/src/pages/roundup.tsx
@@ -2,8 +2,9 @@ import Link from 'next/link'
 import styled from 'styled-components'
 import ReactMarkdown from 'react-markdown'
 import Layout from '~/layout'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import Announcement from '~/components/Announcement'
+import { GetServerSideProps } from 'next'
 
 const Header = styled.h1`
 	color: ${({ theme }) => theme.text1};
@@ -97,7 +98,8 @@ export default function Chains({ messages }: { messages?: string }) {
 	)
 }
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const headers = new Headers()
 	headers.append('Authorization', `Bot ${process.env.ROUND_UP_BOT_TOKEN}`)
 
@@ -136,7 +138,6 @@ export async function getStaticProps() {
 	return {
 		props: {
 			messages: splitLlama[1] || null
-		},
-		revalidate: revalidate()
+		}
 	}
 }

--- a/src/pages/stablecoin/[...peggedasset].js
+++ b/src/pages/stablecoin/[...peggedasset].js
@@ -1,15 +1,16 @@
 import * as React from 'react'
 import PeggedContainer from '~/containers/PeggedContainer'
-import { standardizeProtocolName } from '~/utils'
 import { getPeggedColor } from '~/utils/getColor'
-import { revalidate } from '~/api'
-import { getPeggedAssetPageData, getPeggedAssets } from '~/api/categories/stablecoins'
+import { addMaxAgeHeaderForNext } from '~/api'
+import { getPeggedAssetPageData } from '~/api/categories/stablecoins'
 
-export async function getStaticProps({
+export const getServerSideProps = async ({
 	params: {
 		peggedasset: [peggedasset]
-	}
-}) {
+	},
+	res
+}) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const data = await getPeggedAssetPageData(peggedasset)
 	const { chainsUnique, chainCirculatings, peggedAssetData, totalCirculating, unreleased, mcap, bridgeInfo } =
 		data.props
@@ -26,19 +27,8 @@ export async function getStaticProps({
 			mcap,
 			bridgeInfo,
 			backgroundColor
-		},
-		revalidate: revalidate()
+		}
 	}
-}
-
-export async function getStaticPaths() {
-	const res = await getPeggedAssets()
-
-	const paths = res.peggedAssets.map(({ name }) => ({
-		params: { peggedasset: [standardizeProtocolName(name)] }
-	}))
-
-	return { paths: paths.slice(0, 11), fallback: 'blocking' }
 }
 
 export default function PeggedAsset(props) {

--- a/src/pages/stablecoins.js
+++ b/src/pages/stablecoins.js
@@ -1,10 +1,11 @@
 import Layout from '~/layout'
 import PeggedList from '~/components/PeggedPage/PeggedList'
 import { getPeggedColor } from '~/utils/getColor'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getPeggedOverviewPageData } from '~/api/categories/stablecoins'
 
-export async function getStaticProps({}) {
+export const getServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const props = await getPeggedOverviewPageData(null)
 
 	const backgroundColor = await getPeggedColor({
@@ -14,8 +15,7 @@ export async function getStaticProps({}) {
 		props: {
 			...props,
 			backgroundColor
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 

--- a/src/pages/stablecoins/[...chain].js
+++ b/src/pages/stablecoins/[...chain].js
@@ -1,14 +1,16 @@
 import Layout from '~/layout'
 import PeggedList from '~/components/PeggedPage/PeggedList'
 import { getPeggedColor } from '~/utils/getColor'
-import { revalidate } from '~/api'
-import { getPeggedAssets, getPeggedOverviewPageData } from '~/api/categories/stablecoins'
+import { addMaxAgeHeaderForNext } from '~/api'
+import { getPeggedOverviewPageData } from '~/api/categories/stablecoins'
 
-export async function getStaticProps({
+export const getServerSideProps = async ({
 	params: {
 		chain: [chain]
-	}
-}) {
+	},
+	res
+}) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const props = await getPeggedOverviewPageData(chain)
 
 	if (!props.filteredPeggedAssets || props.filteredPeggedAssets?.length === 0) {
@@ -24,19 +26,8 @@ export async function getStaticProps({
 		props: {
 			...props,
 			backgroundColor
-		},
-		revalidate: revalidate()
+		}
 	}
-}
-
-export async function getStaticPaths() {
-	const { chains } = await getPeggedAssets()
-
-	const paths = chains.slice(0, 20).map((chain) => ({
-		params: { chain: [chain.name] }
-	}))
-
-	return { paths: paths.slice(0, 11), fallback: 'blocking' }
 }
 
 export default function PeggedAssets({

--- a/src/pages/stablecoins/chains.js
+++ b/src/pages/stablecoins/chains.js
@@ -1,18 +1,17 @@
 import Layout from '~/layout'
 import PeggedChainsOverview from '~/components/PeggedPage/PeggedChainsOverview'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getPeggedChainsPageData } from '~/api/categories/stablecoins'
 
-export async function getStaticProps() {
+export const getServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const props = await getPeggedChainsPageData()
 
-	if (!props.chainCirculatings || props.chainCirculatings?.length === 0) { // TODO: Remove
-		throw new Error("getPeggedChainsPageData() broken")
+	if (!props.chainCirculatings || props.chainCirculatings?.length === 0) {
+		// TODO: Remove
+		throw new Error('getPeggedChainsPageData() broken')
 	}
-	return {
-		props,
-		revalidate: revalidate()
-	}
+	return { props }
 }
 
 export default function PeggedAssets({

--- a/src/pages/tokenUsage.tsx
+++ b/src/pages/tokenUsage.tsx
@@ -7,10 +7,11 @@ import { DesktopSearch } from '~/components/Search/Base'
 import LocalLoader from '~/components/LocalLoader'
 import { TableFilters, TableHeader } from '~/components/Table/shared'
 import { PROTOCOLS_BY_TOKEN_API } from '~/constants'
-import { getAllCGTokensList, revalidate } from '~/api'
+import { addMaxAgeHeaderForNext, getAllCGTokensList, revalidate } from '~/api'
 import { fetcher } from '~/utils/useSWR'
 import Announcement from '~/components/Announcement'
 import { compressPageProps, decompressPageProps } from '~/utils/compress'
+import { GetServerSideProps } from 'next'
 
 export default function Tokens({ compressed }) {
 	const { searchData } = decompressPageProps(compressed)
@@ -88,7 +89,8 @@ export default function Tokens({ compressed }) {
 	)
 }
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [23], 3600)
 	const searchData = await getAllCGTokensList()
 
 	const compressed = compressPageProps({
@@ -101,7 +103,6 @@ export async function getStaticProps() {
 	})
 
 	return {
-		props: { compressed },
-		revalidate: revalidate(23)
+		props: { compressed }
 	}
 }

--- a/src/pages/top-gainers-and-losers.tsx
+++ b/src/pages/top-gainers-and-losers.tsx
@@ -4,19 +4,20 @@ import { TYPE } from '~/Theme'
 import Layout from '~/layout'
 import { splitArrayByFalsyValues } from '~/components/Table/utils'
 import { useCalcStakePool2Tvl } from '~/hooks/data'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getSimpleProtocolsPageData } from '~/api/categories/protocols'
 import { basicPropertiesToKeep } from '~/api/categories/protocols/utils'
 import { TopGainersAndLosers } from '~/components/Table/Defi/Protocols'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const { protocols } = await getSimpleProtocolsPageData([...basicPropertiesToKeep, 'extraTvl'])
 
 	return {
 		props: {
 			protocols
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 

--- a/src/pages/top-protocols.tsx
+++ b/src/pages/top-protocols.tsx
@@ -5,15 +5,17 @@ import Layout from '~/layout'
 import { CustomLink } from '~/components/Link'
 import TokenLogo from '~/components/TokenLogo'
 import { chainIconUrl, slug } from '~/utils'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getSimpleProtocolsPageData } from '~/api/categories/protocols'
 import VirtualTable from '~/components/Table/Table'
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { IFormattedProtocol } from '~/api/types'
 import { Name } from '~/components/Table/shared'
 import { descriptions } from './categories'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const { protocols, chains } = await getSimpleProtocolsPageData(['name', 'extraTvl', 'chainTvls', 'category'])
 	const topProtocolPerChainAndCategory = Object.fromEntries(chains.map((c) => [c, {}]))
 
@@ -59,8 +61,7 @@ export async function getStaticProps() {
 		props: {
 			data,
 			columns
-		},
-		revalidate: revalidate()
+		}
 	}
 }
 

--- a/src/pages/users/chain/[...chain].tsx
+++ b/src/pages/users/chain/[...chain].tsx
@@ -1,27 +1,18 @@
 import * as React from 'react'
 import { capitalizeFirstLetter } from '~/utils'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { USER_METRICS_ALL_API, USER_METRICS_CHAIN_API } from '~/constants'
 import { arrayFetcher } from '~/utils/useSWR'
 import UsersByChain from '~/containers/UsersByChain'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticPaths() {
-	/*
-	const res = await fetch(`${USER_METRICS_ALL_API}`).then((res) => res.json())
-
-	const paths: string[] = res.chains.slice(0, 30).map((chain) => ({
-		params: { chain: [chain] }
-	}))
-	*/
-
-	return { paths:[], fallback: 'blocking' }
-}
-
-export async function getStaticProps({
+export const getServerSideProps: GetServerSideProps = async ({
 	params: {
 		chain: [chain]
-	}
-}) {
+	},
+	res
+}) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	try {
 		const [userMetrics, { chains }] = await arrayFetcher([
 			`${USER_METRICS_CHAIN_API}/${chain}`,
@@ -39,8 +30,7 @@ export async function getStaticProps({
 					to: chain === 'All' ? '/users' : `/users/chain/${chain}`
 				})),
 				protocols: userMetrics.protocols || [],
-				chain: chainName,
-				revalidate: revalidate()
+				chain: chainName
 			}
 		}
 	} catch (error) {

--- a/src/pages/users/index.tsx
+++ b/src/pages/users/index.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react'
 import { capitalizeFirstLetter } from '~/utils'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { USER_METRICS_ALL_API } from '~/constants'
 import UsersByChain from '~/containers/UsersByChain'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	try {
 		const userMetrics = await fetch(`${USER_METRICS_ALL_API}`).then((res) => res.json())
 
@@ -17,8 +19,7 @@ export async function getStaticProps() {
 					to: chain === 'All' ? '/users' : `/users/chain/${chain}`
 				})),
 				protocols: userMetrics.protocols || [],
-				chain: 'All',
-				revalidate: revalidate()
+				chain: 'All'
 			}
 		}
 	} catch (error) {

--- a/src/pages/watchlist.tsx
+++ b/src/pages/watchlist.tsx
@@ -1,15 +1,16 @@
 import { DefiWatchlistContainer } from '~/containers/Watchlist'
 import Layout from '~/layout'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getSimpleProtocolsPageData } from '~/api/categories/protocols'
 import { basicPropertiesToKeep } from '~/api/categories/protocols/utils'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [22], 3600)
 	const { protocols } = await getSimpleProtocolsPageData(basicPropertiesToKeep)
 
 	return {
-		props: { protocols },
-		revalidate: revalidate()
+		props: { protocols }
 	}
 }
 

--- a/src/pages/yields.tsx
+++ b/src/pages/yields.tsx
@@ -1,12 +1,14 @@
 import Layout from '~/layout'
 import YieldPage from '~/components/YieldsPage'
 import { getYieldPageData } from '~/api/categories/yield'
-import { getAllCGTokensList, revalidate } from '~/api'
+import { addMaxAgeHeaderForNext, getAllCGTokensList } from '~/api'
 import Announcement from '~/components/Announcement'
 import { disclaimer } from '~/components/YieldsPage/utils'
 import { compressPageProps, decompressPageProps } from '~/utils/compress'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [23], 3600)
 	const data = await getYieldPageData()
 	data.props.pools = data.props.pools.filter((p) => p.apy > 0)
 
@@ -25,8 +27,7 @@ export async function getStaticProps() {
 	const compressed = compressPageProps({ ...data.props, tokens, tokenSymbolsList })
 
 	return {
-		props: { compressed },
-		revalidate: revalidate(23)
+		props: { compressed }
 	}
 }
 

--- a/src/pages/yields/borrow.tsx
+++ b/src/pages/yields/borrow.tsx
@@ -2,11 +2,13 @@ import Layout from '~/layout'
 import YieldPageBorrow from '~/components/YieldsPage/indexBorrow'
 import Announcement from '~/components/Announcement'
 import { disclaimer } from '~/components/YieldsPage/utils'
-import { getAllCGTokensList, revalidate } from '~/api'
+import { addMaxAgeHeaderForNext, getAllCGTokensList } from '~/api'
 import { getLendBorrowData } from '~/api/categories/yield'
 import { compressPageProps, decompressPageProps } from '~/utils/compress'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [23], 3600)
 	const data = await getLendBorrowData()
 
 	const cgTokens = await getAllCGTokensList()
@@ -24,8 +26,7 @@ export async function getStaticProps() {
 	const compressed = compressPageProps({ ...data.props, tokens, tokenSymbolsList })
 
 	return {
-		props: { compressed },
-		revalidate: revalidate(23)
+		props: { compressed }
 	}
 }
 

--- a/src/pages/yields/halal.tsx
+++ b/src/pages/yields/halal.tsx
@@ -93,11 +93,13 @@ import YieldPage from '~/components/YieldsPage'
 import Link from '~/components/Link'
 import Announcement from '~/components/Announcement'
 import { disclaimer } from '~/components/YieldsPage/utils'
-import { getAllCGTokensList, revalidate } from '~/api'
+import { addMaxAgeHeaderForNext, getAllCGTokensList, revalidate } from '~/api'
 import { getYieldPageData } from '~/api/categories/yield'
 import { compressPageProps, decompressPageProps } from '~/utils/compress'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [23], 3600)
 	let {
 		props: { ...data }
 	} = await getYieldPageData()
@@ -131,8 +133,7 @@ export async function getStaticProps() {
 	})
 
 	return {
-		props: { compressed },
-		revalidate: revalidate(23)
+		props: { compressed }
 	}
 }
 

--- a/src/pages/yields/loop.tsx
+++ b/src/pages/yields/loop.tsx
@@ -5,11 +5,13 @@ import Link from '~/components/Link'
 import YieldPageLoop from '~/components/YieldsPage/indexLoop'
 import Announcement from '~/components/Announcement'
 import { disclaimer } from '~/components/YieldsPage/utils'
-import { getAllCGTokensList, revalidate } from '~/api'
+import { addMaxAgeHeaderForNext, getAllCGTokensList } from '~/api'
 import { getLendBorrowData, calculateLoopAPY } from '~/api/categories/yield'
 import { compressPageProps, decompressPageProps } from '~/utils/compress'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [23], 3600)
 	let {
 		props: { ...data }
 	} = await getLendBorrowData()
@@ -35,8 +37,7 @@ export async function getStaticProps() {
 	})
 
 	return {
-		props: { compressed },
-		revalidate: revalidate(23)
+		props: { compressed }
 	}
 }
 

--- a/src/pages/yields/overview.tsx
+++ b/src/pages/yields/overview.tsx
@@ -2,11 +2,13 @@ import Layout from '~/layout'
 import PlotsPage from '~/components/YieldsPage/indexPlots'
 import Announcement from '~/components/Announcement'
 import { disclaimer } from '~/components/YieldsPage/utils'
-import { getAllCGTokensList, revalidate } from '~/api'
+import { addMaxAgeHeaderForNext, getAllCGTokensList } from '~/api'
 import { getYieldPageData, getYieldMedianData } from '~/api/categories/yield'
 import { compressPageProps, decompressPageProps } from '~/utils/compress'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [23], 3600)
 	const {
 		props: { ...data }
 	} = await getYieldPageData()
@@ -28,8 +30,7 @@ export async function getStaticProps() {
 	const compressed = compressPageProps({ ...data, median: median.props, tokens, tokenSymbolsList })
 
 	return {
-		props: { compressed },
-		revalidate: revalidate(23)
+		props: { compressed }
 	}
 }
 

--- a/src/pages/yields/projects.tsx
+++ b/src/pages/yields/projects.tsx
@@ -3,10 +3,11 @@ import { YieldsProjectsTable } from '~/components/Table'
 import Announcement from '~/components/Announcement'
 import { disclaimer } from '~/components/YieldsPage/utils'
 import { compressPageProps, decompressPageProps } from '~/utils/compress'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getYieldPageData } from '~/api/categories/yield'
 
 import PageHeader from '~/components/PageHeader'
+import { GetServerSideProps } from 'next'
 
 function median(numbers) {
 	const sorted: any = Array.from(numbers).sort((a: number, b: number) => a - b)
@@ -19,7 +20,8 @@ function median(numbers) {
 	return sorted[middle]
 }
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [23], 3600)
 	const data = await getYieldPageData()
 
 	const projects = {}
@@ -51,8 +53,7 @@ export async function getStaticProps() {
 	})
 
 	return {
-		props: { compressed },
-		revalidate: revalidate(23)
+		props: { compressed }
 	}
 }
 

--- a/src/pages/yields/stablecoins.tsx
+++ b/src/pages/yields/stablecoins.tsx
@@ -2,11 +2,13 @@ import Layout from '~/layout'
 import YieldPage from '~/components/YieldsPage'
 import Announcement from '~/components/Announcement'
 import { disclaimer } from '~/components/YieldsPage/utils'
-import { getAllCGTokensList, revalidate } from '~/api'
+import { addMaxAgeHeaderForNext, getAllCGTokensList } from '~/api'
 import { getYieldPageData } from '~/api/categories/yield'
 import { compressPageProps, decompressPageProps } from '~/utils/compress'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [23], 3600)
 	const data = await getYieldPageData()
 	const cgTokens = await getAllCGTokensList()
 	data.props.pools = data.props.pools.filter((p) => p.apy > 0)
@@ -24,8 +26,7 @@ export async function getStaticProps() {
 	const compressed = compressPageProps({ ...data.props, tokens, tokenSymbolsList })
 
 	return {
-		props: { compressed },
-		revalidate: revalidate(23)
+		props: { compressed }
 	}
 }
 

--- a/src/pages/yields/strategy.tsx
+++ b/src/pages/yields/strategy.tsx
@@ -2,11 +2,13 @@ import Layout from '~/layout'
 import YieldsStrategyPage from '~/components/YieldsPage/indexStrategy'
 import Announcement from '~/components/Announcement'
 import { disclaimer } from '~/components/YieldsPage/utils'
-import { getAllCGTokensList, revalidate } from '~/api'
+import { addMaxAgeHeaderForNext, getAllCGTokensList } from '~/api'
 import { getLendBorrowData } from '~/api/categories/yield'
 import { compressPageProps, decompressPageProps } from '~/utils/compress'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [23], 3600)
 	const {
 		props: { pools, allPools, ...data }
 	} = await getLendBorrowData()
@@ -35,8 +37,7 @@ export async function getStaticProps() {
 	})
 
 	return {
-		props: { compressed },
-		revalidate: revalidate(23)
+		props: { compressed }
 	}
 }
 

--- a/src/pages/yields/watchlist.tsx
+++ b/src/pages/yields/watchlist.tsx
@@ -2,18 +2,19 @@ import Layout from '~/layout'
 import { YieldsWatchlistContainer } from '~/containers/Watchlist'
 import Announcement from '~/components/Announcement'
 import { disclaimer } from '~/components/YieldsPage/utils'
-import { revalidate } from '~/api'
+import { addMaxAgeHeaderForNext } from '~/api'
 import { getYieldPageData } from '~/api/categories/yield'
 import { compressPageProps, decompressPageProps } from '~/utils/compress'
+import { GetServerSideProps } from 'next'
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async ({ params, res }) => {
+	addMaxAgeHeaderForNext(res, [23], 3600)
 	const data = await getYieldPageData()
 
 	const compressed = compressPageProps(data.props.pools)
 
 	return {
-		props: { compressed },
-		revalidate: revalidate(23)
+		props: { compressed }
 	}
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,6 +1277,15 @@ bignumber.js@^9.0.2:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.0.tgz#8d340146107fe3a6cb8d40699643c302e8773b62"
   integrity sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==
 
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
 bmp-js@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/bmp-js/-/bmp-js-0.1.0.tgz#e05a63f796a6c1ff25f4771ec7adadc148c07233"
@@ -1302,7 +1311,7 @@ buffer-equal@0.0.1:
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-0.0.1.tgz#91bc74b11ea405bc916bc6aa908faafa5b4aac4b"
   integrity sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==
 
-buffer@^5.2.0:
+buffer@^5.2.0, buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -1370,6 +1379,11 @@ character-reference-invalid@^1.0.0:
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
   integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
 
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+
 classnames@^2.2.5, classnames@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
@@ -1394,10 +1408,26 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
+  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 colord@^2.9.3:
   version "2.9.3"
@@ -1622,7 +1652,14 @@ decode-named-character-reference@^1.0.0:
   dependencies:
     character-entities "^2.0.0"
 
-deep-extend@0.6.0:
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
+deep-extend@0.6.0, deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
@@ -1649,6 +1686,11 @@ dequal@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+detect-libc@^2.0.0, detect-libc@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.1.tgz#e1897aa88fa6ad197862937fbc0441ef352ee0cd"
+  integrity sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
 
 diff@^5.0.0:
   version "5.1.0"
@@ -1730,6 +1772,13 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
 
 enquirer@^2.3.5:
   version "2.3.6"
@@ -2027,6 +2076,11 @@ exif-parser@^0.1.12:
   resolved "https://registry.yarnpkg.com/exif-parser/-/exif-parser-0.1.12.tgz#58a9d2d72c02c1f6f02a0ef4a9166272b7760922"
   integrity sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==
 
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
 extend@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
@@ -2147,6 +2201,11 @@ formdata-node@^4.0.0:
     node-domexception "1.0.0"
     web-streams-polyfill "4.0.0-beta.3"
 
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -2201,6 +2260,11 @@ gifwrap@^0.9.2:
   dependencies:
     image-q "^4.0.0"
     omggif "^1.0.10"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
 glob-parent@^5.1.2:
   version "5.1.2"
@@ -2401,10 +2465,15 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ini@~1.3.0:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 inline-style-parser@0.1.1:
   version "0.1.1"
@@ -2449,6 +2518,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-bigint@^1.0.1:
   version "1.0.4"
@@ -2994,6 +3068,11 @@ mime@^1.3.4:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 min-document@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
@@ -3008,10 +3087,15 @@ minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.6:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
+
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
 mkdirp@^0.5.1:
   version "0.5.6"
@@ -3050,6 +3134,11 @@ nanoid@^3.3.4:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
+napi-build-utils@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"
+  integrity sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -3080,6 +3169,18 @@ next@12.3.1:
     "@next/swc-win32-arm64-msvc" "12.3.1"
     "@next/swc-win32-ia32-msvc" "12.3.1"
     "@next/swc-win32-x64-msvc" "12.3.1"
+
+node-abi@^3.3.0:
+  version "3.30.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.30.0.tgz#d84687ad5d24ca81cdfa912a36f2c5c19b137359"
+  integrity sha512-qWO5l3SCqbwQavymOmtTVuCWZE23++S+rxyoHjXqUmPyzRcaoI4lA2gO55/drddGnedAyjA7sk76SfQ5lfUMnw==
+  dependencies:
+    semver "^7.3.5"
+
+node-addon-api@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.0.0.tgz#7d7e6f9ef89043befdb20c1989c905ebde18c501"
+  integrity sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==
 
 node-domexception@1.0.0:
   version "1.0.0"
@@ -3176,7 +3277,7 @@ omggif@^1.0.10, omggif@^1.0.9:
   resolved "https://registry.yarnpkg.com/omggif/-/omggif-1.0.10.tgz#ddaaf90d4a42f532e9e7cb3a95ecdd47f17c7b19"
   integrity sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -3335,6 +3436,24 @@ postcss@8.4.14:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+prebuild-install@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
+  integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^3.3.0"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -3386,6 +3505,14 @@ property-information@^6.0.0:
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.1.1.tgz#5ca85510a3019726cb9afed4197b7b8ac5926a22"
   integrity sha512-hrzC564QIl0r0vy4l6MvRLhafmUowhO/O3KgVSoXIbbA2Sz4j8HGpJc6T2cubRVwMwpdiG/vKGfhT4IixmKN9w==
 
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
@@ -3432,6 +3559,16 @@ randombytes@^2.1.0:
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
+
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
 
 react-copy-to-clipboard@5.1.0:
   version "5.1.0"
@@ -3615,6 +3752,15 @@ react@=17.0.2, react@^17.0.2:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+readable-stream@^3.1.1, readable-stream@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 rebass@^4.0.7:
   version "4.0.7"
@@ -3812,7 +3958,7 @@ sade@^1.7.3:
   dependencies:
     mri "^1.1.0"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -3844,7 +3990,7 @@ semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.7:
+semver@^7.2.1, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
@@ -3871,6 +4017,20 @@ shallowequal@^1.1.0:
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
+sharp@^0.31.2:
+  version "0.31.2"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.31.2.tgz#a8411c80512027f5a452b76d599268760c4e5dfa"
+  integrity sha512-DUdNVEXgS5A97cTagSLIIp8dUZ/lZtk78iNVZgHdHbx1qnQR7JAHY0BnXnwwH39Iw+VKhO08CTYhIg0p98vQ5Q==
+  dependencies:
+    color "^4.2.3"
+    detect-libc "^2.0.1"
+    node-addon-api "^5.0.0"
+    prebuild-install "^7.1.1"
+    semver "^7.3.8"
+    simple-get "^4.0.1"
+    tar-fs "^2.1.1"
+    tunnel-agent "^0.6.0"
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
@@ -3891,6 +4051,27 @@ side-channel@^1.0.4:
     call-bind "^1.0.0"
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
+
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^4.0.0, simple-get@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sirv@^1.0.7:
   version "1.0.19"
@@ -3963,6 +4144,13 @@ string.prototype.trimstart@^1.0.5:
     define-properties "^1.1.4"
     es-abstract "^1.19.5"
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -3979,6 +4167,11 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
 style-to-object@^0.3.0:
   version "0.3.0"
@@ -4116,6 +4309,27 @@ swr@^1.3.0:
   resolved "https://registry.yarnpkg.com/swr/-/swr-1.3.0.tgz#c6531866a35b4db37b38b72c45a63171faf9f4e8"
   integrity sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==
 
+tar-fs@^2.0.0, tar-fs@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -4209,6 +4423,13 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -4337,6 +4558,11 @@ utif@^2.0.1:
   integrity sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==
   dependencies:
     pako "^1.0.5"
+
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
Switching to standard HTTP Cache-Control headers from Vercel ISR.

This PR does the following:
- [x] add a helper to insert (CDN) Cache-Control headers with dynamic TTL
- [x] switch from SSG/ISR to SSR

The helper `addMaxAgeHeaderForNext()` in `src/api/index.ts` replaces `revalidate()` and `next22Minutedate()`.