### PR TITLE
sources links light mode fix.

### DIFF
--- a/src/containers/ProtocolOverview/Emissions/index.tsx
+++ b/src/containers/ProtocolOverview/Emissions/index.tsx
@@ -563,7 +563,7 @@ const ChartContainer = ({ data, isEmissionsPage }: { data: IEmission; isEmission
 									key={source}
 									target="_blank"
 									rel="noopener noreferrer"
-									className="text-white text-base flex items-center font-medium gap-2"
+									className="text-base flex items-center font-medium gap-2"
 								>
 									<span>
 										{i + 1} {new URL(source).hostname}


### PR DESCRIPTION
Before: Links in Sources card not visible in light mode.

<img width="1580" height="147" alt="Screenshot 2025-07-25 111800" src="https://github.com/user-attachments/assets/1b51e327-c61f-4553-a573-301f8c8ff7e4" />

After:

<img width="1556" height="142" alt="Screenshot 2025-07-25 112840" src="https://github.com/user-attachments/assets/b6b547df-e24c-4fd5-80fd-7a8d9b00ab14" />
