### PR TITLE
fix: blockExplorers.ts bug with double address added

### DIFF
--- a/src/utils/blockExplorers.ts
+++ b/src/utils/blockExplorers.ts
@@ -126,7 +126,7 @@ export const getBlockExplorer = (address: string = '') => {
 			blockExplorerLink: e[0] + chainAddress,
 			blockExplorerName: e[1]
 		}))
-		blockExplorerLink = explorers[0].blockExplorerLink + chainAddress
+		blockExplorerLink = explorers[0].blockExplorerLink
 		blockExplorerName = explorers[0].blockExplorerName
 	}
 	chainName = chain


### PR DESCRIPTION
https://github.com/DefiLlama/defillama-app/issues/1652

should fix issue linked by removing repeated address added, but confused about why the same function used results in stablecoins & bridges being bugged but protocol shown correctly.