### PR TITLE
fix: calculation of median invested amount

### DIFF
--- a/src/pages/raises/investors.tsx
+++ b/src/pages/raises/investors.tsx
@@ -94,7 +94,7 @@ const ActiveInvestors = ({ data }) => {
 						.sort((a: [string, number], b: [string, number]) => b[1] - a[1])
 						.map((val) => val[0])
 
-					const medianAmount = findMedian(raises.map((r) => r?.amount))?.toFixed(2)
+					const medianAmount = findMedian(raises.map((r) => r?.amount).filter(Boolean))?.toFixed(2)
 
 					const totalAmount = sumBy(normalizedRaises, 'amount')
 					const averageAmount = totalAmount / normalizedRaises?.length || 0


### PR DESCRIPTION
Because of the unknown values of investments from certain funds, the median investment amount was not calculated correctly. I fixed this by excluding null values during the calculation process.

<img width="683" height="200" alt="Screenshot 2025-07-14 at 15 34 25" src="https://github.com/user-attachments/assets/1b3206db-8491-4c07-a912-7917f73c6b4d" />
