### PR TITLE
Preserved protocol filters in the Router

### DIFF
--- a/src/components/Filters/protocols/Desktop.tsx
+++ b/src/components/Filters/protocols/Desktop.tsx
@@ -62,7 +62,7 @@ export const DesktopProtocolFilters = ({ options, ...props }) => {
 					<>
 						{tvlOptions.slice(0, 3).map((option) => (
 							<ListItem key={option.key}>
-								<OptionToggle {...option} toggle={updater(option.key)} enabled={extraTvlEnabled[option.key]} />
+								<OptionToggle {...option} toggle={updater(option.key, true)} enabled={extraTvlEnabled[option.key]} />
 							</ListItem>
 						))}
 						<ListItem>
@@ -72,7 +72,7 @@ export const DesktopProtocolFilters = ({ options, ...props }) => {
 				) : (
 					tvlOptions.map((option) => (
 						<ListItem key={option.key}>
-							<OptionToggle {...option} toggle={updater(option.key)} enabled={extraTvlEnabled[option.key]} />
+							<OptionToggle {...option} toggle={updater(option.key, true)} enabled={extraTvlEnabled[option.key]} />
 						</ListItem>
 					))
 				)}

--- a/src/components/Filters/protocols/useProtocolFilterState.tsx
+++ b/src/components/Filters/protocols/useProtocolFilterState.tsx
@@ -13,10 +13,10 @@ export function useProtocolsFilterState(props?: { [key: string]: any }) {
 	const onChange = (values) => {
 		if (values.length < selectedOptions.length) {
 			const off = selectedOptions.find((o) => !values.includes(o))
-			updater(off)()
+			updater(off, true)()
 		} else {
 			const on = values.find((o) => !selectedOptions.includes(o))
-			updater(on)()
+			updater(on, true)()
 		}
 	}
 

--- a/src/contexts/types.ts
+++ b/src/contexts/types.ts
@@ -8,4 +8,4 @@ export interface ISettings {
 	[item: string]: boolean
 }
 
-export type TUpdater = (key: string) => () => void
+export type TUpdater = (key: string, shouldUpdateRouter?: boolean) => () => void


### PR DESCRIPTION
## Problem
Changing any of protocol filters in UI made changes only in the local storage.
It wasn't possible to copy and paste link, and preserve filtered state.
![image](https://github.com/DefiLlama/defillama-app/assets/125874670/4d218a99-ce18-43bc-9329-6c4225f48047)

## Solution
This update preserves state in the URL (Router) parameters also:
![image](https://github.com/DefiLlama/defillama-app/assets/125874670/5633fc13-5a5f-4838-aea3-9ca6070966b6)

## Integration with Local Storage - How it works?
It works with existing Local Storage system.
If user changes any of the parameters, they will be populated in the URL, but also in the local storage.
If user opens another tab, state will be preserved as it is right now:
![image](https://github.com/DefiLlama/defillama-app/assets/125874670/d3b9154e-2b5b-4d52-8ed6-3a70f934f4d5)
![image](https://github.com/DefiLlama/defillama-app/assets/125874670/8549952d-0a44-404c-88d5-54b46a6319b6)