### PR TITLE
show full list of projects on hover in Raises/Investors

### DIFF
--- a/src/components/Table/Defi/columns.tsx
+++ b/src/components/Table/Defi/columns.tsx
@@ -565,20 +565,11 @@ export const activeInvestorsColumns: ColumnDef<{
 		enableSorting: false,
 		cell: ({ getValue }) => {
 			return (
-				<Ariakit.HovercardProvider>
-					<Ariakit.HovercardAnchor className="whitespace-nowrap text-ellipsis overflow-hidden">
-						{getValue() as string | null}
-					</Ariakit.HovercardAnchor>
-					<Ariakit.Hovercard
-						unmountOnHide
-						wrapperProps={{
-							className: 'max-sm:fixed! max-sm:bottom-0! max-sm:top-[unset]! max-sm:transform-none! max-sm:w-full!'
-						}}
-						className="max-w-xl z-10 p-1 shadow-sm rounded-md bg-(--bg2) border border-(--bg3) text-(--text1) flex items-center justify-start flex-wrap gap-1 bg-none overflow-hidden max-sm-drawer"
-					>
-						{getValue() as string | null}
-					</Ariakit.Hovercard>
-				</Ariakit.HovercardProvider>
+				<Tooltip content={getValue() as string}>
+					<span className="overflow-x-hidden text-ellipsis whitespace-normal line-clamp-1 min-w-0">
+						{getValue() as string}
+					</span>
+				</Tooltip>
 			)
 		},
 		size: 240


### PR DESCRIPTION
Before: Full list of projects not fully visible on hover,

<img width="712" height="62" alt="Screenshot 2025-07-21 183043" src="https://github.com/user-attachments/assets/04aad91e-de45-46cb-8f69-b79d77d52202" />

After: Full list of projects visible on hover.

<img width="320" height="420" alt="Screenshot 2025-07-21 183022" src="https://github.com/user-attachments/assets/f4a885da-8e12-4ec6-a780-a71e64de64f7" />
