### PR TITLE
fix search articles by slug

### DIFF
--- a/src/api/categories/news/index.ts
+++ b/src/api/categories/news/index.ts
@@ -46,7 +46,7 @@ export const fetchArticles = async ({ tags = '', size = 2 }) => {
 
 	const articles: IArticle[] =
 		articlesRes?.content_elements
-			?.filter((element) => element.taxonomy?.tags?.some((tag) => tag.text.toLowerCase() === target))
+			?.filter((element) => element.taxonomy?.tags?.some((tag) => tag.slug.toLowerCase() === target))
 			.map((element) => ({
 				headline: element.headlines.basic,
 				date: element.display_date,


### PR DESCRIPTION
When you use `tag.text.toLowerCase()`, it doesn't work well for protocols with more than one word (`Tornado Cash` becomes `tornado cash`, but it should be `tornado-cash`. To fix this, use `tag.slug` instead) 

This change will allow protocols like https://defillama.com/protocol/tornado-cash to display news updates.