### PR TITLE
refactor: Disable scroll to the top when clicking on tabs

### DIFF
--- a/src/components/Filters/common/RowLinksWithDropdown/LinksWithDropdown.tsx
+++ b/src/components/Filters/common/RowLinksWithDropdown/LinksWithDropdown.tsx
@@ -140,7 +140,7 @@ export const LinksWithDropdown = ({ links = [], activeLink, alternativeOthersTex
 const LinkItem = ({ option, activeLink, ...props }) => {
 	return (
 		<li {...props}>
-			<Link href={option.to} prefetch={false} passHref>
+			<Link scroll={false} href={option.to} prefetch={false} passHref>
 				{option.label === activeLink ? (
 					<ButtonDark as="a">{option.label}</ButtonDark>
 				) : (


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Disables scrolling for the `LinksWithDropdown` by using the `scroll` prop of [next/link](https://nextjs.org/docs/api-reference/next/link)

## Related Issue

<!--- Please link to the issue here -->

Resolves https://github.com/DefiLlama/defillama-app/issues/1190

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Feels more intuitive to keep the scrolling position rather than scrolling to the top of the page after a navigation.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, refer to screen recording below

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/78794805/211589250-64ba50c2-f582-428f-9e14-f561552778b0.mov
