### PR TITLE
fix: remove nfts/marketplaces table wash volume column

### DIFF
--- a/src/components/Table/Nfts/Marketplaces/columns.tsx
+++ b/src/components/Table/Nfts/Marketplaces/columns.tsx
@@ -109,16 +109,5 @@ export const columns: ColumnDef<INftMarketplace>[] = [
 			align: 'end',
 			headerHelperText: '7day rolling trades'
 		}
-	},
-	{
-		header: '% Wash Volume 7d',
-		accessorKey: 'washVolume7DPct',
-		size: 190,
-		cell: (info) => <>{info.getValue() ? (+info.getValue()).toFixed(2) + '%' : null}</>,
-		meta: {
-			align: 'end',
-			headerHelperText:
-				'% of inorganic trades relative to organic ones over last 7days rolling. All our values are exclusive of wash trades'
-		}
 	}
 ]

--- a/src/components/Table/Nfts/Marketplaces/index.tsx
+++ b/src/components/Table/Nfts/Marketplaces/index.tsx
@@ -43,12 +43,7 @@ export function NftsMarketplaceTable({ data }: { data: Array<INftMarketplace> })
 	return (
 		<>
 			<div className="relative w-full sm:max-w-[280px] ml-auto -mb-6">
-				<Icon
-					name="search"
-					height={16}
-					width={16}
-					className="absolute text-(--text3) top-0 bottom-0 my-auto left-2"
-				/>
+				<Icon name="search" height={16} width={16} className="absolute text-(--text3) top-0 bottom-0 my-auto left-2" />
 				<input
 					value={collectionName}
 					onChange={(e) => {

--- a/src/pages/nfts/marketplaces.tsx
+++ b/src/pages/nfts/marketplaces.tsx
@@ -35,7 +35,6 @@ function Marketplaces({
 }) {
 	const [dominanceChart, setDominanceChart] = React.useState(false)
 
-	//x
 	return (
 		<Layout title="NFT Marketplaces - DefiLlama" defaultSEO>
 			<NFTsSearch />


### PR DESCRIPTION
Currently the nfts api is never returning the exchange's wash volume data (https://github.com/DefiLlama/nft-server/blob/master/src/api/controllers/trades.js#L182) so no real reason to have the column visible.