### PR TITLE
Fix: bug in navigation menu active link detection

### DIFF
--- a/src/components/Nav/Desktop/SubMenu.tsx
+++ b/src/components/Nav/Desktop/SubMenu.tsx
@@ -45,17 +45,21 @@ export const SubMenu = forwardRef<HTMLDetailsElement, { name: string }>(function
 			</summary>
 
 			<span className="my-4 flex flex-col gap-4">
-				{navLinks[name].main.map((subLink) => (
-					<BasicLink
-						href={subLink.path}
-						key={subLink.path}
-						data-linkactive={subLink.path === pathname}
-						className="-my-[6px] pl-7 rounded-md flex items-center gap-3 hover:bg-black/5 dark:hover:bg-white/10 focus-visible:bg-black/5 dark:focus-visible:bg-white/10 data-[linkactive=true]:bg-(--link-active-bg) data-[linkactive=true]:text-white p-[6px]"
-					>
-						<span>{subLink.name}</span>
-						{subLink.newTag === true ? <NewTag /> : null}
-					</BasicLink>
-				))}
+				{navLinks[name].main.map((subLink) => {
+					const isActive = subLink.path.split('?')[0] === pathname
+
+					return (
+						<BasicLink
+							href={subLink.path}
+							key={subLink.path}
+							data-linkactive={isActive}
+							className="-my-[6px] pl-7 rounded-md flex items-center gap-3 hover:bg-black/5 dark:hover:bg-white/10 focus-visible:bg-black/5 dark:focus-visible:bg-white/10 data-[linkactive=true]:bg-(--link-active-bg) data-[linkactive=true]:text-white p-[6px]"
+						>
+							<span>{subLink.name}</span>
+							{subLink.newTag === true ? <NewTag /> : null}
+						</BasicLink>
+					)
+				})}
 			</span>
 		</details>
 	)

--- a/src/components/Nav/Links.tsx
+++ b/src/components/Nav/Links.tsx
@@ -156,7 +156,7 @@ export const navLinks: ILinks = {
 			{ name: 'Top Protocols', path: '/top-protocols' },
 			{ name: 'Compare Protocols', path: '/compare-protocols?protocol=Sky&protocol=Curve+DEX' },
 			{ name: 'Protocol Expenses', path: '/expenses' },
-			{ name: 'Token Usage', path: '/tokenUsage?token=ETH' },
+			{ name: 'Token Usage', path: '/token-usage?token=ETH' },
 			{ name: 'Categories', path: '/categories' },
 			{ name: 'Recent', path: '/recent' },
 			{ name: 'Languages', path: '/languages' },


### PR DESCRIPTION
Active navigation link detection was faulty on links with queries e.g.`https://defillama.com/token-usage?token=ETH`

<img width="753" height="357" alt="Screenshot 2025-07-15 at 17 21 59" src="https://github.com/user-attachments/assets/370a732e-d239-4076-9327-e1ca7f0b8380" />

After the fix: 
<img width="530" height="355" alt="Screenshot 2025-07-15 at 18 05 37" src="https://github.com/user-attachments/assets/56f2696c-4cdb-4542-aabb-48d3266bee92" />
