### PR TITLE
Fix Announcement Dismissal on First Render

### DIFF
--- a/src/components/Announcement.tsx
+++ b/src/components/Announcement.tsx
@@ -52,6 +52,12 @@ export function Announcement({
 	const routeAnnouncementKey = router.pathname + key
 	const routeAnnouncementValue = router.pathname + value
 
+	const [hydrated, setHydrated] = React.useState(false)
+
+	React.useEffect(() => {
+		setHydrated(true)
+	}, [])
+
 	const closeAnnouncement = () => {
 		localStorage.setItem(routeAnnouncementKey, JSON.stringify({ value: routeAnnouncementValue }))
 		window.dispatchEvent(new Event('storage'))
@@ -59,11 +65,21 @@ export function Announcement({
 
 	const store = React.useSyncExternalStore(
 		subscribeToLocalStorage,
-		() => localStorage.getItem(routeAnnouncementKey) ?? null,
+		() => (typeof window !== 'undefined' ? localStorage.getItem(routeAnnouncementKey) ?? null : null),
 		() => null
 	)
 
-	if (notCancellable ? false : JSON.parse(store)?.value === routeAnnouncementValue) {
+	let parsed
+	try {
+		parsed = store ? JSON.parse(store) : null
+	} catch {
+		parsed = null
+	}
+
+	// Wait for hydration before rendering
+	if (!hydrated) return null
+
+	if (notCancellable ? false : parsed?.value === routeAnnouncementValue) {
 		return null
 	}
 


### PR DESCRIPTION
**Changes Made**

- Added hydration check using useState and useEffect to prevent rendering before client-side hydration.
- Updated `useSyncExternalStore `to safely access localStorage only after hydration.
- Wrapped `JSON.parse` in try-catch to prevent runtime errors.
- Ensured dismissal state persists across reloads and tabs via localStorage and storage event.

<img width="1907" height="910" alt="Screenshot 2025-07-31 230603" src="https://github.com/user-attachments/assets/ee585ac9-a930-496a-966c-10b52730fe14" />
