### PR TITLE
Add marketShare7d to ProDashboard for DEXs and Aggregators

### DIFF
--- a/src/containers/ProDashboard/components/datasets/AggregatorsDataset/columns.tsx
+++ b/src/containers/ProDashboard/components/datasets/AggregatorsDataset/columns.tsx
@@ -70,6 +70,15 @@ export const aggregatorsDatasetColumns: ColumnDef<any>[] = [
 		cell: ({ getValue }) => <span className="font-mono pro-text2">{formattedNum(getValue() as number, true)}</span>
 	},
 	{
+		header: '7d Market Share',
+		accessorKey: 'marketShare7d',
+		size: 120,
+		cell: ({ getValue }) => {
+			const value = getValue() as number
+			return <span className="font-mono pro-text2">{formattedPercent(value)}</span>
+		}
+	},
+	{
 		header: '30d Volume',
 		accessorKey: 'total30d',
 		size: 120,

--- a/src/containers/ProDashboard/components/datasets/AggregatorsDataset/index.tsx
+++ b/src/containers/ProDashboard/components/datasets/AggregatorsDataset/index.tsx
@@ -20,6 +20,11 @@ import { LoadingSpinner } from '../../LoadingSpinner'
 import { useAggregatorsData } from './useAggregatorsData'
 import { TagGroup } from '~/components/TagGroup'
 import { ProTableCSVButton } from '../../ProTable/CsvButton'
+import { AggregatorItem } from '~/containers/ProDashboard/types'
+
+type AggregatorItemWithMarketShare = AggregatorItem & {
+	marketShare7d: number
+}
 
 export function AggregatorsDataset({ chains }: { chains?: string[] }) {
 	const [sorting, setSorting] = React.useState<SortingState>([{ id: 'total24h', desc: true }])
@@ -35,8 +40,19 @@ export function AggregatorsDataset({ chains }: { chains?: string[] }) {
 	const { data, isLoading, error, refetch } = useAggregatorsData(chains)
 	const windowSize = useWindowSize()
 
+	const enrichedData = React.useMemo<AggregatorItemWithMarketShare[]>(() => {
+		if (!data || data.length === 0) return []
+
+		const total7dGlobal = data.reduce((sum: number, item: AggregatorItem) => sum + (item.total7d || 0), 0)
+
+		return data.map((item: AggregatorItem) => ({
+			...item,
+			marketShare7d: total7dGlobal > 0 ? (item.total7d / total7dGlobal) * 100 : 0
+		}))
+	}, [data])
+
 	const instance = useReactTable({
-		data: data || [],
+		data: enrichedData,
 		columns: aggregatorsDatasetColumns as ColumnDef<any>[],
 		state: {
 			sorting,

--- a/src/containers/ProDashboard/components/datasets/AggregatorsDataset/useAggregatorsData.ts
+++ b/src/containers/ProDashboard/components/datasets/AggregatorsDataset/useAggregatorsData.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchJson } from '~/utils/async'
+import { AggregatorItem } from '~/containers/ProDashboard/types'
 
 export function useAggregatorsData(chains?: string[]) {
 	const queryParams =
@@ -7,7 +8,7 @@ export function useAggregatorsData(chains?: string[]) {
 
 	const sortedChains = chains ? [...chains].sort() : []
 
-	return useQuery({
+	return useQuery<AggregatorItem[]>({
 		queryKey: ['aggregators-overview', sortedChains.join(',')],
 		queryFn: () => fetchJson(`/api/datasets/aggregators${queryParams}`),
 		staleTime: 5 * 60 * 1000,

--- a/src/containers/ProDashboard/components/datasets/DexsDataset/columns.tsx
+++ b/src/containers/ProDashboard/components/datasets/DexsDataset/columns.tsx
@@ -69,6 +69,15 @@ export const dexsDatasetColumns: ColumnDef<any>[] = [
 		cell: ({ getValue }) => <span className="font-mono pro-text2">{formattedNum(getValue() as number, true)}</span>
 	},
 	{
+		header: '7d Market Share',
+		accessorKey: 'marketShare7d',
+		size: 120,
+		cell: ({ getValue }) => {
+			const value = getValue() as number
+			return <span className="font-mono pro-text2">{formattedPercent(value)}</span>
+		}
+	},
+	{
 		header: '30d Volume',
 		accessorKey: 'total30d',
 		size: 120,

--- a/src/containers/ProDashboard/components/datasets/DexsDataset/useDexsData.ts
+++ b/src/containers/ProDashboard/components/datasets/DexsDataset/useDexsData.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchJson } from '~/utils/async'
+import { DexItem } from '~/containers/ProDashboard/types'
 
 export function useDexsData(chains?: string[]) {
 	const queryParams =
@@ -7,7 +8,7 @@ export function useDexsData(chains?: string[]) {
 
 	const sortedChains = chains ? [...chains].sort() : []
 
-	return useQuery({
+	return useQuery<DexItem[]>({
 		queryKey: ['dexs-overview', sortedChains.join(',')],
 		queryFn: () => fetchJson(`/api/datasets/dexs${queryParams}`),
 		staleTime: 5 * 60 * 1000,

--- a/src/containers/ProDashboard/types.ts
+++ b/src/containers/ProDashboard/types.ts
@@ -189,5 +189,38 @@ export const getChainChartTypes = (): string[] => {
 	]
 }
 
+export interface BaseDatasetItem {
+	id: string
+	name: string
+	slug?: string
+	logo?: string
+	category?: string
+	chains?: string[]
+	total24h?: number
+	total7d?: number
+	total30d?: number
+	totalAllTime?: number
+	change_1d?: number
+	change_7d?: number
+}
+
+export interface DexItem extends BaseDatasetItem {
+	childProtocols?: Array<{
+		name: string
+		slug: string
+		logo?: string
+		chains?: string[]
+		category?: string
+		total24h?: number
+		total7d?: number
+		total30d?: number
+		total1y?: number
+		totalAllTime?: number
+		mcap?: number | null
+	}>
+}
+
+export interface AggregatorItem extends BaseDatasetItem {}
+
 export const isMulti = (x: DashboardItemConfig): x is MultiChartConfig => x.kind === 'multi'
 export const isText = (x: DashboardItemConfig): x is TextConfig => x.kind === 'text'


### PR DESCRIPTION
This PR adds the `marketShare7d` field to the Pro Dashboard tables for DEXs and Aggregators.

This request came from a user (attaching a screenshot).

As discussed in the `#feature-requests` channel on Discord, this metric is calculated client-side based on each protocol’s `total7d` relative to the global total.

Let me know if you’d also like this field added to the CSV export.

<img width="1397" height="144" alt="user-request-pro-dash" src="https://github.com/user-attachments/assets/aa9c583a-7ec2-449a-aef3-2b73d4bbfa42" />
