### PR TITLE
fix undefined link

### DIFF
--- a/src/containers/Defi/Protocol/Yields.tsx
+++ b/src/containers/Defi/Protocol/Yields.tsx
@@ -17,7 +17,8 @@ export function ProtocolPools({ protocol, data }) {
 						pool: i.symbol,
 						configID: i.pool,
 						chains: [i.chain],
-						project: i.projectName
+						project: i.projectName,
+						projectslug: i.project
 					})) ?? null
 		)
 	)


### PR DESCRIPTION
A bug reported here https://github.com/DefiLlama/yield-server/pull/934#issuecomment-1674941508

![](https://user-images.githubusercontent.com/126733611/260044175-3639c376-0e9a-4628-a504-cb041ea7fc2f.png)

It can be reproduced in all projects under yields.