### PR TITLE
fix Cex sorting

### DIFF
--- a/src/components/Table/Defi/columns.tsx
+++ b/src/components/Table/Defi/columns.tsx
@@ -1,4 +1,4 @@
-import { ColumnDef } from '@tanstack/react-table'
+import { ColumnDef, sortingFns } from '@tanstack/react-table'
 import styled from 'styled-components'
 import { ArrowUpRight, ChevronDown, ChevronRight, Tool } from 'react-feather'
 import IconsRow from '~/components/IconsRow'
@@ -694,6 +694,7 @@ export const cexColumn: ColumnDef<any>[] = [
 				</AutoRow>
 			)
 		},
+		sortingFn: sortingFns.datetime,
 		size: 120,
 		meta: {
 			align: 'end',
@@ -725,6 +726,7 @@ export const cexColumn: ColumnDef<any>[] = [
 				</AutoRow>
 			)
 		},
+		sortingFn: sortingFns.datetime,
 		size: 145,
 		meta: {
 			align: 'end',
@@ -740,6 +742,7 @@ export const cexColumn: ColumnDef<any>[] = [
 				{info.getValue() ? formatCexInflows(info.getValue()) : ''}
 			</InflowOutflow>
 		),
+		sortingFn: sortingFns.datetime,
 		meta: {
 			align: 'end'
 		}
@@ -753,6 +756,7 @@ export const cexColumn: ColumnDef<any>[] = [
 				{info.getValue() ? formatCexInflows(info.getValue()) : ''}
 			</InflowOutflow>
 		),
+		sortingFn: sortingFns.datetime,
 		meta: {
 			align: 'end'
 		}
@@ -766,6 +770,7 @@ export const cexColumn: ColumnDef<any>[] = [
 				{info.getValue() ? formatCexInflows(info.getValue()) : ''}
 			</InflowOutflow>
 		),
+		sortingFn: sortingFns.datetime,
 		meta: {
 			align: 'end'
 		}
@@ -800,6 +805,7 @@ export const cexColumn: ColumnDef<any>[] = [
 		header: 'Spot Volume',
 		accessorKey: 'spotVolume',
 		cell: (info) => (info.getValue() ? '$' + formattedNum(info.getValue()) : null),
+		sortingFn: sortingFns.datetime,
 		size: 120,
 		meta: {
 			align: 'end'
@@ -809,6 +815,7 @@ export const cexColumn: ColumnDef<any>[] = [
 		header: '24h Open Interest',
 		accessorKey: 'oi',
 		cell: (info) => (info.getValue() ? '$' + formattedNum(info.getValue()) : null),
+		sortingFn: sortingFns.datetime,
 		size: 160,
 		meta: {
 			align: 'end'
@@ -818,6 +825,7 @@ export const cexColumn: ColumnDef<any>[] = [
 		header: 'Avg Leverage',
 		accessorKey: 'leverage',
 		cell: (info) => (info.getValue() ? Number(Number(info.getValue()).toFixed(2)) + 'x' : null),
+		sortingFn: sortingFns.datetime,
 		size: 120,
 		meta: {
 			align: 'end'


### PR DESCRIPTION
Hi

The sorting was broken on the Cexs transparency page as some data are undefined (see: https://github.com/TanStack/table/issues/4289)

so I'm set the `datetime` sorting function on those column as it handles undefined correctly. Now undefined values will always be at the bottom

Before:
![before](https://user-images.githubusercontent.com/84812080/233792649-1c3cc6cc-3474-49ae-9125-29cf9485e3da.png)

After:
![after](https://user-images.githubusercontent.com/84812080/233792653-7e124941-7338-48b5-b1c3-1b06f33d841b.png)


If current behavior is expected, feel free to close the PR