### PR TITLE
Fix: use fallback logo for nft collections

### DIFF
--- a/src/api/categories/nfts/index.ts
+++ b/src/api/categories/nfts/index.ts
@@ -302,6 +302,7 @@ export const getNFTRoyaltyHistory = async (slug: string) => {
 				name: collection[0].name,
 				displayName: collection[0].name,
 				logo: `https://nft-icons.llamao.fi/icons/nfts/${slug}?w=48&h=48`,
+				fallbackLogo: collection[0].image,
 				address: slug,
 				url: collection[0].projectUrl,
 				twitter: collection[0].twitterUsername,

--- a/src/pages/nfts/royalties/[...collection].tsx
+++ b/src/pages/nfts/royalties/[...collection].tsx
@@ -81,7 +81,7 @@ export default function Collection() {
 			<div className="grid grid-cols-2 relative isolate xl:grid-cols-3 gap-2 *:last:col-span-2">
 				<div className="bg-(--cards-bg) border border-(--cards-border) rounded-md flex flex-col gap-6 p-5 col-span-2 w-full xl:col-span-1 overflow-x-auto">
 					<h1 className="flex items-center gap-2 text-xl">
-						<TokenLogo logo={props.logo} size={48} />
+						<TokenLogo logo={props.logo} fallbackLogo={props.fallbackLogo} size={48} />
 						<FormattedName text={props.name} fontWeight={700} />
 					</h1>
 


### PR DESCRIPTION
These image links are already used in collections list on https://defillama.com/nfts/earnings, but individual collection' pages were trying to access logos from https://nft-icons.llamao.fi, which are, apparently, missing

<img width="695" height="143" alt="Screenshot 2025-07-22 at 20 50 54" src="https://github.com/user-attachments/assets/cc4c7136-e831-4c1f-93cb-6fc2d53de596" />

<img width="512" height="154" alt="Screenshot 2025-07-22 at 20 51 24" src="https://github.com/user-attachments/assets/72eb0c4d-69b9-40df-bbe1-c016d31cc86f" />

