### PR TITLE
fix: resolve theme toggle functionality in mobile view

### DIFF
--- a/src/components/Nav/Mobile/Settings.tsx
+++ b/src/components/Nav/Mobile/Settings.tsx
@@ -7,7 +7,7 @@ import { Icon } from '~/components/Icon'
 import * as Ariakit from '@ariakit/react'
 
 export function Settings() {
-	const [darkMode] = useDarkModeManager()
+	const [darkMode, toggleDarkMode] = useDarkModeManager()
 
 	const { options, dashboardType } = useAppSettings()
 
@@ -18,8 +18,11 @@ export function Settings() {
 		.filter((key) => enabledOptions[key])
 		.concat(darkMode ? [DARK_MODE] : [])
 
-	const onChange = (values) => {
-		if (values.length < selectedOptions.length) {
+	const onChange = (values: string[]) => {
+		const isDarkMode = values.includes(DARK_MODE)
+		if (isDarkMode !== darkMode) {
+			toggleDarkMode()
+		} else if (values.length < selectedOptions.length) {
 			const off = selectedOptions.find((o) => !values.includes(o))
 			updater(off)
 		} else {


### PR DESCRIPTION
This PR fixes a bug that I noticed that prevented the dark mode toggle from working in the mobile settings menu. The issue was caused by the mobile settings component using the wrong mechanism to update the dark mode state.

Changes made in `Settings.tsx`:
- retrieved `toggleDarkMode` via `useDarkModeManager` in addition to the `darkMode` state
- updated `onChange` handler to check if dark mode settings were changed. If so, `toggleDarkMode` is called.

This fix was targeted to fix the bug, a more comprehensive refactor could improve the component's structure by separating out the dark mode logic from other settings if this is deemed to be the move.

How to test:
1. open app in mobile view
2. click on settings gear icon
3. toggle light/dark mode