### PR TITLE
Fix labels for dropdowns

### DIFF
--- a/src/components/ChainPage/index.js
+++ b/src/components/ChainPage/index.js
@@ -311,7 +311,7 @@ function GlobalPage({ selectedChain = 'All', chainsSet, protocolsList, chart, ex
 
 			<ListOptions>
 				<ListHeader>TVL Rankings</ListHeader>
-				<RowLinksWithDropdown links={chainOptions} activeLink={selectedChain} />
+				<RowLinksWithDropdown links={chainOptions} activeLink={selectedChain} alternativeOthersText="Chains" />
 				<TVLRange />
 			</ListOptions>
 

--- a/src/components/Filters/protocols/TVLRange.tsx
+++ b/src/components/Filters/protocols/TVLRange.tsx
@@ -47,7 +47,7 @@ export function TVLRange({ variant = 'primary', subMenu }: { variant?: 'primary'
 	return (
 		<FilterBetweenRange
 			name="TVL Range"
-			header={variant === 'secondary' ? <Header /> : 'Filter by min/max TVL'}
+			header={variant === 'secondary' ? <Header /> : 'TVL Range'}
 			onSubmit={handleSubmit}
 			variant={variant}
 			subMenu={subMenu}


### PR DESCRIPTION
Before
<img width="600" alt="image" src="https://user-images.githubusercontent.com/6696080/223030438-1fb9089c-bed7-4310-ae49-630b19bc89eb.png">
After
<img width="600" alt="image" src="https://user-images.githubusercontent.com/6696080/223030459-cdbbfa75-7ddd-424d-a124-def94c0eb623.png">

"Others" wasn't descriptive since it's detached from chain list. Filter for TVL can be shortened 