### PR TITLE
fix: QuestionHelper toggles on tap for coarse pointers

### DIFF
--- a/src/components/QuestionHelper.tsx
+++ b/src/components/QuestionHelper.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { Tooltip } from '~/components/Tooltip'
 import { Icon } from '~/components/Icon'
+import { useIsCoarsePointer } from '~/hooks/useIsCoarsePointer'
 
 export const QuestionHelper = React.memo(function QuestionHelper({
 	text,
@@ -11,8 +12,10 @@ export const QuestionHelper = React.memo(function QuestionHelper({
 	disabled?: boolean
 	className?: string
 }) {
+	const isCoarsePointer = useIsCoarsePointer()
+
 	return (
-		<Tooltip content={disabled ? null : text}>
+		<Tooltip content={disabled ? null : text} showOnTap={isCoarsePointer}>
 			<Icon name="help-circle" height={16} width={16} {...props} />
 		</Tooltip>
 	)

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -24,6 +24,7 @@ interface ITooltip {
 		| 'right'
 		| 'right-start'
 		| 'right-end'
+	showOnTap?: boolean
 }
 
 export function Tooltip({
@@ -33,9 +34,12 @@ export function Tooltip({
 	fontSize,
 	placement = 'top-start',
 	className,
+	showOnTap,
+	onClick,
 	...props
 }: ITooltip) {
 	const store = Ariakit.useTooltipStore({ placement })
+
 	if (!content || content === '') return <>{children}</>
 
 	return (
@@ -44,6 +48,9 @@ export function Tooltip({
 				store={store}
 				className={`flex items-center overflow-hidden text-ellipsis whitespace-nowrap shrink-0 ${className ?? ''}`}
 				render={<span />}
+				onClick={onClick ?? (showOnTap ? store.toggle : undefined)}
+				onMouseEnter={showOnTap ? undefined : store.show}
+				onMouseLeave={showOnTap ? undefined : store.hide}
 				{...props}
 			>
 				{children}

--- a/src/containers/ChainOverview/index.tsx
+++ b/src/containers/ChainOverview/index.tsx
@@ -130,5 +130,3 @@ const linksToOtherLlamaApps = [
 		)
 	}
 ]
-
-// #5C5CF9

--- a/src/hooks/useIsCoarsePointer.ts
+++ b/src/hooks/useIsCoarsePointer.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Detects whether the user's primary input mechanism is a coarse pointer (touch).
+ * Useful for adapting UI elements based on touch vs mouse interaction capabilities.
+ *
+ * @returns {boolean} Boolean indicating if the primary pointer is coarse (touch device)
+ */
+export function useIsCoarsePointer() {
+	const [isCoarsePointer, setIsCoarsePointer] = useState(false)
+
+	useEffect(() => {
+		const mq = window.matchMedia('(pointer: coarse)')
+		setIsCoarsePointer(mq.matches)
+
+		const handleChange = (e: MediaQueryListEvent) => setIsCoarsePointer(e.matches)
+		mq.addEventListener('change', handleChange)
+		return () => mq.removeEventListener('change', handleChange)
+	}, [])
+
+	return isCoarsePointer
+}


### PR DESCRIPTION
QuestionHelper never showed info on mobile even when tapping. Added `useIsCoarsePointer` to detect when user is interacting with a touchscreen and allowed Tooltip to be shown on tap. QuestionHelper now passes that prop to its `Tooltip`.


https://github.com/user-attachments/assets/9a41ba1f-5d79-4425-b7de-e75d0f6559d4

