### PR TITLE
Fix/compare chains chart

### DIFF
--- a/src/containers/ChainOverview/Chart.tsx
+++ b/src/containers/ChainOverview/Chart.tsx
@@ -157,6 +157,7 @@ export default function ChainLineBarChart({
 			if (type === 'TVL') {
 				finalYAxis.push(yAxis)
 			}
+
 			if (type === 'Stablecoins Mcap') {
 				finalYAxis.push({
 					...options,
@@ -168,6 +169,7 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
+
 			if (type === 'Chain Fees') {
 				finalYAxis.push({
 					...options,
@@ -185,6 +187,7 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
+
 			if (type === 'DEXs Volume') {
 				finalYAxis.push({
 					...options,
@@ -196,6 +199,7 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
+
 			if (type === 'Perps Volume') {
 				finalYAxis.push({
 					...options,
@@ -207,6 +211,7 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
+
 			if (type === 'Token Incentives') {
 				finalYAxis.push({
 					...options,
@@ -218,6 +223,7 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
+
 			if (type === 'Bridged TVL') {
 				finalYAxis.push({
 					...options,
@@ -229,6 +235,7 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
+
 			if (type === 'Active Addresses') {
 				finalYAxis.push({
 					...options,
@@ -249,6 +256,7 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
+
 			if (type === 'Transactions') {
 				finalYAxis.push({
 					...options,
@@ -263,6 +271,7 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
+
 			if (type === 'Net Inflows') {
 				finalYAxis.push({
 					...options,
@@ -274,6 +283,7 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
+
 			if (type === 'Core Developers') {
 				finalYAxis.push({
 					...options,
@@ -288,6 +298,7 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
+
 			if (type === 'Devs Commits') {
 				finalYAxis.push({
 					...options,
@@ -302,6 +313,7 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
+
 			if (type === 'Token Mcap') {
 				finalYAxis.push({
 					...options,
@@ -313,6 +325,7 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
+
 			if (type === 'Token Price') {
 				finalYAxis.push({
 					...options,
@@ -324,6 +337,7 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
+
 			if (type === 'Token Volume') {
 				finalYAxis.push({
 					...options,
@@ -335,6 +349,7 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
+
 			if (type === 'Raises') {
 				finalYAxis.push({
 					...options,

--- a/src/containers/ChainOverview/Chart.tsx
+++ b/src/containers/ChainOverview/Chart.tsx
@@ -12,6 +12,12 @@ import {
 
 const customOffsets = {}
 
+// Helper to extract metric from key
+const extractMetric = (key: string): string => {
+	const parts = key.split(' - ')
+	return parts.length > 1 ? parts[parts.length - 1] : key
+}
+
 export default function ChainLineBarChart({
 	chartData,
 	valueSymbol = '',
@@ -42,10 +48,11 @@ export default function ChainLineBarChart({
 	const { series, allYAxis } = useMemo(() => {
 		const uniqueYAxis = new Set()
 
-		const stacks = Object.keys(chartData) as any
+		const stacks = Object.keys(chartData ?? {}) as any
 
 		for (const stack of stacks) {
-			uniqueYAxis.add(yAxisByChart[stack])
+			const metric = extractMetric(stack) as ChainChartLabels
+			uniqueYAxis.add(yAxisByChart[metric])
 		}
 
 		const indexByYAxis = Object.fromEntries(
@@ -53,13 +60,14 @@ export default function ChainLineBarChart({
 		) as Record<ChainChartLabels, number | undefined>
 
 		const series = stacks.map((stack, index) => {
-			const stackColor = chainOverviewChartColors[stack]
+			const metric = extractMetric(stack) as ChainChartLabels
+			const stackColor = chainOverviewChartColors[metric]
 
-			let type = BAR_CHARTS.includes(stack) && !isCumulative ? 'bar' : 'line'
-			type = DISABLED_CUMULATIVE_CHARTS.includes(stack) ? 'bar' : type
+			let type = BAR_CHARTS.includes(metric) && !isCumulative ? 'bar' : 'line'
+			type = DISABLED_CUMULATIVE_CHARTS.includes(metric) ? 'bar' : type
 
 			const options = {
-				yAxisIndex: indexByYAxis[yAxisByChart[stack]]
+				yAxisIndex: indexByYAxis[yAxisByChart[metric]]
 			}
 
 			return {
@@ -75,7 +83,7 @@ export default function ChainLineBarChart({
 				},
 				symbol: 'none',
 				itemStyle: {
-					color: stackColor || null
+					color: stackColor || (isThemeDark ? '#fff' : '#000')
 				},
 				...(type === 'line'
 					? {
@@ -83,7 +91,7 @@ export default function ChainLineBarChart({
 								color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
 									{
 										offset: 0,
-										color: stackColor ? stackColor : index === 0 ? chainOverviewChartColors[stack] : 'transparent'
+										color: stackColor || (isThemeDark ? '#fff' : '#000')
 									},
 									{
 										offset: 1,
@@ -94,7 +102,7 @@ export default function ChainLineBarChart({
 					  }
 					: {}),
 				markLine: {},
-				data: chartData[stack] ?? []
+				data: (chartData[stack] ?? []).map(([timestamp, value]) => [timestamp * 1000, value])
 			}
 		})
 
@@ -149,7 +157,6 @@ export default function ChainLineBarChart({
 			if (type === 'TVL') {
 				finalYAxis.push(yAxis)
 			}
-
 			if (type === 'Stablecoins Mcap') {
 				finalYAxis.push({
 					...options,
@@ -161,7 +168,6 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
-
 			if (type === 'Chain Fees') {
 				finalYAxis.push({
 					...options,
@@ -179,7 +185,6 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
-
 			if (type === 'DEXs Volume') {
 				finalYAxis.push({
 					...options,
@@ -191,7 +196,6 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
-
 			if (type === 'Perps Volume') {
 				finalYAxis.push({
 					...options,
@@ -203,7 +207,6 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
-
 			if (type === 'Token Incentives') {
 				finalYAxis.push({
 					...options,
@@ -215,7 +218,6 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
-
 			if (type === 'Bridged TVL') {
 				finalYAxis.push({
 					...options,
@@ -227,7 +229,6 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
-
 			if (type === 'Active Addresses') {
 				finalYAxis.push({
 					...options,
@@ -248,7 +249,6 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
-
 			if (type === 'Transactions') {
 				finalYAxis.push({
 					...options,
@@ -263,7 +263,6 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
-
 			if (type === 'Net Inflows') {
 				finalYAxis.push({
 					...options,
@@ -275,7 +274,6 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
-
 			if (type === 'Core Developers') {
 				finalYAxis.push({
 					...options,
@@ -290,7 +288,6 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
-
 			if (type === 'Devs Commits') {
 				finalYAxis.push({
 					...options,
@@ -305,7 +302,6 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
-
 			if (type === 'Token Mcap') {
 				finalYAxis.push({
 					...options,
@@ -317,7 +313,6 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
-
 			if (type === 'Token Price') {
 				finalYAxis.push({
 					...options,
@@ -329,7 +324,6 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
-
 			if (type === 'Token Volume') {
 				finalYAxis.push({
 					...options,
@@ -341,7 +335,6 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
-
 			if (type === 'Raises') {
 				finalYAxis.push({
 					...options,

--- a/src/containers/ChainOverview/useFetchChainChartData.tsx
+++ b/src/containers/ChainOverview/useFetchChainChartData.tsx
@@ -627,40 +627,6 @@ const formatBarChart = ({
 	hasNoPrice?: boolean
 	denominationPriceHistory: Record<string, number> | null
 }): Array<[number, number]> => {
-	if (['weekly', 'monthly', 'cumulative'].includes(groupBy)) {
-		const store = {}
-		let total = 0
-		const isWeekly = groupBy === 'weekly'
-		const isMonthly = groupBy === 'monthly'
-		const isCumulative = groupBy === 'cumulative'
-		for (const [date, value] of data) {
-			const dateKey = isWeekly
-				? lastDayOfWeek(dateInMs ? +date : +date * 1e3)
-				: isMonthly
-				? firstDayOfMonth(dateInMs ? +date : +date * 1e3)
-				: dateInMs
-				? +date / 1e3
-				: +date
-			// sum up values as it is bar chart
-			if (denominationPriceHistory) {
-				const price = denominationPriceHistory[String(dateInMs ? date : +date * 1e3)]
-				store[dateKey] = (store[dateKey] ?? 0) + (price ? value / price : 0) + total
-				if (isCumulative && price) {
-					total += value / price
-				}
-			} else {
-				store[dateKey] = (store[dateKey] ?? 0) + value + total
-				if (isCumulative) {
-					total += value
-				}
-			}
-		}
-		const finalChart = []
-		for (const date in store) {
-			finalChart.push([+date * 1e3, store[date]])
-		}
-		return finalChart
-	}
 	if (denominationPriceHistory) {
 		return data.map(([date, value]) => {
 			const price = denominationPriceHistory[String(dateInMs ? date : +date * 1e3)]

--- a/src/containers/CompareChains/index.tsx
+++ b/src/containers/CompareChains/index.tsx
@@ -240,25 +240,6 @@ export function CompareChains() {
 								false
 							)
 						)}
-
-						{/* GroupBy Controls */}
-						{Object.keys(finalCharts).length > 0 && (
-							<div className="flex items-center gap-1 ml-auto">
-								<span className="text-sm text-[#545757] dark:text-[#cccccc]">Group by:</span>
-								<div className="flex items-center">
-									{['daily', 'weekly', 'monthly', 'cumulative'].map((period) => (
-										<button
-											key={period}
-											className="shrink-0 py-1 px-2 whitespace-nowrap data-[active=true]:font-medium text-sm hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) data-[active=true]:text-(--link-text) capitalize"
-											data-active={router.query?.groupBy === period || (!router.query?.groupBy && period === 'daily')}
-											onClick={() => updateRoute('groupBy', period, router)}
-										>
-											{period === 'cumulative' ? 'Cumulative' : period.charAt(0).toUpperCase()}
-										</button>
-									))}
-								</div>
-							</div>
-						)}
 					</div>
 					{data.isLoading || !router.isReady || isFetchingChartData ? (
 						<div className="flex items-center justify-center m-auto min-h-[360px]">

--- a/src/containers/CompareChains/useCompareChainChartData.tsx
+++ b/src/containers/CompareChains/useCompareChainChartData.tsx
@@ -101,7 +101,7 @@ export const useCompareChainChartData = ({ datasets, router }: { datasets: Array
 					data: chainData.volumeChart,
 					groupBy,
 					chartType: 'bar',
-					dateInMs: false
+					dateInMs: true
 				})
 				if (formattedData.length > 0) {
 					finalCharts[`${chainName} - DEXs Volume`] = formattedData
@@ -114,7 +114,7 @@ export const useCompareChainChartData = ({ datasets, router }: { datasets: Array
 					data: chainData.feesChart,
 					groupBy,
 					chartType: 'bar',
-					dateInMs: false
+					dateInMs: true
 				})
 				if (formattedData.length > 0) {
 					finalCharts[`${chainName} - Chain Fees`] = formattedData
@@ -127,7 +127,7 @@ export const useCompareChainChartData = ({ datasets, router }: { datasets: Array
 					data: chainData.feesChart,
 					groupBy,
 					chartType: 'bar',
-					dateInMs: false
+					dateInMs: true
 				})
 				if (formattedData.length > 0) {
 					finalCharts[`${chainName} - Chain Revenue`] = formattedData
@@ -140,7 +140,7 @@ export const useCompareChainChartData = ({ datasets, router }: { datasets: Array
 					data: chainData.appRevenueChart,
 					groupBy,
 					chartType: 'bar',
-					dateInMs: false
+					dateInMs: true
 				})
 				if (formattedData.length > 0) {
 					finalCharts[`${chainName} - App Revenue`] = formattedData

--- a/src/containers/CompareChains/useCompareChainChartData.tsx
+++ b/src/containers/CompareChains/useCompareChainChartData.tsx
@@ -1,0 +1,186 @@
+import * as React from 'react'
+import { firstDayOfMonth, lastDayOfWeek } from '~/utils'
+
+interface ChainData {
+	chain: string
+	globalChart?: Array<[number, number]>
+	volumeChart?: Array<[number, number]>
+	feesChart?: Array<[number, number]>
+	appRevenueChart?: Array<[number, number]>
+	usersData?: Array<[number, number]>
+	txs?: Array<[number, number]>
+	txsData?: Array<[number, number]>
+}
+
+const formatChartData = ({
+	data,
+	groupBy,
+	chartType,
+	dateInMs = false
+}: {
+	data: Array<[number, number]>
+	groupBy: 'daily' | 'weekly' | 'monthly' | 'cumulative'
+	chartType: 'line' | 'bar'
+	dateInMs?: boolean
+}): Array<[number, number]> => {
+	if (!data || data.length === 0) return []
+
+	if (['weekly', 'monthly', 'cumulative'].includes(groupBy)) {
+		const store = {}
+		let total = 0
+		const isWeekly = groupBy === 'weekly'
+		const isMonthly = groupBy === 'monthly'
+		const isCumulative = groupBy === 'cumulative'
+
+		for (const [date, value] of data) {
+			const dateKey = isWeekly
+				? lastDayOfWeek(dateInMs ? +date : +date * 1e3)
+				: isMonthly
+				? firstDayOfMonth(dateInMs ? +date : +date * 1e3)
+				: dateInMs
+				? +date / 1e3
+				: +date
+
+			if (chartType === 'bar') {
+				// Bar charts: sum up values
+				store[dateKey] = (store[dateKey] ?? 0) + value + total
+				if (isCumulative) {
+					total += value
+				}
+			} else {
+				// Line charts: use last value for each date
+				store[dateKey] = value
+			}
+		}
+
+		const finalChart = []
+		for (const date in store) {
+			finalChart.push([+date * 1e3, store[date]])
+		}
+		return finalChart
+	}
+
+	// Daily data - convert to milliseconds if needed
+	return dateInMs ? (data as Array<[number, number]>) : data.map(([date, value]) => [+date * 1e3, value])
+}
+
+export const useCompareChainChartData = ({ datasets, router }: { datasets: Array<ChainData>; router: any }) => {
+	const chartData = React.useMemo(() => {
+		if (!datasets || datasets.length === 0) {
+			return {}
+		}
+
+		const queryParams = router.query || {}
+		const groupBy = ['daily', 'weekly', 'monthly', 'cumulative'].includes(queryParams.groupBy as any)
+			? (queryParams.groupBy as 'daily' | 'weekly' | 'monthly' | 'cumulative')
+			: 'daily'
+
+		const finalCharts: Record<string, Array<[number, number]>> = {}
+
+		datasets.forEach((chainData) => {
+			if (!chainData) return
+
+			const chainName = chainData.chain
+
+			// TVL Charts - always shown unless explicitly disabled
+			if (queryParams.tvl !== 'false' && chainData.globalChart) {
+				const formattedData = formatChartData({
+					data: chainData.globalChart,
+					groupBy,
+					chartType: 'line',
+					dateInMs: true
+				})
+				if (formattedData.length > 0) {
+					finalCharts[`${chainName} - TVL`] = formattedData
+				}
+			}
+
+			// Volume Charts
+			if (queryParams.volume === 'true' && chainData.volumeChart) {
+				const formattedData = formatChartData({
+					data: chainData.volumeChart,
+					groupBy,
+					chartType: 'bar',
+					dateInMs: false
+				})
+				if (formattedData.length > 0) {
+					finalCharts[`${chainName} - DEXs Volume`] = formattedData
+				}
+			}
+
+			// Fees Charts
+			if (queryParams.chainFees === 'true' && chainData.feesChart) {
+				const formattedData = formatChartData({
+					data: chainData.feesChart,
+					groupBy,
+					chartType: 'bar',
+					dateInMs: false
+				})
+				if (formattedData.length > 0) {
+					finalCharts[`${chainName} - Chain Fees`] = formattedData
+				}
+			}
+
+			// Chain Revenue Charts
+			if (queryParams.chainRevenue === 'true' && chainData.feesChart) {
+				const formattedData = formatChartData({
+					data: chainData.feesChart,
+					groupBy,
+					chartType: 'bar',
+					dateInMs: false
+				})
+				if (formattedData.length > 0) {
+					finalCharts[`${chainName} - Chain Revenue`] = formattedData
+				}
+			}
+
+			// App Revenue Charts
+			if (queryParams.appRevenue === 'true' && chainData.appRevenueChart) {
+				const formattedData = formatChartData({
+					data: chainData.appRevenueChart,
+					groupBy,
+					chartType: 'bar',
+					dateInMs: false
+				})
+				if (formattedData.length > 0) {
+					finalCharts[`${chainName} - App Revenue`] = formattedData
+				}
+			}
+
+			// Active Addresses Charts
+			if (queryParams.addresses === 'true' && chainData.usersData) {
+				const formattedData = formatChartData({
+					data: chainData.usersData,
+					groupBy,
+					chartType: 'bar',
+					dateInMs: true
+				})
+				if (formattedData.length > 0) {
+					finalCharts[`${chainName} - Active Addresses`] = formattedData
+				}
+			}
+
+			// Transactions Charts
+			if (queryParams.txs === 'true' && (chainData.txs || chainData.txsData)) {
+				const txData = chainData.txs || chainData.txsData
+				const formattedData = formatChartData({
+					data: txData,
+					groupBy,
+					chartType: 'bar',
+					dateInMs: true
+				})
+				if (formattedData.length > 0) {
+					finalCharts[`${chainName} - Transactions`] = formattedData
+				}
+			}
+		})
+
+		return finalCharts
+	}, [datasets, router.query])
+
+	return {
+		finalCharts: chartData,
+		valueSymbol: '$',
+		isFetchingChartData: false
+	}
+}


### PR DESCRIPTION
The changes on the PR include:

- Fix the exception in /compare-chains page

<img width="1512" height="870" alt="Screenshot 2025-07-11 at 5 18 38 AM" src="https://github.com/user-attachments/assets/0a17e7fc-aa82-4247-8f09-4edda8b817e2" />

<img width="1512" height="870" alt="Screenshot 2025-07-11 at 5 26 20 AM" src="https://github.com/user-attachments/assets/844b184f-ec44-4dea-bcaf-d1e27ae61fe4" />


- Created useComparativeChartData to get the chain info to be rendered in Chart

- Refactored Chart.tsx to support both plain and composite keys (e.g., "TVL" and "Chain - TVL") by introducing an extractMetric helper for robust metric extraction.

