### PR TITLE
fix: apply the only custom column order to hacks table to avoid shifting

### DIFF
--- a/src/containers/Hacks/index.tsx
+++ b/src/containers/Hacks/index.tsx
@@ -25,7 +25,7 @@ const columnResizeMode = 'onChange'
 
 function HacksTable({ data }) {
 	const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
-	const [columnOrder, setColumnOrder] = React.useState<ColumnOrderState>([])
+	const [columnOrder, setColumnOrder] = React.useState<ColumnOrderState>(hacksColumnOrders[0][1])
 	const [sorting, setSorting] = React.useState<SortingState>([{ desc: true, id: 'date' }])
 	const [projectName, setProjectName] = React.useState('')
 	const windowSize = useWindowSize()

--- a/src/pages/hacks.tsx
+++ b/src/pages/hacks.tsx
@@ -87,14 +87,14 @@ export const getStaticProps = withPerformanceLogging('hacks', async () => {
 	}
 })
 
-const Raises = (props) => {
+const Hacks = (props) => {
 	const monthlyHacks = React.useMemo(() => {
 		return props.monthlyHacks.map((m) => [getFirstDateOfTheMonth(m[0]), m[1]])
 	}, [props.monthlyHacks])
-	return <HacksContainer {...(props as any)} monthlyHacks={monthlyHacks} />
+	return <HacksContainer {...props} monthlyHacks={monthlyHacks} />
 }
 
-export default Raises
+export default Hacks
 
 function getFirstDateOfTheMonth(currentDate) {
 	const date = new Date(currentDate * 1000)


### PR DESCRIPTION
Applies the only custom sorting for the hacks table by default instead of after hydration to avoid column order shifting.

before:

https://github.com/user-attachments/assets/cdf84b56-41a9-4ee3-b481-93139a7f2151


after:

https://github.com/user-attachments/assets/bd12c615-e73f-4fcd-bc1b-96fcdcd213c3

