### PR TITLE
Add Reusable Pagination Component and Integrate with Protocol Tables

### DIFF
--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -1,0 +1,124 @@
+import React, { useMemo } from 'react'
+import { Icon } from '~/components/Icon'
+
+interface PaginationProps {
+	currentPage: number
+	totalPages: number
+	onPageChange: (page: number) => void
+	pageSize: number
+	onPageSizeChange: (size: number) => void
+	totalItems: number
+	showPageSizeSelector?: boolean
+	pageSizeOptions?: number[]
+}
+
+const defaultPageSizeOptions = [25, 50, 100] //number of items per page
+
+export const Pagination: React.FC<PaginationProps> = ({
+	currentPage,
+	totalPages,
+	onPageChange,
+	pageSize,
+	onPageSizeChange,
+	totalItems,
+	showPageSizeSelector = false,
+	pageSizeOptions = defaultPageSizeOptions
+}) => {
+	const visiblePages = useMemo(() => {
+		if (totalPages <= 1) return []
+
+		const delta = 2
+		const range = []
+		const rangeWithDots = []
+
+		for (let i = Math.max(2, currentPage - delta); i <= Math.min(totalPages - 1, currentPage + delta); i++) {
+			range.push(i)
+		}
+
+		if (currentPage - delta > 2) {
+			rangeWithDots.push(1, '...')
+		} else {
+			rangeWithDots.push(1)
+		}
+
+		rangeWithDots.push(...range)
+
+		if (currentPage + delta < totalPages - 1) {
+			rangeWithDots.push('...', totalPages)
+		} else {
+			rangeWithDots.push(totalPages)
+		}
+
+		return rangeWithDots
+	}, [currentPage, totalPages])
+
+	if (totalPages <= 1) return null
+	const startItem = (currentPage - 1) * pageSize + 1
+	const endItem = Math.min(currentPage * pageSize, totalItems)
+
+	return (
+		<div className="flex items-center justify-between flex-wrap gap-4 p-4 bg-(--cards-bg) border-t border-(--divider)">
+			<div className="text-sm text-(--text3)">
+				Showing {startItem} to {endItem} of {totalItems} protocols
+			</div>
+
+			<div className="flex items-center gap-4">
+				{showPageSizeSelector && (
+					<div className="flex items-center gap-2">
+						<span className="text-sm text-(--text3)">Show:</span>
+						<select
+							value={pageSize}
+							onChange={(e) => onPageSizeChange(Number(e.target.value))}
+							className="px-2 py-1 text-sm border border-(--form-control-border) rounded-md bg-(--cards-bg) text-(--text1) focus:outline-none focus:ring-2 focus:ring-(--old-blue)"
+						>
+							{pageSizeOptions.map((size) => (
+								<option key={size} value={size}>
+									{size}
+								</option>
+							))}
+						</select>
+					</div>
+				)}
+
+				<div className="flex items-center gap-1">
+					<button
+						onClick={() => onPageChange(currentPage - 1)}
+						disabled={currentPage === 1}
+						className="flex items-center justify-center w-8 h-8 text-sm border border-(--form-control-border) rounded-md bg-(--cards-bg) text-(--text1) hover:bg-(--link-hover-bg) focus:outline-none focus:ring-2 focus:ring-(--old-blue) disabled:opacity-50 disabled:cursor-not-allowed"
+						aria-label="Previous page"
+					>
+						<Icon name="chevron-left" height={16} width={16} />
+					</button>
+
+					{visiblePages.map((page, index) => (
+						<React.Fragment key={index}>
+							{page === '...' ? (
+								<span className="flex items-center justify-center w-8 h-8 text-sm text-(--text3)">...</span>
+							) : (
+								<button
+									onClick={() => onPageChange(page as number)}
+									className={`flex items-center justify-center w-8 h-8 text-sm border border-(--form-control-border) rounded-md focus:outline-none focus:ring-2 focus:ring-(--old-blue) ${
+										currentPage === page
+											? 'bg-(--old-blue) text-white border-(--old-blue)'
+											: 'bg-(--cards-bg) text-(--text1) hover:bg-(--link-hover-bg)'
+									}`}
+								>
+									{page}
+								</button>
+							)}
+						</React.Fragment>
+					))}
+
+					<button
+						onClick={() => onPageChange(currentPage + 1)}
+						disabled={currentPage === totalPages}
+						className="flex items-center justify-center w-8 h-8 text-sm border border-(--form-control-border) rounded-md bg-(--cards-bg) text-(--text1) hover:bg-(--link-hover-bg) focus:outline-none focus:ring-2 focus:ring-(--old-blue) disabled:opacity-50 disabled:cursor-not-allowed"
+						aria-label="Next page"
+					>
+						<Icon name="chevron-right" height={16} width={16} />
+					</button>
+				</div>
+			</div>
+		</div>
+	)
+}


### PR DESCRIPTION
**Summary**
This PR replaces the infinite row rendering in the Protocol ranking table with paginated tables, showing 50 rows per page by default. It introduces a reusable, accessible pagination component and integrates it into the main protocol views. The update improves performance and navigation for large datasets, while preserving all existing functionality such as sorting, filtering, and custom columns.

**Changes Made**

`src/components/Pagination/index.tsx`

A fully accessible and customizable pagination component with:
- Prev/Next navigation
- Smart page number display (with ellipses for large page counts)
- Page size selector (25, 50, 100)

**Table Enhancements**

`src/containers/ChainOverview/Table.tsx`

Integrated the new pagination component

- Resets pagination state on search and sort
- Paginated the filtered dataset to optimize performance
- Fully compatible with existing sorting/search features
- src/containers/ChainOverview/Table.tsx
- Switched to TanStack Table's native pagination helpers
- Pagination integrated alongside column management and filtering
- Reset behavior preserved on sort/filter changes
- Custom columns and column visibility remain fully functional

**Features**

- Smart pagination from TanStack Table’s getPaginationRowModel()
- Configurable page sizes (default: 50)
-  Pagination state syncs with filters/sorting

<img width="1897" height="887" alt="Screenshot 2025-07-17 004842" src="https://github.com/user-attachments/assets/5ac67efc-b64e-418e-ac07-0cc172f196e6" />

https://www.loom.com/share/f4acba4fc5344276b9ec4ad01dd6ad04?sid=dfdeef39-7d40-46c3-9963-32afeb02b028