### PR TITLE
Fix Show MCap Chart button on protocol

### DIFF
--- a/src/components/ECharts/ProtocolChart/ProtocolChart.tsx
+++ b/src/components/ECharts/ProtocolChart/ProtocolChart.tsx
@@ -119,7 +119,7 @@ export default function ProtocolChart({
 		let chartData = []
 		let tokensUnique = ['TVL']
 
-		if (geckoId && showMcap) {
+		if (!loading && geckoId && showMcap) {
 			tokensUnique = ['TVL', 'Mcap']
 
 			tvlData.forEach(([date, tvl]) => {


### PR DESCRIPTION
Now if you press the button everything explodes because data is not loaded