### PR TITLE
fix duplicate minus sign on price change value

### DIFF
--- a/src/containers/Defi/Protocol/Emissions/index.tsx
+++ b/src/containers/Defi/Protocol/Emissions/index.tsx
@@ -236,7 +236,7 @@ const ChartContainer = ({ data, isEmissionsPage }: { data: IEmission; isEmission
 									fontSize: '14px'
 								}}
 							>
-								{percentChange > 0 ? '+' : '-'}
+								{percentChange > 0 && '+'}
 								{percentChange}%
 							</Value>
 						</div>


### PR DESCRIPTION
This PR will resolve the issue by correcting the duplicate minus sign on the price change.

https://defillama.com/unlocks/liquity
<img width="1512" alt="image" src="https://github.com/DefiLlama/defillama-app/assets/48804700/6cf2a4a5-9a0c-4e99-b36b-54152d54a8e2">