### PR TITLE
remove dominance display

### DIFF
--- a/src/containers/ChainContainer/index.tsx
+++ b/src/containers/ChainContainer/index.tsx
@@ -327,11 +327,6 @@ export function ChainContainer({
 									<span>Change (24h)</span>
 									<span>{percentChange || 0}%</span>
 								</StatInARow>
-
-								<StatInARow>
-									<span>{topToken.name} Dominance</span>
-									<span>{dominance}%</span>
-								</StatInARow>
 							</span>
 						</AccordionStat>
 


### PR DESCRIPTION
double counting etc are erroneously calculated in protocol tvl dominance even wen toggles were off. decided to remove afta discusshun

exampo: lido being shown as dominant protocol while liquid staking toggle is off

![image](https://github.com/DefiLlama/defillama-app/assets/107649472/fd288fff-f6e5-47f8-98a9-357a3da4192d)
