### PR TITLE
Fix link to open protocol treasury chart

### DIFF
--- a/src/containers/Treasuries/index.tsx
+++ b/src/containers/Treasuries/index.tsx
@@ -120,7 +120,7 @@ export const columns: ColumnDef<any>[] = [
 					<span className="shrink-0">{index + 1}</span>
 					<TokenLogo logo={tokenIconUrl(name)} data-lgonly />
 					<BasicLink
-						href={`/protocol/${slug}?treasury=true`}
+						href={`/protocol/${slug}?treasury=true&tvl=false`}
 						className="text-sm font-medium text-(--link-text) overflow-hidden whitespace-nowrap text-ellipsis"
 					>
 						{name}


### PR DESCRIPTION
Links on the /treasuries page were using query fragments, which are not supported by the Protocol chart and weren't opening the treasury chart by default.

Before/after:


https://github.com/user-attachments/assets/6531ed4b-eaab-4ba9-bb69-95345bcf698e

