### PR TITLE
fix: tooltip positioning on RWA TVL and Stablecoins Market Cap cards

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -11,15 +11,37 @@ interface ITooltip {
 	color?: string
 	fontSize?: string
 	className?: string
-	placement?: 'top' | 'bottom' | 'left' | 'right'
+	placement?:
+		| 'top'
+		| 'top-start'
+		| 'top-end'
+		| 'bottom'
+		| 'bottom-start'
+		| 'bottom-end'
+		| 'left'
+		| 'left-start'
+		| 'left-end'
+		| 'right'
+		| 'right-start'
+		| 'right-end'
 }
 
-export function Tooltip({ content, children, color, fontSize, placement, className, ...props }: ITooltip) {
+export function Tooltip({
+	content,
+	children,
+	color,
+	fontSize,
+	placement = 'top-start',
+	className,
+	...props
+}: ITooltip) {
+	const store = Ariakit.useTooltipStore({ placement })
 	if (!content || content === '') return <>{children}</>
 
 	return (
-		<Ariakit.TooltipProvider>
+		<Ariakit.TooltipProvider store={store}>
 			<Ariakit.TooltipAnchor
+				store={store}
 				className={`flex items-center overflow-hidden text-ellipsis whitespace-nowrap shrink-0 ${className ?? ''}`}
 				render={<span />}
 				{...props}
@@ -28,8 +50,10 @@ export function Tooltip({ content, children, color, fontSize, placement, classNa
 			</Ariakit.TooltipAnchor>
 
 			<Ariakit.Tooltip
+				store={store}
 				className="text-sm p-2 max-w-56 whitespace-pre-wrap rounded-md bg-(--bg1) border border-[hsl(204,20%,88%)] dark:border-[hsl(204,3%,32%)] overflow-auto max-h-[80vh]"
 				unmountOnHide
+				portal
 			>
 				{content}
 			</Ariakit.Tooltip>

--- a/src/containers/ChainOverview/SmolStats.tsx
+++ b/src/containers/ChainOverview/SmolStats.tsx
@@ -160,6 +160,7 @@ export const SmolStats = (props: IChainOverviewData) => {
 					{rwaTvl ? (
 						<div className="col-span-1 h-[196px] bg-(--cards-bg) border border-(cards-border) rounded-md p-2 flex flex-col gap-1">
 							<Tooltip
+								placement="top-start"
 								render={
 									<BasicLink
 										href={props.metadata.name === 'All' ? '/protocols/rwa' : `/protocols/RWA/${props.metadata.name}`}
@@ -253,6 +254,7 @@ export const SmolStats = (props: IChainOverviewData) => {
 			{props.stablecoins?.mcapChartData?.length > 0 ? (
 				<div className="col-span-1 h-[196px] bg-(--cards-bg) border border-(cards-border) rounded-md p-2 flex flex-col gap-1">
 					<Tooltip
+						placement="top-start"
 						render={
 							<BasicLink
 								href={props.metadata.name === 'All' ? '/stablecoins' : `/stablecoins/${props.metadata.name}`}


### PR DESCRIPTION
Closes #1974

Fixed the tooltip position by creating a store with a defined placement (top-start) to control where the tooltip appears. Also enabled portal so the tooltip renders outside the card layout, avoiding issues like centering or clipping. Now appears correctly above the title, aligned to the left — consistent with the other cards.