### PR TITLE
Feat/skeleton loading components

### DIFF
--- a/src/components/Skeleton/ChartSkeleton.tsx
+++ b/src/components/Skeleton/ChartSkeleton.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+type ChartSkeletonProps = {
+	minHeight?: string
+	width?: string
+	className?: string
+}
+
+export const ChartSkeleton: React.FC<ChartSkeletonProps> = ({
+	minHeight = 'min-h-[480px]',
+	width = 'w-full',
+	className = ''
+}) => (
+	<div
+		className={`${width} bg-neutral-200 dark:bg-neutral-700 rounded animate-pulse ${minHeight} ${className}`}
+		aria-busy="true"
+		aria-label="Loading chart area"
+	/>
+)

--- a/src/components/Skeleton/InfoBlockSkeleton.tsx
+++ b/src/components/Skeleton/InfoBlockSkeleton.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+type InfoBlockSkeletonProps = {
+	blockWidths?: string[]
+	blockHeights?: string[]
+	className?: string
+	containerClass?: string
+}
+
+export const InfoBlockSkeleton: React.FC<InfoBlockSkeletonProps> = ({
+	blockWidths = ['w-32', 'w-24', 'w-20', 'w-28'],
+	blockHeights = ['h-6', 'h-4', 'h-4', 'h-4'],
+	className = '',
+	containerClass = 'bg-[var(--cards-bg)] rounded-md p-5'
+}) => (
+	<div className={`${containerClass} ${className}`} aria-busy="true" aria-label="Loading info block">
+		{blockWidths.map((w, i) => (
+			<div
+				key={i}
+				className={`${blockHeights[i] || 'h-4'} bg-neutral-200 dark:bg-neutral-700 rounded ${w} animate-pulse mb-1`}
+			/>
+		))}
+	</div>
+)

--- a/src/components/Skeleton/RiskRatingSkeleton.tsx
+++ b/src/components/Skeleton/RiskRatingSkeleton.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+type RiskRatingSkeletonProps = {
+	count?: number
+	className?: string
+	circleSize?: string
+	blockWidth?: string
+	blockHeight?: string
+}
+
+export const RiskRatingSkeleton: React.FC<RiskRatingSkeletonProps> = ({
+	count = 3,
+	className = '',
+	circleSize = 'w-7 h-7',
+	blockWidth = 'w-20',
+	blockHeight = 'h-6'
+}) => (
+	<div className={`flex flex-col gap-3 w-full ${className}`} aria-busy="true" aria-label="Loading risk rating block">
+		<div className="flex items-center gap-2 flex-nowrap">
+			<div className={`${circleSize} rounded-full bg-neutral-200 dark:bg-neutral-700 animate-pulse`} />
+			<div className="h-6 bg-neutral-200 dark:bg-neutral-700 rounded w-32 animate-pulse" />
+		</div>
+		{Array.from({ length: count }).map((_, i) => (
+			<div key={i} className="flex items-center gap-2">
+				<div className={`${blockWidth} rounded-xl bg-neutral-200 dark:bg-neutral-700 ${blockHeight} animate-pulse`} />
+				<div className="h-4 bg-neutral-200 dark:bg-neutral-700 rounded w-20 animate-pulse" />
+			</div>
+		))}
+	</div>
+)

--- a/src/components/Skeleton/StatCardSkeleton.tsx
+++ b/src/components/Skeleton/StatCardSkeleton.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+type StatCardSkeletonProps = {
+	width?: string
+	numberHeight?: string
+	labelHeight?: string
+	className?: string
+}
+
+export const StatCardSkeleton: React.FC<StatCardSkeletonProps> = ({
+	width = 'max-w-[120px]',
+	numberHeight = 'min-h-8 h-8',
+	labelHeight = 'h-4',
+	className = ''
+}) => (
+	<div className={`flex flex-col gap-1 w-full ${width} ${className}`} aria-busy="true" aria-label="Loading stat card">
+		<div className={`${labelHeight} bg-neutral-200 dark:bg-neutral-700 rounded w-16 animate-pulse`} />
+		<div className={`${numberHeight} bg-neutral-200 dark:bg-neutral-700 rounded w-20 animate-pulse`} />
+	</div>
+)

