### PR TITLE
fix(bake): update url slug and wallets link

### DIFF
--- a/src/pages/cexs/index.tsx
+++ b/src/pages/cexs/index.tsx
@@ -313,9 +313,9 @@ export const cexData: Array<ICex> = [
 	},
 	{
 		name: 'Bake.io',
-		slug: 'cake-defi',
+		slug: 'bake.io',
 		coin: null,
-		walletsLink: 'https://blog.cakedefi.com/proof-of-reserves'
+		walletsLink: 'https://blog.bake.io/proof-of-reserves/'
 	},
 	{
 		name: 'BingX',


### PR DESCRIPTION
Updating our URL slug from https://defillama.com/cex/cake-defi to https://defillama.com/cex/bake.io due to our recent name change (in other PRs)