### PR TITLE
Feat: improvements to cex transparency page

### DIFF
--- a/src/components/Table/Defi/columns.tsx
+++ b/src/components/Table/Defi/columns.tsx
@@ -822,6 +822,39 @@ export const cexColumn: ColumnDef<any>[] = [
 		}
 	},
 	{
+		header: 'Spot Volume',
+		accessorKey: 'spotVolume',
+		accessorFn: (row) => row.spotVolume ?? undefined,
+		cell: (info) => (info.getValue() ? formattedNum(info.getValue(), true) : null),
+		sortUndefined: 'last',
+		size: 125,
+		meta: {
+			align: 'end'
+		}
+	},
+	{
+		header: '24h Open Interest',
+		accessorKey: 'oi',
+		accessorFn: (row) => row.oi ?? undefined,
+		cell: (info) => (info.getValue() ? formattedNum(info.getValue(), true) : null),
+		sortUndefined: 'last',
+		size: 160,
+		meta: {
+			align: 'end'
+		}
+	},
+	{
+		header: 'Avg Leverage',
+		accessorKey: 'leverage',
+		accessorFn: (row) => row.leverage ?? undefined,
+		cell: (info) => (info.getValue() ? Number(Number(info.getValue()).toFixed(2)) + 'x' : null),
+		sortUndefined: 'last',
+		size: 130,
+		meta: {
+			align: 'end'
+		}
+	},
+	{
 		header: 'Custom range Inflows',
 		accessorKey: 'customRange',
 		accessorFn: (row) => row.customRange ?? undefined,
@@ -857,40 +890,7 @@ export const cexColumn: ColumnDef<any>[] = [
 		header: 'Last audit date',
 		accessorKey: 'lastAuditDate',
 		cell: ({ getValue }) => <>{getValue() === undefined ? null : toNiceDayMonthAndYear(getValue())}</>,
-		size: 128,
-		meta: {
-			align: 'end'
-		}
-	},
-	{
-		header: 'Spot Volume',
-		accessorKey: 'spotVolume',
-		accessorFn: (row) => row.spotVolume ?? undefined,
-		cell: (info) => (info.getValue() ? formattedNum(info.getValue(), true) : null),
-		sortUndefined: 'last',
-		size: 125,
-		meta: {
-			align: 'end'
-		}
-	},
-	{
-		header: '24h Open Interest',
-		accessorKey: 'oi',
-		accessorFn: (row) => row.oi ?? undefined,
-		cell: (info) => (info.getValue() ? formattedNum(info.getValue(), true) : null),
-		sortUndefined: 'last',
-		size: 160,
-		meta: {
-			align: 'end'
-		}
-	},
-	{
-		header: 'Avg Leverage',
-		accessorKey: 'leverage',
-		accessorFn: (row) => row.leverage ?? undefined,
-		cell: (info) => (info.getValue() ? Number(Number(info.getValue()).toFixed(2)) + 'x' : null),
-		sortUndefined: 'last',
-		size: 120,
+		size: 130,
 		meta: {
 			align: 'end'
 		}

--- a/src/containers/Cexs/index.tsx
+++ b/src/containers/Cexs/index.tsx
@@ -13,7 +13,7 @@ import { useDateRangeValidation } from '~/hooks/useDateRangeValidation'
 
 const getOutflowsByTimerange = async (startTime, endTime) => {
 	if (startTime && endTime) {
-		const cexs = await Promise.all(
+		const cexsApiResults = await Promise.allSettled(
 			cexData.map(async (c) => {
 				if (c.slug === undefined) {
 					return [null, null]
@@ -24,6 +24,14 @@ const getOutflowsByTimerange = async (startTime, endTime) => {
 				}
 			})
 		)
+
+		const cexs = cexsApiResults
+			.map((result) => {
+				if (result.status === 'fulfilled') {
+					return result.value
+				}
+			})
+			.filter(Boolean)
 
 		return Object.fromEntries(cexs)
 	}

--- a/src/containers/Cexs/index.tsx
+++ b/src/containers/Cexs/index.tsx
@@ -18,7 +18,9 @@ const getOutflowsByTimerange = async (startTime, endTime) => {
 				if (c.slug === undefined) {
 					return [null, null]
 				} else {
-					const res = await fetchJson(`${INFLOWS_API}/${c.slug}/${startTime}?end=${endTime}`)
+					const res = await fetchJson(
+						`${INFLOWS_API}/${c.slug}/${startTime}?end=${endTime}&tokensToExclude=${c.coin ?? ''}`
+					)
 
 					return [c.slug, res]
 				}


### PR DESCRIPTION
Found some problems on /cexs page:
1. Custom range inflows column didn't have any data. The problem was that one of API calls was failing, and the whole promise.all didn't return any results, I've added a safeguard with promise.allSettled
2. The audit columns are empty for all but 2 exchanges – I moved them to the end of the table,  so the users wouldn't have to scroll through empty data to see spot volume/open interest
3. Minor one, but pre-fetched calls at getStaticProps had `tokensToExclude` with exchange' native tokens, while calls for custom time range were missing this query param

before
<img width="1251" height="744" alt="Screenshot 2025-07-19 at 11 19 05" src="https://github.com/user-attachments/assets/cd1c69a3-21f5-48df-9695-2b6a64f4e20b" />

after
<img width="1269" height="703" alt="Screenshot 2025-07-19 at 11 27 16" src="https://github.com/user-attachments/assets/b8419635-1395-473f-9799-01d77742cb98" />
