### PR TITLE
Fix: invisible text with light theme

### DIFF
--- a/src/containers/ProtocolOverview/Emissions/UpcomingEvent.tsx
+++ b/src/containers/ProtocolOverview/Emissions/UpcomingEvent.tsx
@@ -245,11 +245,11 @@ export const UpcomingEvent = ({
 						<div className="flex space-x-2 items-center">
 							<div className="flex justify-between items-end" style={{ width: '150px' }}>
 								<div className="flex flex-col items-start">
-									<span className="text-white text-sm font-semibold">{formattedNum(tokenValue, true)}</span>
+									<span className="text-(--text1) text-sm font-semibold">{formattedNum(tokenValue, true)}</span>
 									<span className="text-(--text3) text-xs font-medium">Unlock Value</span>
 								</div>
 								<div className="flex flex-col items-end">
-									<span className="text-white text-sm font-semibold">{formattedNum(unlockPercentFloat)}%</span>
+									<span className="text-(--text1) text-sm font-semibold">{formattedNum(unlockPercentFloat)}%</span>
 									<span className="text-(--text3) text-xs font-medium">of float</span>
 								</div>
 							</div>


### PR DESCRIPTION
With light app theme, some text on /unlocks page was invisible because it was hardcoded to be white.

before
<img width="441" height="268" alt="Screenshot 2025-07-15 at 18 14 59" src="https://github.com/user-attachments/assets/0812de06-6fc8-425e-87ae-9d58776dc953" />

after
<img width="451" height="334" alt="Screenshot 2025-07-15 at 18 15 24" src="https://github.com/user-attachments/assets/71bc53c2-bbcf-4258-aa6e-a89db3042c98" />
