### PR TITLE
Fix: remove 'expandable' icon when there're no subrows

### DIFF
--- a/src/components/Table/Defi/columns.tsx
+++ b/src/components/Table/Defi/columns.tsx
@@ -438,24 +438,26 @@ export const governanceColumns: ColumnDef<IGovernance>[] = [
 					className="flex items-center gap-2 relative"
 					style={{ paddingLeft: row.depth ? row.depth * 48 : row.depth === 0 ? 24 : 0 }}
 				>
-					<button
-						className="absolute -left-[2px]"
-						{...{
-							onClick: row.getToggleExpandedHandler()
-						}}
-					>
-						{row.getIsExpanded() ? (
-							<>
-								<Icon name="chevron-down" height={16} width={16} />
-								<span className="sr-only">View child protocols</span>
-							</>
-						) : (
-							<>
-								<Icon name="chevron-right" height={16} width={16} />
-								<span className="sr-only">Hide child protocols</span>
-							</>
-						)}
-					</button>
+					{row.subRows?.length > 0 ? (
+						<button
+							className="absolute -left-[2px]"
+							{...{
+								onClick: row.getToggleExpandedHandler()
+							}}
+						>
+							{row.getIsExpanded() ? (
+								<>
+									<Icon name="chevron-down" height={16} width={16} />
+									<span className="sr-only">View child protocols</span>
+								</>
+							) : (
+								<>
+									<Icon name="chevron-right" height={16} width={16} />
+									<span className="sr-only">Hide child protocols</span>
+								</>
+							)}
+						</button>
+					) : null}
 					<span className="shrink-0">{index + 1}</span>
 					<TokenLogo logo={tokenIconUrl(getValue())} data-lgonly />
 					<BasicLink


### PR DESCRIPTION
The /governance table didn't have a check if the row has any subRows, and was always displaying the 'expandable' icon.

<img width="595" height="350" alt="Screenshot 2025-07-14 at 17 48 59" src="https://github.com/user-attachments/assets/76091c29-a282-424a-bd7c-5fcc5c1c6bd0" />
