### PR TITLE
Fix: Unlocks and allocation charts

### DIFF
--- a/src/components/ECharts/PieChart/index.tsx
+++ b/src/components/ECharts/PieChart/index.tsx
@@ -39,7 +39,7 @@ export default function PieChart({
 			name: '',
 			type: 'pie',
 			left: 0,
-			right: 0,
+			right: 200,
 			top: title ? 25 : 0,
 			bottom: 0,
 			label: {

--- a/src/containers/ProtocolOverview/Emissions/index.tsx
+++ b/src/containers/ProtocolOverview/Emissions/index.tsx
@@ -563,7 +563,7 @@ const ChartContainer = ({ data, isEmissionsPage }: { data: IEmission; isEmission
 									key={source}
 									target="_blank"
 									rel="noopener noreferrer"
-									className="text-white text-base flex items-center font-medium gap-2"
+									className="text-base flex items-center font-medium gap-2"
 								>
 									<span>
 										{i + 1} {new URL(source).hostname}


### PR DESCRIPTION
Before: Overlay between legends text and pie chart.

<img width="1568" height="508" alt="Screenshot 2025-07-25 114905" src="https://github.com/user-attachments/assets/0a302026-14c4-44ed-8cd7-b93eccd29357" />

After:
<img width="1568" height="482" alt="Screenshot 2025-07-25 114550" src="https://github.com/user-attachments/assets/a54265c9-dfda-4086-918f-81cf3680dde9" />
