### PR TITLE
fix(yields): allow filtering by projectName or slug

### DIFF
--- a/src/containers/Yields/utils.ts
+++ b/src/containers/Yields/utils.ts
@@ -41,7 +41,10 @@ export function toFilterPool({
 		}
 	})
 
-	toFilter = toFilter && selectedProjects.includes(curr.projectName)
+	// Accept both the display name ('Project Name') and the slug ('project-name')
+	// when matching selected projects (used by the “View All Yields” view
+	// in ProtocolOverview).
+	toFilter = toFilter && (selectedProjects.includes(curr.projectName) || selectedProjects.includes(curr.project))
 
 	toFilter = toFilter && selectedCategories.includes(curr.category)
 


### PR DESCRIPTION
The "View All Yields" link on a protocol page failed when it received the project’s slug ("project-name") instead of its display name ("Project Name").

This PR updates the filter logic to accept both forms (projectName and project), so the yields view works regardless of which value is passed.

Fix #1936 