### PR TITLE
Fix: minor charts improvements

### DIFF
--- a/src/api/categories/protocols/index.ts
+++ b/src/api/categories/protocols/index.ts
@@ -466,6 +466,7 @@ export async function getLSDPageData() {
 	let lsdApy = pools
 		.filter((p) => lsdProtocolsSlug.includes(p.project) && p.chain === 'Ethereum' && p.symbol.includes('ETH'))
 		.concat(pools.find((i) => i.project === 'crypto.com-staked-eth'))
+		.filter(Boolean)
 		.map((p) => ({
 			...p,
 			name: p.project

--- a/src/containers/Hacks/index.tsx
+++ b/src/containers/Hacks/index.tsx
@@ -114,7 +114,7 @@ const HacksContainer = ({ data, monthlyHacks, totalHacked, totalHackedDefi, tota
 					</p>
 				</div>
 				<div className="bg-(--cards-bg) border border-(--cards-border) rounded-md flex flex-col col-span-2 min-h-[360px]">
-					<div className="flex items-center p-3 -mb-12">
+					<div className="flex items-center p-3">
 						<ChartSelector options={chartTypeList} selectedChart={chartType} onClick={setChartType} />
 					</div>
 

--- a/src/pages/lst.tsx
+++ b/src/pages/lst.tsx
@@ -4,7 +4,7 @@ import { ProtocolsChainsSearch } from '~/components/Search/ProtocolsChains'
 import { maxAgeForNext } from '~/api'
 import { getLSDPageData } from '~/api/categories/protocols'
 import { withPerformanceLogging } from '~/utils/perf'
-import { formattedNum, firstDayOfMonth, lastDayOfWeek } from '~/utils'
+import { formattedNum, firstDayOfMonth, lastDayOfWeek, preparePieChartData } from '~/utils'
 import type { IBarChartProps, IChartProps, IPieChartProps } from '~/components/ECharts/types'
 import { TableWithSearch } from '~/components/Table/TableWithSearch'
 import { LSDColumn } from '~/components/Table/Defi/columns'
@@ -411,7 +411,12 @@ async function getChartData({ chartData, lsdRates, lsdApy, lsdColors }) {
 		}
 	})
 
-	const pieChartData = tokenTvls.map((p) => ({ name: p.name, value: p.stakedEth }))
+	const pieChartData = preparePieChartData({
+		data: tokenTvls,
+		sliceIdentifier: 'name',
+		sliceValue: 'stakedEth',
+		limit: 10
+	})
 
 	const tokens = tokensList.map((p) => p.name)
 


### PR DESCRIPTION
- Limited the number of items on lst chart, as it was pretty hard to read
<img width="548" height="534" alt="Screenshot 2025-08-01 at 12 55 12" src="https://github.com/user-attachments/assets/95d0ee30-257a-4233-a824-0a059bb45214" />

- Fixed the filter overlapping the chart title
<img width="225" height="145" alt="Screenshot 2025-08-01 at 12 44 38" src="https://github.com/user-attachments/assets/5c2cbdcf-79cf-4ef5-a06d-527b77f39052" />

- the /lst page was failing to load for me because the `.concat(pools.find((i) => i.project === 'crypto.com-staked-eth'))` was resulting in `undefined` added to the pools array. Added a safeguard