### PR TITLE
fix: fix ChainAssets structure because table was crashing on sorting

### DIFF
--- a/src/components/Table/Defi/columns.tsx
+++ b/src/components/Table/Defi/columns.tsx
@@ -887,8 +887,8 @@ export const chainsColumn: ColumnDef<IChainsRow>[] = [
 			)
 		},
 		sortingFn: (rowA, rowB) => {
-			const valueA = rowA.original?.chainAssets?.total.total
-			const valueB = rowB.original?.chainAssets?.total.total
+			const valueA = rowA.original?.chainAssets?.total
+			const valueB = rowB.original?.chainAssets?.total
 
 			if (valueA === undefined || valueA === null) return 1
 			if (valueB === undefined || valueB === null) return -1

--- a/src/hooks/data/defi.tsx
+++ b/src/hooks/data/defi.tsx
@@ -1,9 +1,9 @@
+import { IOverviewProps } from '~/api/categories/adaptors'
 import { IFormattedProtocol, IParentProtocol, TCompressedChain } from '~/api/types'
+import { removedCategories } from '~/constants'
 import { ISettings } from '~/contexts/types'
 import { getDominancePercent, getPercentChange } from '~/utils'
 import { groupProtocols } from './utils'
-import { IOverviewProps, getAnnualizedRatio } from '~/api/categories/adaptors'
-import { removedCategories } from '~/constants'
 
 interface IData {
 	tvl: number
@@ -22,26 +22,11 @@ interface Breakdown {
 }
 
 export interface ChainAssets {
-	canonical: {
-		total: string
-		breakdown: Breakdown
-	}
-	native: {
-		total: string
-		breakdown: Breakdown
-	}
-	thirdParty: {
-		total: string
-		breakdown: Breakdown
-	}
-	total: {
-		breakdown: Breakdown
-		total: string
-	}
-	ownTokens: {
-		breakdown: Breakdown
-		total: string
-	}
+	canonical: string
+	native: string
+	thirdParty: string
+	total: string
+	ownTokens: string
 }
 
 interface IFormattedDataWithExtraTvlProps {


### PR DESCRIPTION
Fix: Prevent crash on /chains page when sorting by bridged TVL

This PR addresses an issue where the /chains page crashes when attempting to sort by bridged TVL. The crash occurs due to an undefined value, resulting from a mismatch between the frontend type definition and the backend response.
