### PR TITLE
Feat: protocol unlocks page style changes

### DIFF
--- a/src/components/ECharts/UnlocksChart/index.tsx
+++ b/src/components/ECharts/UnlocksChart/index.tsx
@@ -36,7 +36,6 @@ export default function AreaChart({
 
 	const defaultChartSettings = useDefaults({
 		color,
-		title,
 		valueSymbol,
 		tooltipSort,
 		hideLegend: true,
@@ -46,7 +45,6 @@ export default function AreaChart({
 
 	const usdChartSettings = useDefaults({
 		color,
-		title,
 		valueSymbol: '$',
 		tooltipSort,
 		hideLegend: true,
@@ -228,7 +226,7 @@ export default function AreaChart({
 		// create instance
 		const chartInstance = createInstance()
 
-		const { graphic, titleDefaults, grid, tooltip, xAxis, yAxis, dataZoom } = defaultChartSettings
+		const { graphic, tooltip, xAxis, yAxis, dataZoom } = defaultChartSettings
 
 		for (const option in chartOptions) {
 			if (defaultChartSettings[option]) {
@@ -239,17 +237,16 @@ export default function AreaChart({
 		}
 
 		chartInstance.setOption({
-			graphic: { ...graphic },
-			tooltip: {
-				...tooltip
+			graphic,
+			tooltip,
+			grid: {
+				left: 12,
+				bottom: 68,
+				top: 12,
+				right: 12,
+				containLabel: true
 			},
-			title: {
-				...titleDefaults
-			},
-			grid: { ...grid },
-			xAxis: {
-				...xAxis
-			},
+			xAxis,
 			yAxis: [
 				{
 					...yAxis,
@@ -277,7 +274,7 @@ export default function AreaChart({
 					}
 				}))
 			].filter(Boolean),
-			dataZoom: [...dataZoom],
+			dataZoom,
 			series
 		})
 
@@ -303,31 +300,33 @@ export default function AreaChart({
 	])
 
 	const legendTitle = customLegendName === 'Category' && legendOptions.length > 1 ? 'Categories' : customLegendName
-
+	const showLegend = customLegendName && customLegendOptions?.length > 1 ? true : false
 	return (
-		<div
-			className="relative *:[&[role='combobox']]:ml-auto *:[&[role='combobox']]:mr-3 *:[&[role='combobox']]:mt-3"
-			{...props}
-		>
-			{customLegendName && customLegendOptions?.length > 1 && (
-				<SelectWithCombobox
-					allValues={customLegendOptions}
-					selectedValues={legendOptions}
-					setSelectedValues={setLegendOptions}
-					selectOnlyOne={(newOption) => {
-						setLegendOptions([newOption])
-					}}
-					label={legendTitle}
-					clearAll={() => setLegendOptions([])}
-					toggleAll={() => setLegendOptions(customLegendOptions)}
-					labelType="smol"
-					triggerProps={{
-						className:
-							'flex items-center justify-between gap-2 p-2 text-xs rounded-md cursor-pointer flex-nowrap relative border border-(--form-control-border) text-[#666] dark:text-[#919296] hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium z-10'
-					}}
-					portal
-				/>
-			)}
+		<div className="relative" {...props}>
+			{title || showLegend ? (
+				<div className="flex justify-end items-center gap-2 mb-2 px-2">
+					{title && <h1 className="text-lg mr-auto font-bold">{title}</h1>}
+					{customLegendName && customLegendOptions?.length > 1 && (
+						<SelectWithCombobox
+							allValues={customLegendOptions}
+							selectedValues={legendOptions}
+							setSelectedValues={setLegendOptions}
+							selectOnlyOne={(newOption) => {
+								setLegendOptions([newOption])
+							}}
+							label={legendTitle}
+							clearAll={() => setLegendOptions([])}
+							toggleAll={() => setLegendOptions(customLegendOptions)}
+							labelType="smol"
+							triggerProps={{
+								className:
+									'flex items-center justify-between gap-2 py-[6px] px-2 text-xs rounded-md cursor-pointer flex-nowrap relative border border-(--form-control-border) text-[#666] dark:text-[#919296] hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium'
+							}}
+							portal
+						/>
+					)}
+				</div>
+			) : null}
 			<div id={id} className="min-h-[360px] my-auto" style={height ? { height } : undefined} />
 		</div>
 	)

--- a/src/containers/ProtocolOverview/Emissions/Pagination.tsx
+++ b/src/containers/ProtocolOverview/Emissions/Pagination.tsx
@@ -111,14 +111,16 @@ const Pagination = ({ items, startIndex = 0 }) => {
 		<>
 			<div
 				ref={paginationRef}
-				className="flex items-center justify-center rounded-xl bg-(--bg6) w-full relative"
+				className="flex items-center justify-center rounded-xl w-full relative"
 				onTouchStart={onTouchStart}
 				onTouchMove={onTouchMove}
 				onTouchEnd={onTouchEnd}
 			>
-				<button onClick={handlePrevPage} className="bg-(--bg2) text-(--text1) p-2 rounded-xl hidden md:block">
-					<Icon name="arrow-left" height={24} width={24} />
-				</button>
+				{totalPages > 1 && (
+					<button onClick={handlePrevPage} className="bg-(--bg2) text-(--text1) p-2 rounded-xl hidden md:block">
+						<Icon name="arrow-left" height={24} width={24} />
+					</button>
+				)}
 				<div className="flex items-center justify-start overflow-hidden flex-1">
 					<div style={contentStyle}>
 						{currentItems.map((item, index) => (
@@ -128,9 +130,11 @@ const Pagination = ({ items, startIndex = 0 }) => {
 						))}
 					</div>
 				</div>
-				<button onClick={handleNextPage} className="bg-(--bg2) text-(--text1) p-2 rounded-xl hidden md:block">
-					<Icon name="arrow-right" height={24} width={24} />
-				</button>
+				{totalPages > 1 && (
+					<button onClick={handleNextPage} className="bg-(--bg2) text-(--text1) p-2 rounded-xl hidden md:block">
+						<Icon name="arrow-right" height={24} width={24} />
+					</button>
+				)}
 			</div>
 
 			{totalPages > 1 && (

--- a/src/containers/ProtocolOverview/Emissions/index.tsx
+++ b/src/containers/ProtocolOverview/Emissions/index.tsx
@@ -402,7 +402,7 @@ const ChartContainer = ({ data, isEmissionsPage }: { data: IEmission; isEmission
 				</div>
 			)}
 
-			<div className="flex flex-col gap-1">
+			<div className="flex flex-col gap-2">
 				{categoriesFromData.length > 0 && rawChartData.length > 0 && (
 					<LazyChart className="bg-(--cards-bg) border border-(--cards-border) rounded-md min-h-[384px] p-3 relative">
 						<div className="absolute right-4 z-10">
@@ -455,7 +455,7 @@ const ChartContainer = ({ data, isEmissionsPage }: { data: IEmission; isEmission
 					</LazyChart>
 				)}
 
-				<div className="grid grid-cols-2 gap-1">
+				<div className="grid grid-cols-2 gap-2">
 					{data.pieChartData?.[dataType] && data.stackColors[dataType] && (
 						<LazyChart className="relative col-span-full p-3 min-h-[384px] bg-(--cards-bg) border border-(--cards-border) rounded-md flex flex-col xl:col-span-1 xl:[&:last-child:nth-child(2n-1)]:col-span-full">
 							<Suspense fallback={<></>}>
@@ -553,7 +553,7 @@ const ChartContainer = ({ data, isEmissionsPage }: { data: IEmission; isEmission
 				</div>
 			) : null}
 
-			<div className="flex flex-wrap *:flex-1 gap-4">
+			<div className="flex flex-wrap *:flex-1 gap-2">
 				{data.sources?.length > 0 ? (
 					<div className="flex flex-col items-center justify-start p-3 w-full bg-(--cards-bg) border border-(--cards-border) rounded-md h-full">
 						<h1 className="text-center text-xl font-medium">Sources</h1>

--- a/src/containers/ProtocolOverview/Emissions/index.tsx
+++ b/src/containers/ProtocolOverview/Emissions/index.tsx
@@ -527,7 +527,7 @@ const ChartContainer = ({ data, isEmissionsPage }: { data: IEmission; isEmission
 			</div>
 
 			{data.events?.length > 0 ? (
-				<div className="flex flex-col items-center justify-start p-3 w-full bg-(--cards-bg) border border-(--cards-border) rounded-md h-full">
+				<div className="flex flex-col items-center justify-start p-3 w-full bg-(--cards-bg) border border-(--cards-border) rounded-md">
 					<h1 className="text-center text-xl font-semibold">Unlock Events</h1>
 
 					<Pagination

--- a/src/containers/ProtocolOverview/Emissions/index.tsx
+++ b/src/containers/ProtocolOverview/Emissions/index.tsx
@@ -404,8 +404,8 @@ const ChartContainer = ({ data, isEmissionsPage }: { data: IEmission; isEmission
 
 			<div className="flex flex-col gap-2">
 				{categoriesFromData.length > 0 && rawChartData.length > 0 && (
-					<LazyChart className="bg-(--cards-bg) border border-(--cards-border) rounded-md min-h-[384px] p-3 relative">
-						<div className="absolute right-4 z-10">
+					<LazyChart className="bg-(--cards-bg) border border-(--cards-border) rounded-md pt-2 relative min-h-[406px]">
+						<div className="absolute right-2 z-10">
 							<SelectWithCombobox
 								allValues={availableCategories}
 								selectedValues={selectedCategories}
@@ -437,7 +437,7 @@ const ChartContainer = ({ data, isEmissionsPage }: { data: IEmission; isEmission
 								labelType="smol"
 								triggerProps={{
 									className:
-										'flex items-center justify-between gap-2 p-2 text-xs rounded-md cursor-pointer flex-nowrap relative border border-[#E6E6E6] dark:border-[#2F3336] text-[#666] dark:text-[#919296] hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium'
+										'flex items-center justify-between gap-2 py-[6px] px-2 text-xs rounded-md cursor-pointer flex-nowrap relative border border-(--form-control-border) text-[#666] dark:text-[#919296] hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium'
 								}}
 							/>
 						</div>
@@ -455,9 +455,9 @@ const ChartContainer = ({ data, isEmissionsPage }: { data: IEmission; isEmission
 					</LazyChart>
 				)}
 
-				<div className="grid grid-cols-2 gap-2">
+				<div className="grid grid-cols-2 gap-2 min-h-[398px]">
 					{data.pieChartData?.[dataType] && data.stackColors[dataType] && (
-						<LazyChart className="relative col-span-full p-3 min-h-[384px] bg-(--cards-bg) border border-(--cards-border) rounded-md flex flex-col xl:col-span-1 xl:[&:last-child:nth-child(2n-1)]:col-span-full">
+						<LazyChart className="relative col-span-full pt-2 min-h-[398px] bg-(--cards-bg) border border-(--cards-border) rounded-md flex flex-col xl:col-span-1 xl:[&:last-child:nth-child(2n-1)]:col-span-full">
 							<Suspense fallback={<></>}>
 								<PieChart
 									showLegend
@@ -474,7 +474,7 @@ const ChartContainer = ({ data, isEmissionsPage }: { data: IEmission; isEmission
 					)}
 
 					{unlockedPercent > 0 && (
-						<LazyChart className="relative col-span-full p-3 min-h-[384px] bg-(--cards-bg) border border-(--cards-border) rounded-md flex flex-col xl:col-span-1 xl:[&:last-child:nth-child(2n-1)]:col-span-full">
+						<LazyChart className="relative col-span-full pt-2 min-h-[398px] bg-(--cards-bg) border border-(--cards-border) rounded-md flex flex-col xl:col-span-1 xl:[&:last-child:nth-child(2n-1)]:col-span-full">
 							<Suspense fallback={<></>}>
 								<PieChart
 									formatTooltip={unlockedPieChartFormatTooltip}

--- a/src/pages/protocol/unlocks/[...protocol].tsx
+++ b/src/pages/protocol/unlocks/[...protocol].tsx
@@ -60,7 +60,7 @@ export default function Protocols({ clientSide, protocolData, ...props }) {
 			tab="unlocks"
 			warningBanners={props.warningBanners}
 		>
-			<div className="bg-(--cards-bg) border border-(--cards-border) rounded-md">
+			<div className="flex flex-col gap-2 rounded-md">
 				<UnlocksCharts protocolName={props.name} />
 			</div>
 		</ProtocolOverviewLayout>


### PR DESCRIPTION
What initially caught my eye was a bug with height of the 'unlock events' card, but I also
- fixed pagination component so it won't render arrows when there's only 1 page
- modified gaps between cards & background colors to align with app' common style approach

https://github.com/user-attachments/assets/26a06703-63e0-44b3-8092-9c0f570457a3