--- a/src/components/Skeleton/TableSkeleton.tsx
+++ b/src/components/Skeleton/TableSkeleton.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+
+type TableSkeletonProps = {
+	columns?: number
+	rows?: number
+	className?: string
+}
+
+export const TableSkeleton: React.FC<TableSkeletonProps> = ({ columns = 7, rows = 10, className = '' }) => (
+	<div className={`w-full ${className}`} aria-busy="true" aria-label="Loading table">
+		<div className="overflow-x-auto">
+			<table className="min-w-full divide-y divide-gray-200 dark:divide-neutral-700">
+				<thead>
+					<tr>
+						{Array.from({ length: columns }).map((_, i) => (
+							<th key={i} className="px-4 py-2">
+								<div className="h-4 bg-neutral-200 dark:bg-neutral-700 rounded w-20 animate-pulse" />
+							</th>
+						))}
+					</tr>
+				</thead>
+				<tbody>
+					{Array.from({ length: rows }).map((_, rowIdx) => (
+						<tr key={rowIdx} className="even:bg-neutral-50 dark:even:bg-neutral-800">
+							{Array.from({ length: columns }).map((_, colIdx) => (
+								<td key={colIdx} className="px-4 py-3">
+									<div className="h-4 bg-neutral-200 dark:bg-neutral-700 rounded w-full animate-pulse" />
+								</td>
+							))}
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	</div>
+)

--- a/src/components/Skeleton/YieldPoolSkeleton.tsx
+++ b/src/components/Skeleton/YieldPoolSkeleton.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { StatCardSkeleton } from './StatCardSkeleton'
+import { ChartSkeleton } from './ChartSkeleton'
+import { RiskRatingSkeleton } from './RiskRatingSkeleton'
+import { InfoBlockSkeleton } from './InfoBlockSkeleton'
+
+export const YieldPoolSkeleton: React.FC = () => (
+	<div className="flex flex-col gap-4 w-full" aria-busy="true" aria-label="Loading yield pool page">
+		{/* Header and Stats */}
+		<div className="grid grid-cols-2 relative isolate xl:grid-cols-3 gap-1">
+			<div className="bg-[var(--cards-bg)] rounded-md flex flex-col gap-6 col-span-2 w-full xl:col-span-1 overflow-x-auto p-5">
+				{/* Title */}
+				<div className="h-7 bg-neutral-200 dark:bg-neutral-700 rounded w-40 animate-pulse mb-2" />
+				{/* Stats Row */}
+				<div className="flex items-end justify-between flex-wrap gap-5 relative">
+					<StatCardSkeleton />
+					<StatCardSkeleton />
+					<StatCardSkeleton />
+				</div>
+				{/* TVL */}
+				<div className="flex flex-col gap-1">
+					<div className="h-4 bg-neutral-200 dark:bg-neutral-700 rounded w-32 animate-pulse" />
+					<div className="min-h-8 h-8 bg-neutral-200 dark:bg-neutral-700 rounded w-24 animate-pulse" />
+				</div>
+				{/* Risk */}
+				<RiskRatingSkeleton />
+				{/* Outlook */}
+				<div className="flex flex-col gap-1">
+					<div className="h-4 bg-neutral-200 dark:bg-neutral-700 rounded w-16 animate-pulse" />
+					<div className="h-8 bg-neutral-200 dark:bg-neutral-700 rounded w-full animate-pulse" />
+				</div>
+			</div>
+			{/* Main Chart */}
+			<div className="bg-[var(--cards-bg)] rounded-md col-span-2 flex flex-col justify-center items-center">
+				<ChartSkeleton />
+			</div>
+		</div>
+		{/* Risk Section */}
+		<div className="grid grid-cols-2 gap-1 rounded-md bg-[var(--cards-bg)]">
+			<div className="flex flex-col col-span-2 xl:col-span-1 p-5">
+				<div className="h-6 bg-neutral-200 dark:bg-neutral-700 rounded w-48 mb-6 animate-pulse" />
+				<RiskRatingSkeleton />
+			</div>
+		</div>
+		{/* Borrow/Net APY/Pool Liquidity Charts */}
+		<div className="grid grid-cols-2 gap-1 rounded-md bg-[var(--cards-bg)]">
+			<ChartSkeleton minHeight="h-[400px]" />
+			<ChartSkeleton minHeight="h-[400px]" />
+		</div>
+		{/* Protocol Info */}
+		<InfoBlockSkeleton />
+	</div>
+)

--- a/src/pages/trending-contracts.tsx
+++ b/src/pages/trending-contracts.tsx
@@ -9,6 +9,7 @@ import { formattedPercent } from '~/utils'
 import { fetchWithErrorLogging } from '~/utils/async'
 import { TagGroup } from '~/components/TagGroup'
 import { useQuery } from '@tanstack/react-query'
+import { TableSkeleton } from '~/components/Skeleton/TableSkeleton'
 
 const fetch = fetchWithErrorLogging
 
@@ -113,7 +114,7 @@ export default function TrendingContracts() {
 					/>
 				</div>
 				{isLoading ? (
-					<p className="text-center p-3">Loading...</p>
+					<TableSkeleton columns={7} rows={20} />
 				) : error ? (
 					<p className="text-center p-3">Sorry, couldn't fetch trending contracts.</p>
 				) : (

--- a/src/pages/yields/pool/[pool].tsx
+++ b/src/pages/yields/pool/[pool].tsx
@@ -21,6 +21,7 @@ import { Icon } from '~/components/Icon'
 import { CSVDownloadButton } from '~/components/ButtonStyled/CsvButton'
 import { BasicLink } from '~/components/Link'
 import { defaultPageStyles } from '~/containers/ProtocolOverview/queries'
+import { YieldPoolSkeleton } from 'src/components/Skeleton/YieldPoolSkeleton'
 
 const BarChart = dynamic(() => import('~/components/ECharts/BarChart'), {
 	ssr: false,
@@ -246,11 +247,7 @@ const PageView = (props) => {
 			riskData?.chain?.underlying?.some((c) => c?.rating))
 
 	if (isLoading) {
-		return (
-			<div className="flex items-center justify-center h-full rounded-md bg-[var(--cards-bg)]">
-				<p className="text-center">Loading...</p>
-			</div>
-		)
+		return <YieldPoolSkeleton />
 	}
 
 	return (


### PR DESCRIPTION
This is a proposal to start using skeletons in parts of the code where the data may be heavy and therefore the response time longer, offering users a much more "user-friendly" loading state.

In this first test just two pages were edited, specifically in two places where there was just a text showing "Loading..." as loading state like:

<img width="1512" height="782" alt="Screenshot 2025-07-12 at 12 42 41 PM" src="https://github.com/user-attachments/assets/aa0a8d79-8451-416d-a844-f1104ab59bd4" />

The added scenaries were: A detail page (Pool detail) and a table

<img width="1512" height="782" alt="Screenshot 2025-07-12 at 12 50 57 PM" src="https://github.com/user-attachments/assets/2b64e25f-4d59-4f52-8db1-14e1c1fde121" />

<img width="1512" height="782" alt="Screenshot 2025-07-12 at 12 51 40 PM" src="https://github.com/user-attachments/assets/609dfc69-cbbe-426b-bbea-0ac69340178a" />


