### PR TITLE
fix: improved ux for Include in TVL select

### DIFF
--- a/src/components/Search/ProtocolsChains/index.tsx
+++ b/src/components/Search/ProtocolsChains/index.tsx
@@ -118,6 +118,7 @@ const TvlOptions = ({ options }: { options?: { name: string; key: string }[] }) 
 					className:
 						'flex items-center gap-2 py-2 px-3 text-xs rounded-md cursor-pointer flex-nowrap bg-[#E2E2E2] dark:bg-[#181A1C]'
 				}}
+				placement="bottom-end"
 			/>
 		</>
 	)

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -16,6 +16,7 @@ interface ISelect {
 	labelType?: 'regular' | 'smol' | 'none'
 	triggerProps?: Ariakit.SelectProps
 	portal?: boolean
+	placement?: Ariakit.SelectProviderProps['placement']
 }
 
 export function Select({
@@ -29,7 +30,8 @@ export function Select({
 	nestedMenu,
 	labelType = 'regular',
 	triggerProps,
-	portal
+	portal,
+	placement = 'bottom-start'
 }: ISelect) {
 	const valuesAreAnArrayOfStrings = typeof allValues[0] === 'string'
 
@@ -97,6 +99,7 @@ export function Select({
 			setValue={(values) => {
 				setSelectedValues(values)
 			}}
+			placement={placement}
 		>
 			<Ariakit.Select
 				className="bg-(--btn-bg) hover:bg-(--btn-hover-bg) focus-visible:bg-(--btn-hover-bg) flex items-center gap-2 py-2 px-3 text-xs rounded-md cursor-pointer text-(--text1) flex-nowrap"
@@ -154,7 +157,7 @@ export function Select({
 							<Ariakit.SelectItem
 								key={`${label}-${valuesAreAnArrayOfStrings ? option : option.key}`}
 								value={valuesAreAnArrayOfStrings ? option : option.key}
-								className="group flex items-center gap-4 py-2 px-3 shrink-0 hover:bg-(--primary1-hover) focus-visible:bg-(--primary1-hover) data-active-item:bg-(--primary1-hover) cursor-pointer last-of-type:rounded-b-md border-b border-(--form-control-border)"
+								className="group flex items-center gap-4 py-2 px-3 shrink-0 justify-between hover:bg-(--primary1-hover) focus-visible:bg-(--primary1-hover) data-active-item:bg-(--primary1-hover) cursor-pointer last-of-type:rounded-b-md border-b border-(--form-control-border)"
 							>
 								{valuesAreAnArrayOfStrings ? (
 									<span>{option}</span>
@@ -166,18 +169,20 @@ export function Select({
 								) : (
 									<span>{option.name}</span>
 								)}
-								{selectOnlyOne ? (
-									<button
-										onClick={(e) => {
-											e.stopPropagation()
-											selectOnlyOne(valuesAreAnArrayOfStrings ? option : option.key)
-										}}
-										className="font-medium text-xs text-(--link) underline invisible group-hover:visible group-focus-visible:visible"
-									>
-										Only
-									</button>
-								) : null}
-								<Ariakit.SelectItemCheck className="ml-auto h-3 w-3 flex items-center justify-center rounded-xs shrink-0 border border-[#28a2b5]" />
+								<div className="flex items-center gap-2">
+									{selectOnlyOne ? (
+										<button
+											onClick={(e) => {
+												e.stopPropagation()
+												selectOnlyOne(valuesAreAnArrayOfStrings ? option : option.key)
+											}}
+											className="font-medium text-xs text-(--link) underline invisible group-hover:visible group-focus-visible:visible"
+										>
+											Only
+										</button>
+									) : null}
+									<Ariakit.SelectItemCheck className="h-3 w-3 flex items-center justify-center rounded-xs shrink-0 border border-[#28a2b5]" />
+								</div>
 							</Ariakit.SelectItem>
 						))}
 


### PR DESCRIPTION
Improved ux of the Include in TVL select in the index page by removing layout shift in two instances:
- incosinstent size of select items
- popover moving due to being aligned at the start of the anchor

This PR changes the position of the `Only` button within select items which will effect all usages of the component. I believe this to be a good thing as it keeps it close to the other interactive element (checkbox).

before:

https://github.com/user-attachments/assets/36348878-adbf-41e9-8eb1-0e34888fe938

after:

https://github.com/user-attachments/assets/c81ed690-672a-4961-930a-5c4f057a39ae

