### PR TITLE
Fix typo in column header

### DIFF
--- a/src/components/Table/Adaptors/columns/common.tsx
+++ b/src/components/Table/Adaptors/columns/common.tsx
@@ -135,7 +135,7 @@ export const TotalAllTimeColumn = (
 ): ColumnDef<IDexsRow> => {
 	const accessor = alternativeAccessor ?? 'totalAllTime'
 	return {
-		header: `Commulative ${type}`,
+		header: `Cumulative ${type}`,
 		accessorKey: accessor,
 		enableSorting: true,
 		cell: (info) => {


### PR DESCRIPTION
Fixed a minor typo in the header of the last column on https://defillama.com/fees: Commulative -> Cumulative