### PR TITLE
Make protocol charts zoomable

### DIFF
--- a/src/components/ECharts/useDefaults.tsx
+++ b/src/components/ECharts/useDefaults.tsx
@@ -270,12 +270,10 @@ export function useDefaults({
 				type: 'inside',
 				start: 0,
 				end: 100,
-				filterMode: 'none'
 			},
 			{
 				start: 0,
 				end: 100,
-				filterMode: 'none',
 				right: 6,
 				textStyle: {
 					color: isDark ? 'rgba(255, 255, 255, 1)' : 'rgba(0, 0, 0, 1)'


### PR DESCRIPTION
In the protocol charts, if you zoom in, the line actually doesn't adapt to the new zoomed view

New version:

![new](https://user-images.githubusercontent.com/22419450/230742374-7958ac5b-07b5-4249-86f2-1c3ff602f350.gif)

Old version:

![old](https://user-images.githubusercontent.com/22419450/230742378-842b84bb-6a85-4ca4-a3ed-c77afd19bceb.gif)
