### PR TITLE
Change /summary/dexs/{protocol} example

### DIFF
--- a/src/docs/resolvedSpec.json
+++ b/src/docs/resolvedSpec.json
@@ -1445,7 +1445,7 @@
 						"description": "protocol slug",
 						"schema": {
 							"type": "string",
-							"example": "aave"
+							"example": "uniswap"
 						}
 					},
 					{

--- a/src/docs/spec.yaml
+++ b/src/docs/spec.yaml
@@ -951,7 +951,7 @@ paths:
           description: protocol slug
           schema:
             type: string
-            example: aave
+            example: uniswap
         - name: excludeTotalDataChart
           in: query
           required: false


### PR DESCRIPTION
Aave is an invalid protocol for the /summary/dexs/{protocol} endpoint. Change to Uniswap.