### PR TITLE
UI fixes for Combobox popover

### DIFF
--- a/src/components/SelectWithCombobox.tsx
+++ b/src/components/SelectWithCombobox.tsx
@@ -184,7 +184,7 @@ export function SelectWithCombobox({
 					<Ariakit.Combobox
 						placeholder="Search..."
 						autoFocus
-						className="bg-white dark:bg-black rounded-md text-base py-1 px-3 m-3 mb-0"
+						className="bg-white dark:bg-black rounded-md text-base py-1 px-3 m-3 mb-2"
 					/>
 
 					{matches.length > 0 ? (

--- a/src/components/SelectWithCombobox.tsx
+++ b/src/components/SelectWithCombobox.tsx
@@ -178,7 +178,7 @@ export function SelectWithCombobox({
 					wrapperProps={{
 						className: 'max-sm:fixed! max-sm:bottom-0! max-sm:top-[unset]! max-sm:transform-none! max-sm:w-full!'
 					}}
-					className="flex flex-col bg-(--bg1) rounded-md max-sm:rounded-b-none z-10 overflow-auto overscroll-contain min-w-[180px] border border-[hsl(204,20%,88%)] dark:border-[hsl(204,3%,32%)] max-sm:drawer h-full max-h-[70vh] sm:max-h-[60vh]"
+					className="lg:max-h-[var(--popover-available-height)]! flex flex-col bg-(--bg1) rounded-md max-sm:rounded-b-none z-10 overflow-auto overscroll-contain min-w-[180px] border border-[hsl(204,20%,88%)] dark:border-[hsl(204,3%,32%)] max-sm:drawer h-full max-h-[70vh] sm:max-h-[60vh]"
 					portal={portal || false}
 				>
 					<Ariakit.Combobox


### PR DESCRIPTION
### BUGFIXES:
Fix two UI styling issues with the Combobox popover and search input field:
1. **ISSUE:** Bottom of search input field was getting cut off due to not enough space in its parent container. Adjusted the padding to fix this.

| Before  | After |
| ------------- | ------------- |
| <img width="262" height="334" alt="Screenshot 2025-07-14 at 5 05 35 PM" src="https://github.com/user-attachments/assets/0d89caed-ca99-455e-86d4-09525a0222f1" />  | <img width="258" height="344" alt="Screenshot 2025-07-14 at 5 08 21 PM" src="https://github.com/user-attachments/assets/f8d1244b-9590-4e8b-bcda-90ebc29810cf" />  |
2. **ISSUE:** When the Combobox popover was opened vertically, the top of it was getting cut off due to expanding beyond the top edge of the browser window. Fixed this by having it base its max height on the available space on desktop.

| Before  | After |
| ------------- | ------------- |
| <img width="300" alt="Screenshot 2025-07-14 at 5 17 13 PM" src="https://github.com/user-attachments/assets/9232ed01-df5f-4a1c-9625-e5405ed2d091" /> |  <img width="300" alt="Screenshot 2025-07-14 at 5 26 13 PM" src="https://github.com/user-attachments/assets/63515f07-63d1-4095-b604-85e9ef75371e" /> |