### PR TITLE
fix a crash happening when chain assets chart returns array containing null value

### DIFF
--- a/src/containers/ChainContainer/useFetchChainChartData.tsx
+++ b/src/containers/ChainContainer/useFetchChainChartData.tsx
@@ -183,8 +183,7 @@ export const useFetchChainChartData = ({
 			Math.floor(nearestUtc(dayjs(k).toDate().getTime()) / 1000),
 			cc
 		])
-
-		const finalChainAssetsChart = chainAssetsChart?.map(({ data, timestamp }) => {
+		const finalChainAssetsChart = chainAssetsChart?.filter(Boolean).map(({ data, timestamp }) => {
 			const ts = Math.floor(
 				dayjs(timestamp * 1000)
 					.utc()


### PR DESCRIPTION
The Bitcoin chain page currently crashes because of a chain assets chart data table containing `[null]`. This fixes it on the frontend. A similar PR has been made on the backend to fix the source of the issue (array containing null value) -> https://github.com/DefiLlama/defillama-server/pull/6524