### PR TITLE
fix: accessorKey

### DIFF
--- a/src/components/Table/Bridges/Bridges/columns.tsx
+++ b/src/components/Table/Bridges/Bridges/columns.tsx
@@ -343,7 +343,7 @@ export const bridgeTokensColumn: ColumnDef<IBridge>[] = [
 	},
 	{
 		header: 'Deposited',
-		accessorKey: 'withdrawn',
+		accessorKey: 'deposited',
 		cell: (info) => <>${formattedNum(info.getValue() ?? 0)}</>,
 		size: 120,
 		meta: {
@@ -352,7 +352,7 @@ export const bridgeTokensColumn: ColumnDef<IBridge>[] = [
 	},
 	{
 		header: 'Withdrawn',
-		accessorKey: 'deposited',
+		accessorKey: 'withdrawn',
 		cell: (info) => <>${formattedNum(info.getValue() ?? 0)}</>,
 		size: 120,
 		meta: {
@@ -404,7 +404,7 @@ export const bridgeAddressesColumn: ColumnDef<IBridge>[] = [
 	},
 	{
 		header: 'Deposited',
-		accessorKey: 'withdrawn',
+		accessorKey: 'deposited',
 		cell: (info) => <>${formattedNum(info.getValue() ?? 0)}</>,
 		size: 120,
 		meta: {
@@ -413,7 +413,7 @@ export const bridgeAddressesColumn: ColumnDef<IBridge>[] = [
 	},
 	{
 		header: 'Withdrawn',
-		accessorKey: 'deposited',
+		accessorKey: 'withdrawn',
 		cell: (info) => <>${formattedNum(info.getValue() ?? 0)}</>,
 		size: 120,
 		meta: {


### PR DESCRIPTION
Hi team, this is Ryan from XY finance, our XY adapter PR has recently been merged to bridge-server https://github.com/DefiLlama/bridges-server/pull/100, and we are able to see XY finance is shown on bridge overview page and detail page, thanks
- https://defillama.com/bridges
- https://defillama.com/bridge/xy-finance

However, we found that the summary amount does not match the sum of table column
<img width="2255" alt="截圖 2024-01-29 上午11 21 34" src="https://github.com/DefiLlama/defillama-app/assets/9876706/b748fbc2-4294-403b-b41f-17e17eeaea80">
This problem could obviously be seen in other adaptors, e.g,
- https://defillama.com/bridge/pnetwork
- https://defillama.com/bridge/satellite-(powered-by-axelar)

I think there is a PR before, https://github.com/DefiLlama/defillama-app/pull/1004/files#diff-9d6116aff39fdbf238f091ceeddfe4f35523dd3b5c255068980879f01be47848L325-L369 The header text seems to be incorrect?