### PR TITLE
fix: component enhancements and responsiveness for smaller screens

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"@tanstack/react-query-devtools": "5.61.3",
 		"@tanstack/react-table": "8.20.5",
 		"@tanstack/react-virtual": "3.10.9",
+		"clsx": "^2.1.1",
 		"colord": "2.9.3",
 		"dayjs": "1.11.3",
 		"echarts": "5.6.0",
@@ -49,6 +50,7 @@
 		"react-markdown": "^10.1.0",
 		"react-select": "5.3.2",
 		"swagger-ui-react": "^5.26.0",
+		"tailwind-merge": "^3.3.1",
 		"viem": "2.21.57",
 		"wagmi": "2.14.6"
 	},

--- a/src/components/ButtonStyled/CsvButton.tsx
+++ b/src/components/ButtonStyled/CsvButton.tsx
@@ -33,9 +33,12 @@ export const CSVDownloadButton = ({
 	return (
 		<>
 			<button
-				className={customClassName || `flex items-center gap-1 justify-center py-2 px-2 whitespace-nowrap text-xs rounded-md text-(--link-text) bg-(--link-bg) hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) disabled:opacity-50 disabled:cursor-not-allowed ${
-					className ?? ''
-				}`}
+				className={
+					customClassName ||
+					`flex items-center gap-1 justify-center py-2 px-2 whitespace-nowrap text-xs rounded-md text-(--link-text) bg-(--link-bg) hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) disabled:opacity-50 disabled:cursor-not-allowed min-w-fit ${
+						className ?? ''
+					}`
+				}
 				onClick={() => {
 					if (isLoading) return
 
@@ -49,7 +52,7 @@ export const CSVDownloadButton = ({
 			>
 				{isClient && isLoading ? (
 					<svg
-						className="animate-spin mx-auto h-[14px] w-[14px"
+						className="animate-spin mx-auto h-[14px] w-[14px] shrink-0"
 						xmlns="http://www.w3.org/2000/svg"
 						fill="none"
 						viewBox="0 0 24 24"
@@ -65,7 +68,7 @@ export const CSVDownloadButton = ({
 					<span>{customText}</span>
 				) : (
 					<>
-						<Icon name="download-paper" className="h-3 w-3" />
+						<Icon name="download-paper" className="h-3 w-3 shrink-0" />
 						<span>{smol ? '' : 'Download'} .csv</span>
 					</>
 				)}

--- a/src/components/Filters/FilterBetweenRange.tsx
+++ b/src/components/Filters/FilterBetweenRange.tsx
@@ -1,6 +1,7 @@
 import { FormEventHandler, ReactNode } from 'react'
 import * as Ariakit from '@ariakit/react'
 import { NestedMenu } from '~/components/NestedMenu'
+import { cn } from '~/utils/cn'
 
 interface IFilterBetweenRange {
 	name: string
@@ -10,6 +11,18 @@ interface IFilterBetweenRange {
 	min: string | null
 	max: string | null
 	variant?: 'primary' | 'secondary' | 'third'
+	triggerClassName?: string
+}
+
+const getVariantClasses = (variant: string) => {
+	switch (variant) {
+		case 'third':
+			return 'flex items-center justify-between gap-2 p-2 text-xs rounded-md cursor-pointer flex-nowrap relative border border-(--form-control-border) text-[#666] dark:text-[#919296] hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium'
+		case 'secondary':
+			return 'bg-(--btn-bg) hover:bg-(--btn-hover-bg) focus-visible:bg-(--btn-hover-bg) flex items-center justify-between gap-2 py-2 px-3 rounded-md cursor-pointer text-(--text1) text-xs flex-nowrap'
+		default:
+			return 'bg-(--btn2-bg)  hover:bg-(--btn2-hover-bg) focus-visible:bg-(--btn2-hover-bg) flex items-center justify-between gap-2 py-2 px-3 rounded-lg cursor-pointer text-(--text1) flex-nowrap relative'
+	}
 }
 
 export function FilterBetweenRange({
@@ -19,7 +32,8 @@ export function FilterBetweenRange({
 	nestedMenu,
 	min,
 	max,
-	variant = 'primary'
+	variant = 'primary',
+	triggerClassName
 }: IFilterBetweenRange) {
 	if (nestedMenu) {
 		return (
@@ -53,18 +67,9 @@ export function FilterBetweenRange({
 
 	return (
 		<Ariakit.PopoverProvider>
-			<Ariakit.PopoverDisclosure
-				data-variant={variant}
-				className={
-					variant === 'third'
-						? 'flex items-center justify-between gap-2 p-2 text-xs rounded-md cursor-pointer flex-nowrap relative border border-(--form-control-border) text-[#666] dark:text-[#919296] hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium'
-						: variant === 'secondary'
-						? 'bg-(--btn-bg) hover:bg-(--btn-hover-bg) focus-visible:bg-(--btn-hover-bg) flex items-center justify-between gap-2 py-2 px-3 rounded-md cursor-pointer text-(--text1) text-xs flex-nowrap'
-						: 'bg-(--btn2-bg)  hover:bg-(--btn2-hover-bg) focus-visible:bg-(--btn2-hover-bg) flex items-center justify-between gap-2 py-2 px-3 rounded-lg cursor-pointer text-(--text1) flex-nowrap relative'
-				}
-			>
+			<Ariakit.PopoverDisclosure data-variant={variant} className={cn(getVariantClasses(variant), triggerClassName)}>
 				{trigger}
-				<Ariakit.PopoverDisclosureArrow className="h-3 w-3" />
+				<Ariakit.PopoverDisclosureArrow className="h-3 w-3 shrink-0" />
 			</Ariakit.PopoverDisclosure>
 			<Ariakit.Popover
 				unmountOnHide

--- a/src/components/Filters/TVLRange.tsx
+++ b/src/components/Filters/TVLRange.tsx
@@ -3,10 +3,12 @@ import { FilterBetweenRange } from '~/components/Filters/FilterBetweenRange'
 
 export function TVLRange({
 	variant = 'primary',
-	nestedMenu
+	nestedMenu,
+	triggerClassName
 }: {
 	variant?: 'primary' | 'secondary' | 'third'
 	nestedMenu?: boolean
+	triggerClassName?: string
 }) {
 	const router = useRouter()
 
@@ -60,6 +62,7 @@ export function TVLRange({
 			nestedMenu={nestedMenu}
 			min={min}
 			max={max}
+			triggerClassName={triggerClassName}
 		/>
 	)
 }

--- a/src/components/SelectWithCombobox.tsx
+++ b/src/components/SelectWithCombobox.tsx
@@ -152,9 +152,9 @@ export function SelectWithCombobox({
 				>
 					{labelType === 'smol' ? (
 						<span className="flex items-center gap-1">
-							<span className="text-[10px] -my-2 rounded-full min-w-4 flex items-center justify-center border border-(--form-control-border) p-px">
+							<div className="text-[10px] rounded-full min-w-4 flex items-center justify-center border border-(--form-control-border) py-0.5 px-1 leading-none">
 								{selectedValues.length}
-							</span>
+							</div>
 							<span>{label}</span>
 						</span>
 					) : labelType === 'regular' && selectedValues.length > 0 ? (

--- a/src/components/TagGroup.tsx
+++ b/src/components/TagGroup.tsx
@@ -1,20 +1,31 @@
-interface IProps {
+import React from 'react'
+import { cn } from '~/utils/cn'
+
+interface IProps extends React.ComponentProps<'div'> {
 	selectedValue: string
 	setValue: (period: string) => void
 	values: Array<string>
 	style?: Record<string, string>
+	triggerClassName?: string
 }
 
-export const TagGroup = ({ selectedValue, setValue, values, style }: IProps) => {
+export const TagGroup = ({ selectedValue, setValue, values, style, className, triggerClassName, ...props }: IProps) => {
 	return (
 		<div
-			className="text-xs font-medium flex items-center rounded-md overflow-x-auto flex-nowrap w-fit border border-(--form-control-border) text-[#666] dark:text-[#919296]"
+			className={cn(
+				'text-xs font-medium flex items-center rounded-md overflow-x-auto flex-nowrap w-fit border border-(--form-control-border) text-[#666] dark:text-[#919296]',
+				className
+			)}
 			style={style}
+			{...props}
 		>
 			{values.map((value) => {
 				return (
 					<button
-						className="shrink-0 py-2 px-3 whitespace-nowrap hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) data-[active=true]:bg-(--old-blue) data-[active=true]:text-white"
+						className={cn(
+							'shrink-0 py-2 px-3 whitespace-nowrap hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) data-[active=true]:bg-(--old-blue) data-[active=true]:text-white',
+							triggerClassName
+						)}
 						data-active={value === selectedValue}
 						key={value}
 						onClick={() => setValue(value)}

--- a/src/containers/ChainOverview/Table.tsx
+++ b/src/containers/ChainOverview/Table.tsx
@@ -393,46 +393,56 @@ export const ChainProtocolsTable = ({
 
 	return (
 		<div className="bg-(--cards-bg) rounded-md border border-[#e6e6e6] dark:border-[#222324] isolate">
-			<div className="flex items-center justify-between flex-wrap gap-2 p-3">
-				<h3 className="text-lg font-semibold mr-auto">Protocol Rankings</h3>
-				<TagGroup
-					setValue={setFilter('category')}
-					selectedValue={filterState}
-					values={Object.values(TABLE_CATEGORIES) as Array<string>}
-				/>
-				<TagGroup
-					setValue={setFilter('period')}
-					selectedValue={filterState}
-					values={Object.values(TABLE_PERIODS) as Array<string>}
-				/>
-				<SelectWithCombobox
-					allValues={mergedColumns}
-					selectedValues={selectedColumns}
-					setSelectedValues={addColumn}
-					selectOnlyOne={addOnlyOneColumn}
-					toggleAll={toggleAllColumns}
-					clearAll={clearAllColumns}
-					nestedMenu={false}
-					label={'Columns'}
-					labelType="smol"
-					triggerProps={{
-						className:
-							'flex items-center justify-between gap-2 p-2 text-xs rounded-md cursor-pointer flex-nowrap relative border border-(--form-control-border) text-[#666] dark:text-[#919296] hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium'
-					}}
-					customFooter={
-						<button
-							className="w-full flex items-center gap-2 px-3 py-2 mt-2 rounded-md bg-(--btn-bg) hover:bg-(--btn-hover-bg) text-(--text1) text-xs font-medium border border-(--form-control-border)"
-							onClick={handleAddCustomColumn}
-							type="button"
-						>
-							<Icon name="plus" height={16} width={16} />
-							Add Custom Column
-						</button>
-					}
-					onEditCustomColumn={handleEditCustomColumn}
-					onDeleteCustomColumn={handleDeleteCustomColumn}
-				/>
-				<TVLRange variant="third" />
+			<div className="flex items-center gap-2 p-3 flex-wrap">
+				<div className="text-lg font-semibold flex grow w-full md:w-auto">Protocol Rankings</div>
+
+				<div className="flex items-center gap-2 max-md:w-full max-sm:flex-col">
+					<TagGroup
+						setValue={setFilter('category')}
+						selectedValue={filterState}
+						values={Object.values(TABLE_CATEGORIES) as Array<string>}
+						className="max-sm:w-full"
+						triggerClassName="inline-flex max-sm:flex-1 items-center justify-center whitespace-nowrap"
+					/>
+					<TagGroup
+						setValue={setFilter('period')}
+						selectedValue={filterState}
+						values={Object.values(TABLE_PERIODS) as Array<string>}
+						className="max-sm:w-full"
+						triggerClassName="inline-flex max-sm:flex-1 items-center justify-center whitespace-nowrap"
+					/>
+
+					<div className="flex items-center gap-2 w-full sm:w-auto">
+						<SelectWithCombobox
+							allValues={mergedColumns}
+							selectedValues={selectedColumns}
+							setSelectedValues={addColumn}
+							selectOnlyOne={addOnlyOneColumn}
+							toggleAll={toggleAllColumns}
+							clearAll={clearAllColumns}
+							nestedMenu={false}
+							label={'Columns'}
+							labelType="smol"
+							triggerProps={{
+								className:
+									'flex items-center justify-between gap-2 p-2 text-xs rounded-md cursor-pointer flex-nowrap relative border border-(--form-control-border) text-[#666] dark:text-[#919296] hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium w-full sm:w-auto'
+							}}
+							customFooter={
+								<button
+									className="w-full flex items-center gap-2 px-3 py-2 mt-2 rounded-md bg-(--btn-bg) hover:bg-(--btn-hover-bg) text-(--text1) text-xs font-medium border border-(--form-control-border)"
+									onClick={handleAddCustomColumn}
+									type="button"
+								>
+									<Icon name="plus" height={16} width={16} />
+									Add Custom Column
+								</button>
+							}
+							onEditCustomColumn={handleEditCustomColumn}
+							onDeleteCustomColumn={handleDeleteCustomColumn}
+						/>
+						<TVLRange variant="third" triggerClassName="w-full sm:w-auto" />
+					</div>
+				</div>
 			</div>
 			<VirtualTable instance={instance} />
 			<CustomColumnModal

--- a/src/containers/ChainsByCategory/Table.tsx
+++ b/src/containers/ChainsByCategory/Table.tsx
@@ -160,8 +160,8 @@ export function ChainsByCategoryTable({ data }: { data: Array<IFormattedDataWith
 
 	return (
 		<div className="bg-(--cards-bg) rounded-md isolate border border-[#e6e6e6] dark:border-[#222324]">
-			<div className="flex items-center justify-end flex-wrap gap-2 p-2">
-				<div className="relative w-full sm:max-w-[280px] mr-auto">
+			<div className="flex items-center justify-between flex-wrap gap-2 p-3">
+				<div className="relative w-full sm:max-w-[280px]">
 					<Icon
 						name="search"
 						height={16}
@@ -177,38 +177,43 @@ export function ChainsByCategoryTable({ data }: { data: Array<IFormattedDataWith
 						className="border border-(--form-control-border) w-full pl-7 pr-2 py-[6px] bg-white dark:bg-black text-black dark:text-white rounded-md text-sm"
 					/>
 				</div>
-				<SelectWithCombobox
-					allValues={DEFI_CHAINS_SETTINGS}
-					selectedValues={selectedAggregateTypes}
-					setSelectedValues={addAggrOption}
-					selectOnlyOne={addOnlyOneAggrOption}
-					toggleAll={toggleAllAggrOptions}
-					clearAll={clearAllAggrOptions}
-					nestedMenu={false}
-					label={'Group Chains'}
-					labelType="smol"
-					triggerProps={{
-						className:
-							'flex items-center justify-between gap-2 p-2 text-xs rounded-md cursor-pointer flex-nowrap relative border border-(--form-control-border) text-[#666] dark:text-[#919296] hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium'
-					}}
-				/>
-				<SelectWithCombobox
-					allValues={columnOptions}
-					selectedValues={selectedColumns}
-					setSelectedValues={addColumn}
-					selectOnlyOne={addOnlyOneColumn}
-					toggleAll={toggleAllColumns}
-					clearAll={clearAllColumns}
-					nestedMenu={false}
-					label={'Columns'}
-					labelType="smol"
-					triggerProps={{
-						className:
-							'flex items-center justify-between gap-2 p-2 text-xs rounded-md cursor-pointer flex-nowrap relative border border-(--form-control-border) text-[#666] dark:text-[#919296] hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium'
-					}}
-				/>
 
-				<TVLRange variant="third" />
+				<div className="flex items-center gap-2 max-sm:w-full max-sm:flex-col">
+					<div className="flex items-center gap-2 w-full sm:w-auto">
+						<SelectWithCombobox
+							allValues={DEFI_CHAINS_SETTINGS}
+							selectedValues={selectedAggregateTypes}
+							setSelectedValues={addAggrOption}
+							selectOnlyOne={addOnlyOneAggrOption}
+							toggleAll={toggleAllAggrOptions}
+							clearAll={clearAllAggrOptions}
+							nestedMenu={false}
+							label={'Group Chains'}
+							labelType="smol"
+							triggerProps={{
+								className:
+									'flex items-center justify-between gap-2 p-2 text-xs rounded-md cursor-pointer flex-nowrap relative border border-(--form-control-border) text-[#666] dark:text-[#919296] hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium w-full sm:w-auto'
+							}}
+						/>
+						<SelectWithCombobox
+							allValues={columnOptions}
+							selectedValues={selectedColumns}
+							setSelectedValues={addColumn}
+							selectOnlyOne={addOnlyOneColumn}
+							toggleAll={toggleAllColumns}
+							clearAll={clearAllColumns}
+							nestedMenu={false}
+							label={'Columns'}
+							labelType="smol"
+							triggerProps={{
+								className:
+									'flex items-center justify-between gap-2 p-2 text-xs rounded-md cursor-pointer flex-nowrap relative border border-(--form-control-border) text-[#666] dark:text-[#919296] hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium w-full sm:w-auto'
+							}}
+						/>
+					</div>
+
+					<TVLRange variant="third" triggerClassName="w-full sm:w-auto" />
+				</div>
 			</div>
 			<VirtualTable instance={instance} />
 		</div>

--- a/src/containers/RecentProtocols/Table.tsx
+++ b/src/containers/RecentProtocols/Table.tsx
@@ -144,8 +144,8 @@ export function RecentlyListedProtocolsTable({
 
 	return (
 		<div className="bg-(--cards-bg) border border-[#e6e6e6] dark:border-[#222324] rounded-md">
-			<div className="flex items-center justify-end flex-wrap gap-2 p-3">
-				<div className="relative w-full sm:max-w-[280px] mr-auto">
+			<div className="flex items-center justify-between flex-wrap gap-2 p-3">
+				<div className="relative w-full sm:max-w-[280px]">
 					<Icon
 						name="search"
 						height={16}
@@ -161,22 +161,28 @@ export function RecentlyListedProtocolsTable({
 						className="border border-(--form-control-border) w-full pl-7 pr-2 py-[6px] bg-white dark:bg-black text-black dark:text-white rounded-md text-sm"
 					/>
 				</div>
-				<SelectWithCombobox
-					label="Chains"
-					allValues={chainList}
-					clearAll={clearAllChains}
-					toggleAll={toggleAllChains}
-					selectOnlyOne={selectOnlyOneChain}
-					selectedValues={selectedChains}
-					setSelectedValues={selectChain}
-					labelType="smol"
-					triggerProps={{
-						className:
-							'flex items-center justify-between gap-2 p-2 text-xs rounded-md cursor-pointer flex-nowrap relative border border-(--form-control-border) text-[#666] dark:text-[#919296] hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium'
-					}}
-				/>
-				<TVLRange variant="third" />
-				{forkedList ? <HideForkedProtocols /> : null}
+
+				<div className="flex items-start sm:items-center gap-2 max-sm:w-full max-sm:flex-col">
+					<div className="flex items-center gap-2 w-full sm:w-auto">
+						<SelectWithCombobox
+							label="Chains"
+							allValues={chainList}
+							clearAll={clearAllChains}
+							toggleAll={toggleAllChains}
+							selectOnlyOne={selectOnlyOneChain}
+							selectedValues={selectedChains}
+							setSelectedValues={selectChain}
+							labelType="smol"
+							triggerProps={{
+								className:
+									'flex items-center justify-between gap-2 p-2 text-xs rounded-md cursor-pointer flex-nowrap relative border border-(--form-control-border) text-[#666] dark:text-[#919296] hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium w-full sm:w-auto'
+							}}
+						/>
+						<TVLRange variant="third" triggerClassName="w-full sm:w-auto" />
+					</div>
+
+					{forkedList ? <HideForkedProtocols /> : null}
+				</div>
 			</div>
 			<VirtualTable instance={instance} />
 		</div>

--- a/src/hooks/useMedia.tsx
+++ b/src/hooks/useMedia.tsx
@@ -1,26 +1,19 @@
 // adadpted from https://github.com/ariakit/ariakit
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
-function getInitialState(query: string, defaultState?: boolean) {
-	if (defaultState !== undefined) {
-		return defaultState
-	}
-	if (typeof document !== 'undefined') {
-		return window.matchMedia(query).matches
-	}
-	return false
-}
+export function useMedia(query: string) {
+	const [matches, setMatches] = useState(false)
 
-export function useMedia(query: string, defaultState?: boolean) {
-	const [matches, setMatches] = useState(getInitialState(query, defaultState))
+	const handleChange = useCallback((event: MediaQueryListEvent) => setMatches(event.matches), [])
 
 	useEffect(() => {
-		const mql = window.matchMedia(query)
-		setMatches(mql.matches)
-		const onChange = () => setMatches(!!mql.matches)
-		mql.addEventListener('change', onChange)
-		return () => mql.removeEventListener('change', onChange)
-	}, [query])
+		const result = matchMedia(query)
+		result.addEventListener('change', handleChange)
+
+		setMatches(result.matches)
+
+		return () => result.removeEventListener('change', handleChange)
+	}, [query, handleChange])
 
 	return matches
 }

--- a/src/pages/token-usage.tsx
+++ b/src/pages/token-usage.tsx
@@ -16,6 +16,7 @@ import { TokenLogo } from '~/components/TokenLogo'
 import { BasicLink } from '~/components/Link'
 import { fetchJson } from '~/utils/async'
 import { useMedia } from '~/hooks/useMedia'
+import { Switch } from '~/components/Switch'
 
 export const getStaticProps = withPerformanceLogging('tokenUsage', async () => {
 	const searchData = await getAllCGTokensList()
@@ -102,12 +103,12 @@ export default function Tokens({ searchData }) {
 					<></>
 				) : (
 					<>
-						<div className="flex items-center flex-wrap gap-4 justify-end p-3">
-							<h1 className="text-xl font-medium mr-auto">{`${tokenSymbol.toUpperCase()} usage in protocols`}</h1>
-							<CSVDownloadButton onClick={downloadCSV} />
-							<label className="flex items-center gap-2 cursor-pointer">
-								<input
-									type="checkbox"
+						<div className="flex items-center justify-between flex-wrap gap-2 p-3">
+							<div className="text-lg font-semibold flex grow w-full sm:w-auto">{`${tokenSymbol.toUpperCase()} usage in protocols`}</div>
+
+							<div className="flex items-center gap-2 max-sm:w-full">
+								<Switch
+									label="Include CEXs"
 									value="includeCentraliseExchanges"
 									checked={includeCentraliseExchanges}
 									onChange={() =>
@@ -121,8 +122,8 @@ export default function Tokens({ searchData }) {
 										)
 									}
 								/>
-								<span>Include CEXs</span>
-							</label>
+								<CSVDownloadButton onClick={downloadCSV} />
+							</div>
 						</div>
 
 						<Suspense

--- a/src/pages/token-usage.tsx
+++ b/src/pages/token-usage.tsx
@@ -15,6 +15,7 @@ import { ColumnDef, getCoreRowModel, getSortedRowModel, SortingState, useReactTa
 import { TokenLogo } from '~/components/TokenLogo'
 import { BasicLink } from '~/components/Link'
 import { fetchJson } from '~/utils/async'
+import { useMedia } from '~/hooks/useMedia'
 
 export const getStaticProps = withPerformanceLogging('tokenUsage', async () => {
 	const searchData = await getAllCGTokensList()
@@ -37,6 +38,7 @@ export const getStaticProps = withPerformanceLogging('tokenUsage', async () => {
 
 export default function Tokens({ searchData }) {
 	const router = useRouter()
+	const isSmall = useMedia(`(max-width: 639px)`)
 
 	const { token, includecex } = router.query
 
@@ -81,13 +83,16 @@ export default function Tokens({ searchData }) {
 	return (
 		<Layout title="Token Usage - DefiLlama" defaultSEO>
 			<Announcement notCancellable>This is not an exhaustive list</Announcement>
+
 			<DesktopSearch
 				data={searchData}
 				placeholder="Search tokens..."
 				data-alwaysdisplay
 				onItemClick={onItemClick}
 				customSearchRoute="/token-usage?token="
+				variant={isSmall ? 'secondary' : 'primary'}
 			/>
+
 			<div className="bg-(--cards-bg) rounded-md w-full">
 				{isLoading ? (
 					<div className="flex items-center justify-center mx-auto w-full my-32">

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+	return twMerge(clsx(inputs))
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3037,7 +3037,7 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
-clsx@2.1.1:
+clsx@2.1.1, clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
@@ -7152,6 +7152,11 @@ swagger-ui-react@^5.26.0:
     xml "=1.0.1"
     xml-but-prettier "^1.0.1"
     zenscroll "^4.0.2"
+
+tailwind-merge@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-3.3.1.tgz#a7e7db7c714f6020319e626ecfb7e7dac8393a4b"
+  integrity sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==
 
 tailwindcss@4.1.11, tailwindcss@^4.1.11:
   version "4.1.11"


### PR DESCRIPTION
Improve code maintainability, component reusability, and user interface responsiveness.

* Added `clsx` and `tailwind-merge` libraries to manage conditional class names and Tailwind CSS utility merging.

* Updated the `CSVDownloadButton` component.

| Before | After |
|--------|-------|
| <img width="395" height="94" alt="Screenshot 2025-07-12 at 16 38 00" src="https://github.com/user-attachments/assets/c7bf2181-465f-49fd-82b3-1561eda57c82" /> | <img width="395" height="85" alt="Screenshot 2025-07-12 at 16 39 11" src="https://github.com/user-attachments/assets/6008d6e9-ae1d-4753-996e-79597f477f86" /> |


* Improved the filters layout of tables like `ChainProtocolsTable`, `ChainsByCategoryTable`, and `RecentlyListedProtocolsTable` by making components responsive to smaller screens.

| Before | After |
|--------|-------|
| <img width="395" height="182" alt="Screenshot 2025-07-12 at 16 49 04" src="https://github.com/user-attachments/assets/53996496-af65-404d-a7e5-d2dafaf1d69b" /> | <img width="395" height="186" alt="Screenshot 2025-07-12 at 16 49 54" src="https://github.com/user-attachments/assets/fe32fe5e-589c-4c65-82dc-c0b8346cb9f6" /> |

| Before | After |
|--------|-------|
| <img width="395" height="143" alt="Screenshot 2025-07-12 at 16 52 43" src="https://github.com/user-attachments/assets/999538eb-ae6e-4d7b-a2b1-53bb892378e2" /> | <img width="395" height="147" alt="Screenshot 2025-07-12 at 16 53 23" src="https://github.com/user-attachments/assets/5f66bb6c-7540-4adb-bb82-e8f14d143f1e" /> |

| Before | After |
|--------|-------|
| <img width="395" height="135" alt="Screenshot 2025-07-12 at 16 55 42" src="https://github.com/user-attachments/assets/4761d7e9-2409-4f07-9dd2-e93d4ab56847" /> | <img width="395" height="135" alt="Screenshot 2025-07-12 at 16 56 04" src="https://github.com/user-attachments/assets/91d7b6e0-3be8-4b64-8fc0-6abb2d949796" /> |


* Refactor the `useMedia` hook and updated the `token-usage` page to adjust the `DesktopSearch` component's variant based on screen size.

| Before | After |
|--------|-------|
| <img width="395" height="155" alt="Screenshot 2025-07-12 at 17 15 02" src="https://github.com/user-attachments/assets/134150d0-4853-49b9-adc8-dead70055bd7" /> | <img width="395" height="155" alt="Screenshot 2025-07-12 at 17 15 08" src="https://github.com/user-attachments/assets/aa3fd5bb-4cc3-4002-b237-d4cd708b08b2" /> |


* Updated the `SelectWithCombobox` component for better pill shape.

| Before | After |
|--------|-------|
| <img width="395" height="143" alt="Screenshot 2025-07-12 at 17 26 29" src="https://github.com/user-attachments/assets/991a1a24-669d-4f35-8c60-d8f1e275f7cb" /> | <img width="395" height="96" alt="Screenshot 2025-07-12 at 17 27 06" src="https://github.com/user-attachments/assets/7b2d114d-0752-420c-98e8-719b13959d4a" /> |
