### PR TITLE
fix: tvl tab not found

### DIFF
--- a/src/pages/protocol/tvl/[...protocol].tsx
+++ b/src/pages/protocol/tvl/[...protocol].tsx
@@ -34,7 +34,7 @@ export const getStaticProps = withPerformanceLogging(
 			}
 		}
 
-		if (!metadata || !metadata[1].yields) {
+		if (!metadata || !metadata[1].tvl) {
 			return { notFound: true, props: null }
 		}
 


### PR DESCRIPTION
Added fix for incorrect reference to metadata property resulting in 404 error message

Before:
<img width="2560" height="1268" alt="rysk-v12-tvl-before" src="https://github.com/user-attachments/assets/946eb562-1f85-4647-9bf5-559e49d29b4d" />

After:
<img width="2560" height="1268" alt="rysk-v12-tvl-after" src="https://github.com/user-attachments/assets/0b66a7e7-08b8-4e4f-9b9d-7e85cb53c58e" />

However, there seems to be a persisting issue with the tvl tab not populating for certain protocols even after this change, e.g. Coinbase XRP

Before:
<img width="2560" height="1270" alt="coinbase-xrp-tvl-before" src="https://github.com/user-attachments/assets/f9428e2e-d4b2-4c48-a027-f22c8658a7d2" />

After:
<img width="2560" height="1268" alt="coinbase-xrp-tvl-after" src="https://github.com/user-attachments/assets/8d4f9e67-95bc-4957-95bf-6d2a2d1c2454" />