### PR TITLE
Fix: 'chains' column in /raises is too narrow

### DIFF
--- a/src/components/Table/Defi/columns.tsx
+++ b/src/components/Table/Defi/columns.tsx
@@ -178,7 +178,7 @@ export const raisesColumns: ColumnDef<IRaiseRow>[] = [
 		accessorKey: 'chains',
 		enableSorting: false,
 		cell: ({ getValue }) => <IconsRow links={getValue() as Array<string>} url="/chain" iconType="chain" />,
-		size: 60
+		size: 80
 	},
 	{
 		header: 'Other Investors',
@@ -506,12 +506,12 @@ export const activeInvestorsColumns: ColumnDef<{
 		enableSorting: false,
 		cell: ({ getValue }) => {
 			return (
-					<BasicLink
-						href={`/raises/${slug(getValue() as string)}`}
-						className="text-sm font-medium text-(--link-text) overflow-hidden whitespace-nowrap text-ellipsis hover:underline"
-					>
-						{getValue() as string}
-					</BasicLink>
+				<BasicLink
+					href={`/raises/${slug(getValue() as string)}`}
+					className="text-sm font-medium text-(--link-text) overflow-hidden whitespace-nowrap text-ellipsis hover:underline"
+				>
+					{getValue() as string}
+				</BasicLink>
 			)
 		},
 		size: 200


### PR DESCRIPTION
The width of chains column in raises table was too narrow to display two chains properly, cutting one icon in half. 
_Another option would be to change the `IconsRow` component to handle smaller sizes and wrap the icons, but I believe it'd be overkill, and displaying both icons fully should suffice in this case_

Before
<img width="539" height="113" alt="Screenshot 2025-07-14 at 14 13 19" src="https://github.com/user-attachments/assets/053c848d-c46b-4090-afb2-fbcfbe028f4c" />
After
<img width="532" height="98" alt="Screenshot 2025-07-14 at 14 17 14" src="https://github.com/user-attachments/assets/0bf209fe-eef2-414f-9fee-3a70374b75c2" />
