### PR TITLE
fix: SortIcon caret-up active color

### DIFF
--- a/src/components/Table/SortIcon.tsx
+++ b/src/components/Table/SortIcon.tsx
@@ -10,7 +10,7 @@ export function SortIcon({ dir }: { dir: string | boolean }) {
 				data-icon="caret-up"
 				fill={dir === 'asc' ? 'var(--blue)' : 'gray'}
 				aria-hidden="true"
-				className="block shrink-0 relative top-[2px] fill-[gray]"
+				className="block shrink-0 relative top-[2px]"
 			>
 				<path d="M858.9 689L530.5 308.2c-9.4-10.9-27.5-10.9-37 0L165.1 689c-12.2 14.2-1.2 35 18.5 35h656.8c19.7 0 30.7-20.8 18.5-35z"></path>
 			</svg>


### PR DESCRIPTION
Currently setting the sorting order to `asc` results in the top carat not changing color despite the svg being passed a fill of `var(--blue)`. The PR makes it so the top carat turns blue when sort order changes to `asc`, similarly to what happens for `desc`.

Before
https://github.com/user-attachments/assets/d0819fd2-e4c8-43b5-8d2d-3cb5e8eb931d

After
https://github.com/user-attachments/assets/0272de00-c7cf-4d26-b037-e7f16a80d9fd