### PR TITLE
Fix long portfolio folder name (#1340)

### DIFF
--- a/src/containers/Watchlist/Defi.tsx
+++ b/src/containers/Watchlist/Defi.tsx
@@ -47,7 +47,13 @@ export function DefiWatchlistContainer({ protocolsDict }) {
 
 			<Row sx={{ gap: '1rem', margin: '12px 0 -20px' }}>
 				<TYPE.main>Current portfolio:</TYPE.main>
-				<Menu name={selectedPortfolio} options={portfolios} onItemClick={(value) => setSelectedPortfolio(value)} />
+				<Menu
+					name={selectedPortfolio.length > 100 ? selectedPortfolio.substring(0, 100) + '...' : selectedPortfolio}
+					options={portfolios.map(function (portfolio) {
+						return portfolio.length > 100 ? portfolio.substring(0, 100) + '...' : portfolio
+					})}
+					onItemClick={(value) => setSelectedPortfolio(value)}
+				/>
 				<Action onClick={addPortfolio}>
 					<FolderPlus />
 				</Action>

--- a/src/contexts/LocalStorage.tsx
+++ b/src/contexts/LocalStorage.tsx
@@ -330,7 +330,7 @@ export function useWatchlist() {
 
 		if (newPortfolio) {
 			const newList = state?.[WATCHLIST]
-			newList[newPortfolio] = {}
+			newList[newPortfolio.substring(0, 100)] = {}
 			updateKey(WATCHLIST, newList)
 		}
 	}


### PR DESCRIPTION
# Solution

This limits the name of portfolio folders to 100 characters and displays a truncated name if needed.

## Potential improvements

- Modify the "New Portfolio name" prompt to something like "New Portfolio name (max 100)"
- Wrap the logic into a function