### PR TITLE
Add FDV/TVL and Mcap/TVL ratios to protocol page

### DIFF
--- a/src/containers/Defi/Protocol/index.tsx
+++ b/src/containers/Defi/Protocol/index.tsx
@@ -591,9 +591,22 @@ function ProtocolContainer({
 								) : null}
 
 								{tokenSupply && priceOfToken ? (
+									<>
+										<tr>
+											<th>Fully Diluted Valuation</th>
+											<td>{formattedNum(priceOfToken * tokenSupply, true)}</td>
+										</tr>
+										<tr>
+											<th>FDV / TVL ratio</th>
+											<td>{formattedNum((priceOfToken * tokenSupply) / totalVolume, false)}</td>
+										</tr>
+									</>
+								) : null}
+
+								{tokenMcap ? (
 									<tr>
-										<th>Fully Diluted Valuation</th>
-										<td>{formattedNum(priceOfToken * tokenSupply, true)}</td>
+										<th>Mcap / TVL ratio</th>
+										<td>{formattedNum(tokenMcap / totalVolume, false)}</td>
 									</tr>
 								) : null}
 


### PR DESCRIPTION
Maybe check if the positions / labels are ok :)

<img width="368" alt="Screenshot 2023-04-24 at 14 30 42" src="https://user-images.githubusercontent.com/22419450/233996664-0e64b004-cf28-479a-a486-5ea9fc37dbe5.png">