### PR TITLE
add column to oracles table denoting total volume secured

### DIFF
--- a/src/components/Oracles/index.tsx
+++ b/src/components/Oracles/index.tsx
@@ -34,7 +34,16 @@ const ChartsWrapper = styled(Panel)`
 		grid-template-columns: 1fr 1fr;
 	}
 `
-const Oracles = ({ chartData, tokensProtocols, tokens, tokenLinks, oraclesColors, chainsByOracle, chain }) => {
+const Oracles = ({
+	chartData,
+	tokensProtocols,
+	tokens,
+	tokenLinks,
+	oraclesColors,
+	chainsByOracle,
+	chain,
+	oracleSevenDayVolumes
+}) => {
 	const { chainsWithExtraTvlsByDay, chainsWithExtraTvlsAndDominanceByDay } = useCalcGroupExtraTvlsByDay(chartData)
 	const { tokenTvls, tokensList } = React.useMemo(() => {
 		const tvls = Object.entries(chainsWithExtraTvlsByDay[chainsWithExtraTvlsByDay.length - 1])
@@ -49,11 +58,17 @@ const Oracles = ({ chartData, tokensProtocols, tokens, tokenLinks, oraclesColors
 		const tokenTvls = tvls.slice(0, 5).concat({ name: 'Others', value: otherTvl })
 
 		const tokensList = tvls.map(({ name, value }) => {
-			return { name, protocolsSecured: tokensProtocols[name], tvs: value, chains: chainsByOracle[name] }
+			return {
+				name,
+				protocolsSecured: tokensProtocols[name],
+				tvs: value,
+				chains: chainsByOracle[name],
+				sevenDayVolume: oracleSevenDayVolumes[name]
+			}
 		})
 
 		return { tokenTvls, tokensList }
-	}, [chainsWithExtraTvlsByDay, tokensProtocols, chainsByOracle])
+	}, [chainsWithExtraTvlsByDay, tokensProtocols, chainsByOracle, oracleSevenDayVolumes])
 
 	const downloadCsv = () => {
 		const header = Object.keys(tokensList[0]).join(',')

--- a/src/components/Table/Defi/columns.tsx
+++ b/src/components/Table/Defi/columns.tsx
@@ -90,6 +90,15 @@ export const oraclesColumn: ColumnDef<IOraclesRow>[] = [
 			align: 'end',
 			headerHelperText: 'Excludes CeFi'
 		}
+	},
+	{
+		header: 'Volume (7d)',
+		accessorKey: 'sevenDayVolume',
+		cell: ({ getValue }) => <>{'$' + formattedNum(getValue())}</>,
+		meta: {
+			align: 'end',
+			headerHelperText: 'Cumulative last 7d volume secured'
+		}
 	}
 ]
 

--- a/src/components/Table/Defi/columns.tsx
+++ b/src/components/Table/Defi/columns.tsx
@@ -94,7 +94,7 @@ export const oraclesColumn: ColumnDef<IOraclesRow>[] = [
 	{
 		header: 'Volume (7d)',
 		accessorKey: 'sevenDayVolume',
-		cell: ({ getValue }) => <>{'$' + formattedNum(getValue())}</>,
+		cell: ({ getValue }) => <>{getValue() ? '$' + formattedNum(getValue()) : null}</>,
 		meta: {
 			align: 'end',
 			headerHelperText: 'Cumulative last 7d volume secured'


### PR DESCRIPTION
This PR cross-references the protocols associated with all oracles with the total volume secured by those protocols over the last 7 days, and displays the summed volume as a column in the oracles table at the bottom of the **Oracles** page.