### PR TITLE
feat: show full description on hover

### DIFF
--- a/src/containers/Stablecoins/Table/columns.tsx
+++ b/src/containers/Stablecoins/Table/columns.tsx
@@ -579,7 +579,7 @@ export const peggedChainsColumns: ColumnDef<IPeggedChain>[] = [
 
 			return (
 				<div className="w-full flex items-center justify-end gap-1">
-					<span>{`${value.name}: `}</span>
+					<span>{`${value.name}${value.value ? ':' : ''}`}</span>
 					<span>{formattedPercent(value.value, true)}</span>
 				</div>
 			)

--- a/src/pages/categories.tsx
+++ b/src/pages/categories.tsx
@@ -15,6 +15,7 @@ import { fetchJson } from '~/utils/async'
 import { DEFI_SETTINGS_KEYS, useLocalStorageSettingsManager } from '~/contexts/LocalStorage'
 import { SelectWithCombobox } from '~/components/SelectWithCombobox'
 import { tvlOptions } from '~/components/Filters/options'
+import { Tooltip } from '~/components/Tooltip'
 
 const LineAndBarChart = React.lazy(
 	() => import('~/components/ECharts/LineAndBarChart')
@@ -599,7 +600,15 @@ const categoriesColumn: ColumnDef<ICategoryRow>[] = [
 	{
 		header: 'Description',
 		accessorKey: 'description',
+		accessorFn: (protocol) => protocol.description ?? null,
+		cell: ({ getValue }) => (
+			<Tooltip content={getValue() as string}>
+				<span className="overflow-x-hidden text-ellipsis whitespace-normal line-clamp-1 min-w-0">
+					{getValue() as string}
+				</span>
+			</Tooltip>
+		),
 		enableSorting: false,
-		size: 1600
+		size: 400
 	}
 ]


### PR DESCRIPTION
Before: User need to scroll in x direction to read the full description

<img width="1146" height="871" alt="Screenshot 2025-07-17 141120" src="https://github.com/user-attachments/assets/5eff150c-f02a-41dc-931c-2351c4b447de" />

After: Full description is hidden by default and user needs to hover over to read the full description.

<img width="503" height="537" alt="Screenshot 2025-07-17 141032" src="https://github.com/user-attachments/assets/c255049a-ec07-49cd-ae7e-ccc3967e7048" />
