### PR TITLE
Switch pf and ps key to fix column selection

### DIFF
--- a/src/components/Table/Defi/Protocols/index.tsx
+++ b/src/components/Table/Defi/Protocols/index.tsx
@@ -153,8 +153,8 @@ const protocolsByChainTableColumns = [
 		category: TABLE_CATEGORIES.REVENUE,
 		period: TABLE_PERIODS.ONE_DAY
 	},
-	{ name: 'P/S', key: 'pf', category: TABLE_CATEGORIES.FEES },
-	{ name: 'P/F', key: 'ps', category: TABLE_CATEGORIES.FEES },
+	{ name: 'P/S', key: 'ps', category: TABLE_CATEGORIES.FEES },
+	{ name: 'P/F', key: 'pf', category: TABLE_CATEGORIES.FEES },
 	{ name: 'Volume 24h', key: 'volume_24h', category: TABLE_CATEGORIES.VOLUME, period: TABLE_PERIODS.ONE_DAY },
 	{ name: 'Volume 7d', key: 'volume_7d', category: TABLE_CATEGORIES.VOLUME, period: TABLE_PERIODS.SEVEN_DAYS },
 	{


### PR DESCRIPTION
Hi!

A simple PR to fix P/F and P/S columns selection in the protocols list (toggling P/S shows P/F columns and the opposite).
I don't think I need to explain more :)