### PR TITLE
fix unlock page sorting and make search to be able to search using token symbol

### DIFF
--- a/src/components/Table/Defi/columns.tsx
+++ b/src/components/Table/Defi/columns.tsx
@@ -435,7 +435,12 @@ export const emissionsColumns: ColumnDef<IEmission>[] = [
 	{
 		header: 'Next Event',
 		id: 'upcomingEvent',
-		accessorFn: (row) => row.upcomingEvent?.[0]?.timestamp,
+		accessorFn: (row) => {
+			let { timestamp } = row.upcomingEvent?.[0] || {}
+			if (!timestamp || timestamp < Date.now() / 1e3) return undefined
+			return timestamp
+		},
+		sortUndefined: 'last',
 		cell: ({ row }) => {
 			let { timestamp } = row.original.upcomingEvent[0]
 

--- a/src/pages/unlocks.tsx
+++ b/src/pages/unlocks.tsx
@@ -30,32 +30,36 @@ export const getStaticProps = withPerformanceLogging('unlocks', async () => {
 })
 
 export default function Protocols({ data }) {
-	const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
 	const [sorting, setSorting] = React.useState<SortingState>([])
 
+	const [projectName, setProjectName] = React.useState('')
+	const [filteredData, setFilteredData] = React.useState(data)
+
+	React.useEffect(() => {
+		const id = setTimeout(() => {
+			const searchTerm = projectName.toLowerCase()
+			const filtered = projectName
+				? data.filter(
+						(protocol) =>
+							protocol.name.toLowerCase().includes(searchTerm) ||
+							(protocol.tSymbol && protocol.tSymbol.toLowerCase().includes(searchTerm))
+				  )
+				: data
+			setFilteredData(filtered)
+		}, 200)
+		return () => clearTimeout(id)
+	}, [projectName, data])
+
 	const instance = useReactTable({
-		data,
+		data: filteredData,
 		columns: emissionsColumns,
 		state: {
-			columnFilters,
 			sorting
 		},
 		onSortingChange: setSorting,
-		onColumnFiltersChange: setColumnFilters,
-		getFilteredRowModel: getFilteredRowModel(),
 		getCoreRowModel: getCoreRowModel(),
 		getSortedRowModel: getSortedRowModel()
 	})
-
-	const [projectName, setProjectName] = React.useState('')
-
-	React.useEffect(() => {
-		const projectsColumns = instance.getColumn('name')
-		const id = setTimeout(() => {
-			projectsColumns.setFilterValue(projectName)
-		}, 200)
-		return () => clearTimeout(id)
-	}, [projectName, instance])
 
 	const { upcomingUnlocks30dValue } = React.useMemo(() => {
 		let upcomingUnlocks30dValue = 0


### PR DESCRIPTION
fix unlock page sorting, currently when there's no event it causes the null event to be sorted at top, this fix moves it to bottom and modify search to be able to search using token symbol instead of name only