### PR TITLE
fix: remove unused token logo

### DIFF
--- a/src/pages/borrow.tsx
+++ b/src/pages/borrow.tsx
@@ -179,7 +179,6 @@ const TokensSelect = ({
 				<Ariakit.Select className="bg-(--btn-bg) hover:bg-(--btn-hover-bg) focus-visible:bg-(--btn-hover-bg) flex items-center gap-2 p-3 text-base font-medium rounded-md cursor-pointer text-(--text1) flex-nowrap">
 					{tokenInSearchData ? (
 						<>
-							<TokenLogo logo={tokenInSearchData.image2} fallbackLogo={tokenInSearchData.image} />
 							<span>
 								{tokenInSearchData.symbol === 'USD_STABLES' ? tokenInSearchData.name : tokenInSearchData.symbol}
 							</span>


### PR DESCRIPTION
Token logos were removed from the /borrow page in [this commit](https://github.com/DefiLlama/defillama-app/commit/d5fadb5c0012ab9c411bd1251d4f0334506a0411), but one instance of tokenLogo remained in tokenSelect, resulting in rendering empty logo placeholders (because the backend dont send img data anymore)

Before: 
<img width="424" height="280" alt="Screenshot 2025-07-14 at 12 17 29" src="https://github.com/user-attachments/assets/1e9791e9-0215-4e02-b33d-3bda463cdc15" />

After: 
<img width="440" height="276" alt="Screenshot 2025-07-14 at 12 19 46" src="https://github.com/user-attachments/assets/5f996b59-a62e-442c-b871-f8c5881ea04b" />
