### PR TITLE
Feat: use branding colors for stablecoins charts

### DIFF
--- a/src/containers/Stablecoins/StablecoinsByChain.tsx
+++ b/src/containers/Stablecoins/StablecoinsByChain.tsx
@@ -413,7 +413,12 @@ const tokenColors = {
 	DAI: '#F4B731',
 	USDe: '#3A3A3A',
 	BUIDL: '#111111',
-	USD1: '#E7AC08'
+	USD1: '#D2B48C',
+	USDS: '#E67E22',
+	PYUSD: '#4A90E2',
+	USDTB: '#C0C0C0',
+	FDUSD: '#00FF00',
+	Others: '#FF1493'
 }
 
 export default PeggedAssetsOverview


### PR DESCRIPTION
Added branding colors for most popular stablecoins, instead of showing random colors on every page load

<img width="790" height="451" alt="Screenshot 2025-07-16 at 19 18 32" src="https://github.com/user-attachments/assets/9981cfce-b6a8-4aef-9089-ef0be3239975" />
