### PR TITLE
fix: n/a risk rating styles

### DIFF
--- a/src/pages/yields/pool/[pool].tsx
+++ b/src/pages/yields/pool/[pool].tsx
@@ -279,7 +279,9 @@ const PageView = (props) => {
 							<span className="text-base text-[#545757] dark:text-[#cccccc]">Total Risk Rating</span>
 							<span className="flex items-center gap-2 flex-nowrap">
 								<span
-									className="w-7 h-7 rounded-full flex items-center justify-center text-base font-bold"
+									className={`w-7 h-7 rounded-full flex items-center justify-center text-base font-bold ${
+										riskData?.pool_rating ? 'text-base' : 'text-sm'
+									}`}
 									style={getRatingColor(riskData?.pool_rating_color)}
 								>
 									{riskData?.pool_rating || 'N/A'}
@@ -417,7 +419,9 @@ const PageView = (props) => {
 								<div className="flex items-center justify-between rounded-xl min-w-[160px] mb-4 p-3">
 									<h3 className="flex items-center gap-1 text-base font-bold">
 										<span
-											className="w-7 h-7 rounded-full flex items-center justify-center"
+											className={`w-7 h-7 rounded-full flex items-center justify-center ${
+												riskData?.pool_rating ? 'text-base' : 'text-sm'
+											}`}
 											style={getRatingColor(riskData?.pool_rating_color)}
 										>
 											{riskData?.pool_rating || 'N/A'}


### PR DESCRIPTION
Fixed styles for N/A risk rating in yield/pool page. Tested at `/yields/pool/f88b9d36-ae43-4be7-abdf-37acd0643745`.

Before:
<img width="568" height="815" alt="Screenshot 2025-07-10 at 12 31 20" src="https://github.com/user-attachments/assets/56db599a-f99e-4dfc-8280-eada5c9ddabc" />

After:
<img width="598" height="840" alt="Screenshot 2025-07-10 at 12 38 52" src="https://github.com/user-attachments/assets/b796c328-3609-4956-b5f7-16d9d287dac7" />
