### PR TITLE
Add Only Option to Combobox

### DIFF
--- a/src/components/Filters/common/Base.tsx
+++ b/src/components/Filters/common/Base.tsx
@@ -132,6 +132,12 @@ export const SelectItem = styled(AriaSelectItem)`
 		border-radius: 0;
 	}
 
+	:hover {
+		button {
+			opacity: 1;
+		}
+	}
+
 	opacity: ${({ disabled }) => (disabled ? 0.6 : 1)};
 
 	@media screen and (min-width: 640px) {

--- a/src/components/Filters/common/BasicDropdown.tsx
+++ b/src/components/Filters/common/BasicDropdown.tsx
@@ -102,6 +102,20 @@ export function BasicDropdown({
 		)
 	}
 
+	const selectOnlyOne = (option: string) => {
+		router.push(
+			{
+				pathname,
+				query: {
+					...queries,
+					[urlKey]: option
+				}
+			},
+			undefined,
+			{ shallow: true }
+		)
+	}
+
 	// Resets combobox value when popover is collapsed
 	if (!selectState.mounted && combobox.value) {
 		combobox.setValue('')
@@ -122,6 +136,7 @@ export function BasicDropdown({
 					selectedOptions={selectedOptions}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}
@@ -172,6 +187,7 @@ export function BasicDropdown({
 					selectedOptions={selectedOptions}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}

--- a/src/components/Filters/common/ComboboxSelectContent.tsx
+++ b/src/components/Filters/common/ComboboxSelectContent.tsx
@@ -1,8 +1,26 @@
 import { MutableRefObject, useMemo, useState } from 'react'
+import styled from 'styled-components'
 import { useDebounce } from '~/hooks'
 import { FilterFnsGroup, SelectItem } from './Base'
 import { Checkbox } from '~/components'
 import { slug } from '~/utils'
+
+const LeftContainer = styled.div`
+	display: flex;
+	align-items: center;
+`
+
+const OnlyButton = styled.button`
+	margin-left: 0.4rem;
+	padding: 0;
+	font-weight: 500;
+	opacity: 0;
+	transition: opacity 0.3s;
+
+	:hover {
+		text-decoration: underline;
+	}
+`
 
 interface ISelectContent {
 	options: Array<string>
@@ -13,6 +31,7 @@ interface ISelectContent {
 	isOptionToggled: (option: any) => boolean
 	clearAllOptions: () => void
 	toggleAllOptions: () => void
+	selectOnlyOne: (options: string) => void
 	isSlugValue?: boolean
 }
 
@@ -29,6 +48,7 @@ const SelectContent = ({
 	clearAllOptions,
 	toggleAllOptions,
 	isOptionToggled,
+	selectOnlyOne,
 	isSlugValue
 }: ISelectContent) => {
 	return (
@@ -50,7 +70,17 @@ const SelectContent = ({
 							ref={i === 0 && selectedOptions.length === options.length ? focusItemRef : null}
 							focusOnHover
 						>
-							<span data-name>{value}</span>
+							<LeftContainer>
+								<span data-name>{value}</span>
+								<OnlyButton
+									onClick={(e) => {
+										e.stopPropagation()
+										selectOnlyOne(formattedValue)
+									}}
+								>
+									Only
+								</OnlyButton>
+							</LeftContainer>
 							<Checkbox checked={isOptionToggled(formattedValue)} />
 						</SelectItem>
 					)

--- a/src/components/Filters/common/FilterByToken.tsx
+++ b/src/components/Filters/common/FilterByToken.tsx
@@ -84,6 +84,20 @@ export function FiltersByToken({
 		)
 	}
 
+	const selectOnlyOne = (option: string) => {
+		router.push(
+			{
+				pathname,
+				query: {
+					...queries,
+					token: option
+				}
+			},
+			undefined,
+			{ shallow: true }
+		)
+	}
+
 	const focusItemRef = useRef(null)
 
 	const isSelected = selectedTokens.length > 0 && selectedTokens.length !== tokensList.length
@@ -98,6 +112,7 @@ export function FiltersByToken({
 					selectedOptions={selectedTokens}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}
@@ -147,6 +162,7 @@ export function FiltersByToken({
 					selectedOptions={selectedTokens}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}

--- a/src/components/Filters/common/FiltersByChain.tsx
+++ b/src/components/Filters/common/FiltersByChain.tsx
@@ -84,6 +84,20 @@ export function FiltersByChain({
 		)
 	}
 
+	const selectOnlyOne = (option: string) => {
+		router.push(
+			{
+				pathname,
+				query: {
+					...queries,
+					chain: option
+				}
+			},
+			undefined,
+			{ shallow: true }
+		)
+	}
+
 	// Resets combobox value when popover is collapsed
 	if (!selectState.mounted && combobox.value) {
 		combobox.setValue('')
@@ -104,6 +118,7 @@ export function FiltersByChain({
 					selectedOptions={selectedChains}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}
@@ -154,6 +169,7 @@ export function FiltersByChain({
 					selectedOptions={selectedChains}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}

--- a/src/components/Filters/raises/Investors.tsx
+++ b/src/components/Filters/raises/Investors.tsx
@@ -98,6 +98,20 @@ export function Investors({
 		)
 	}
 
+	const selectOnlyOne = (option: string) => {
+		router.push(
+			{
+				pathname,
+				query: {
+					...queries,
+					investor: option
+				}
+			},
+			undefined,
+			{ shallow: true }
+		)
+	}
+
 	// Resets combobox value when popover is collapsed
 	if (!selectState.mounted && combobox.value) {
 		combobox.setValue('')
@@ -118,6 +132,7 @@ export function Investors({
 					selectedOptions={selectedInvestors}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}
@@ -168,6 +183,7 @@ export function Investors({
 					selectedOptions={selectedInvestors}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}

--- a/src/components/Filters/raises/chains.tsx
+++ b/src/components/Filters/raises/chains.tsx
@@ -92,6 +92,20 @@ export function Chains({ chains = [], selectedChains, pathname, variant = 'prima
 		)
 	}
 
+	const selectOnlyOne = (option: string) => {
+		router.push(
+			{
+				pathname,
+				query: {
+					...queries,
+					chain: option
+				}
+			},
+			undefined,
+			{ shallow: true }
+		)
+	}
+
 	// Resets combobox value when popover is collapsed
 	if (!selectState.mounted && combobox.value) {
 		combobox.setValue('')
@@ -112,6 +126,7 @@ export function Chains({ chains = [], selectedChains, pathname, variant = 'prima
 					selectedOptions={selectedChains}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}
@@ -162,6 +177,7 @@ export function Chains({ chains = [], selectedChains, pathname, variant = 'prima
 					selectedOptions={selectedChains}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}

--- a/src/components/Filters/raises/rounds.tsx
+++ b/src/components/Filters/raises/rounds.tsx
@@ -92,6 +92,20 @@ export function Rounds({ rounds = [], selectedRounds, pathname, variant = 'prima
 		)
 	}
 
+	const selectOnlyOne = (option: string) => {
+		router.push(
+			{
+				pathname,
+				query: {
+					...queries,
+					round: option
+				}
+			},
+			undefined,
+			{ shallow: true }
+		)
+	}
+
 	// Resets combobox value when popover is collapsed
 	if (!selectState.mounted && combobox.value) {
 		combobox.setValue('')
@@ -112,6 +126,7 @@ export function Rounds({ rounds = [], selectedRounds, pathname, variant = 'prima
 					selectedOptions={selectedRounds}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}
@@ -162,6 +177,7 @@ export function Rounds({ rounds = [], selectedRounds, pathname, variant = 'prima
 					selectedOptions={selectedRounds}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}

--- a/src/components/Filters/raises/sectors.tsx
+++ b/src/components/Filters/raises/sectors.tsx
@@ -98,6 +98,20 @@ export function Sectors({
 		)
 	}
 
+	const selectOnlyOne = (option: string) => {
+		router.push(
+			{
+				pathname,
+				query: {
+					...queries,
+					sector: option
+				}
+			},
+			undefined,
+			{ shallow: true }
+		)
+	}
+
 	// Resets combobox value when popover is collapsed
 	if (!selectState.mounted && combobox.value) {
 		combobox.setValue('')
@@ -118,6 +132,7 @@ export function Sectors({
 					selectedOptions={selectedSectors}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}
@@ -168,6 +183,7 @@ export function Sectors({
 					selectedOptions={selectedSectors}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}

--- a/src/components/Filters/yields/Categories.tsx
+++ b/src/components/Filters/yields/Categories.tsx
@@ -90,6 +90,20 @@ export function FiltersByCategory({
 		)
 	}
 
+	const selectOnlyOne = (option: string) => {
+		router.push(
+			{
+				pathname,
+				query: {
+					...queries,
+					category: option
+				}
+			},
+			undefined,
+			{ shallow: true }
+		)
+	}
+
 	const focusItemRef = useRef(null)
 
 	const isSelected = selectedCategories.length > 0 && selectedCategories.length !== categoryList.length
@@ -105,6 +119,7 @@ export function FiltersByCategory({
 					selectedOptions={selectedCategories}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}
@@ -155,6 +170,7 @@ export function FiltersByCategory({
 					selectedOptions={selectedCategories}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}

--- a/src/components/Filters/yields/Projects.tsx
+++ b/src/components/Filters/yields/Projects.tsx
@@ -100,6 +100,21 @@ export function YieldProjects({
 		)
 	}
 
+	const selectOnlyOne = (option: string) => {
+		router.push(
+			{
+				pathname,
+				query: {
+					...queries,
+					...(query && (isFarmingProtocolFilter ? { lendingProtocol } : { farmProtocol })),
+					[query || 'project']: option
+				}
+			},
+			undefined,
+			{ shallow: true }
+		)
+	}
+
 	const focusItemRef = useRef(null)
 
 	const isSelected = selectedProjects.length > 0 && selectedProjects.length !== projectList.length
@@ -119,6 +134,7 @@ export function YieldProjects({
 					selectedOptions={selectedProjects}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}
@@ -169,6 +185,7 @@ export function YieldProjects({
 					selectedOptions={selectedProjects}
 					clearAllOptions={clearAllOptions}
 					toggleAllOptions={toggleAllOptions}
+					selectOnlyOne={selectOnlyOne}
 					focusItemRef={focusItemRef}
 					variant={variant}
 					pathname={pathname}


### PR DESCRIPTION
Inspired by [this post](https://twitter.com/0xngmi/status/1789607412967575798) this PR introduces an Only option to the Combobox component.

The Only button only shows when hovering over an option:
<img width="325" alt="image" src="https://github.com/DefiLlama/defillama-app/assets/53957795/56d0d6dc-e4f8-4025-beb2-2dd5e4cdee65">

Hovering over the Only button underlines it to indicate it can be interacted with:
<img width="296" alt="image" src="https://github.com/DefiLlama/defillama-app/assets/53957795/eaafd009-0b62-4b4e-849c-8be87779e590">

Clicking the Only button changes the selected state so that only that button is selected.

This should improve UX as it is now just one click instead of two to select a single option. And selecting a single option is a common action for users.

The following comboboxes have been tested and are working as expected:
- Raises > Chains
- Raises > Investors
- Raises > Rounds
- Raises > Sectors
- Yields > Categories
- Yields > Projects