### PR TITLE
Fix bug in hacks sum calculation

### DIFF
--- a/src/pages/hacks.tsx
+++ b/src/pages/hacks.tsx
@@ -23,9 +23,9 @@ export const getStaticProps = withPerformanceLogging('hacks', async () => {
 
 	const monthlyHacks = {}
 
-	data.forEach((r) => {
-		const monthlyDate = getFirstDateOfTheMonth(r.date)
-		monthlyHacks[monthlyDate] = (monthlyHacks[monthlyDate] ?? 0) + r.amount * 1e6
+	data.forEach((hack) => {
+		const monthlyDate = getFirstDateOfTheMonth(hack.date)
+		monthlyHacks[monthlyDate] = (monthlyHacks[monthlyDate] ?? 0) + hack.amount * 1e6
 	})
 
 	const totalHacked = formattedNum(
@@ -57,20 +57,18 @@ export const getStaticProps = withPerformanceLogging('hacks', async () => {
 	const sumDuplicates = (acc, obj) => {
 		const found = acc.find((o) => o.name === obj.name)
 		if (found) {
-			found.value += obj.value
+			found.value += obj.value * 1e6
 		} else {
-			acc.push(obj)
+			acc.push({ ...obj, value: obj.value * 1e6 })
 		}
 		return acc
 	}
 
-	const reducedData = onlyHacksTechnique.reduce(sumDuplicates, [])
-	const othersValue = reducedData.slice(15).reduce((total, entry) => total + entry.value, 0)
+	const groupedHacks = onlyHacksTechnique.reduce(sumDuplicates, []).toSorted((a, b) => b.value - a.value)
 
-	const pieChartData = [
-		...reducedData.sort((a, b) => b.value - a.value).slice(0, 15),
-		{ name: 'Others', value: othersValue }
-	]
+	const othersValue = groupedHacks.slice(15).reduce((total, entry) => total + entry.value, 0)
+
+	const pieChartData = [...groupedHacks.slice(0, 15), { name: 'Others', value: othersValue }]
 
 	return {
 		props: {

--- a/src/pages/hacks.tsx
+++ b/src/pages/hacks.tsx
@@ -66,9 +66,10 @@ export const getStaticProps = withPerformanceLogging('hacks', async () => {
 
 	const groupedHacks = onlyHacksTechnique.reduce(sumDuplicates, []).toSorted((a, b) => b.value - a.value)
 
+	const mainCategories = groupedHacks.slice(0, 15)
 	const othersValue = groupedHacks.slice(15).reduce((total, entry) => total + entry.value, 0)
 
-	const pieChartData = [...groupedHacks.slice(0, 15), { name: 'Others', value: othersValue }]
+	const pieChartData = [...mainCategories, { name: 'Others', value: othersValue }]
 
 	return {
 		props: {


### PR DESCRIPTION
1. The pie chart wasn't showing hacks sum properly by some orders of magnitude (thousands instead of billions)
<img width="573" height="242" alt="Screenshot 2025-07-23 at 22 02 16" src="https://github.com/user-attachments/assets/3ebae686-7549-4f63-afa2-4fc1a4aaa6c4" />

2. Sum of pieChart values was ~15billion, which is 3bil more than expected. There was a bug in calculation, caused by the 'others' value being taken by splitting unsorted array, which subsequently led to double counting of some hacks' categories