### PR TITLE
Add `category` column to raises table

### DIFF
--- a/src/components/Table/Defi/columns.tsx
+++ b/src/components/Table/Defi/columns.tsx
@@ -128,6 +128,15 @@ export const raisesColumns: ColumnDef<IRaiseRow>[] = [
 	},
 	{ header: 'Round', accessorKey: 'round', enableSorting: false, size: 140 },
 	{
+		header: 'Category',
+		accessorKey: 'category',
+		size: 160,
+		enableSorting: false,
+		cell: ({ getValue }) => {
+			return <Tooltip content={getValue() as string}>{getValue() as string}</Tooltip>
+		}
+	},
+	{
 		header: 'Description',
 		accessorKey: 'sector',
 		size: 140,
@@ -1388,12 +1397,25 @@ export const hacksColumnOrders = formatColumnOrder({
 })
 
 export const raisesColumnOrders = formatColumnOrder({
-	0: ['name', 'amount', 'date', 'round', 'sector', 'leadInvestors', 'source', 'valuation', 'chains', 'otherInvestors'],
+	0: [
+		'name',
+		'amount',
+		'date',
+		'round',
+		'category',
+		'sector',
+		'leadInvestors',
+		'source',
+		'valuation',
+		'chains',
+		'otherInvestors'
+	],
 	1024: [
 		'name',
 		'date',
 		'amount',
 		'round',
+		'category',
 		'sector',
 		'leadInvestors',
 		'source',


### PR DESCRIPTION
The page already has filters by startup' category, but lacks that data in the table

<img width="999" height="602" alt="Screenshot 2025-08-01 at 19 23 19" src="https://github.com/user-attachments/assets/7c448277-b88b-419b-a9a4-2702c3bc52b2" />
