### PR TITLE
fix fees/category toggle all and clear

### DIFF
--- a/src/components/Filters/yields/Categories.tsx
+++ b/src/components/Filters/yields/Categories.tsx
@@ -69,6 +69,7 @@ export function FiltersByCategory({
 				pathname,
 				query: {
 					...queries,
+					...(!pathname.includes('/chains/') && chain ? { chain } : {}),
 					category: 'All'
 				}
 			},
@@ -83,6 +84,7 @@ export function FiltersByCategory({
 				pathname,
 				query: {
 					...queries,
+					...(!pathname.includes('/chains/') && chain ? { chain } : {}),
 					category: 'None'
 				}
 			},
@@ -97,6 +99,7 @@ export function FiltersByCategory({
 				pathname,
 				query: {
 					...queries,
+					...(!pathname.includes('/chains/') && chain ? { chain } : {}),
 					category: option
 				}
 			},


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/30026e52-1698-42fa-af94-2a0382e99a57)
can't press toggle all or clear for categories on fees/simple, it's working fine on all chain view but doesn't work on single chain view clicking category one by one works though so i just added the ...(!pathname.includes('/chains/') && chain ? { chain } : {}) to toggleAllOptions clearAllOptions and selectOnlyOne