### PR TITLE
Feat: add tooltip for hacks' technique description

### DIFF
--- a/src/containers/Hacks/index.tsx
+++ b/src/containers/Hacks/index.tsx
@@ -243,7 +243,11 @@ export const hacksColumns: ColumnDef<IHacksPageData['data'][0]>[] = [
 			}
 		}),
 		cell: ({ getValue }) => {
-			return <Tooltip content={getValue() as string}>{getValue() as string}</Tooltip>
+			return (
+				<Tooltip content={getValue() as string} className="inline text-ellipsis">
+					{getValue() as string}
+				</Tooltip>
+			)
 		}
 	})),
 	{

--- a/src/containers/Hacks/index.tsx
+++ b/src/containers/Hacks/index.tsx
@@ -19,6 +19,7 @@ import { downloadChart } from '~/components/ECharts/utils'
 import { capitalizeFirstLetter, download, formattedNum, toNiceDayMonthAndYear } from '~/utils'
 import { IHacksPageData } from './queries'
 import { IconsRow } from '~/components/IconsRow'
+import { Tooltip } from '~/components/Tooltip'
 
 const PieChart = React.lazy(() => import('~/components/ECharts/PieChart')) as React.FC<IPieChartProps>
 const LineAndBarChart = React.lazy(
@@ -240,7 +241,10 @@ export const hacksColumns: ColumnDef<IHacksPageData['data'][0]>[] = [
 				headerHelperText:
 					'Classified based on whether the hack targeted a weakness in Infrastructure, Smart Contract Language, Protocol Logic or the interaction between multiple protocols (Ecosystem)'
 			}
-		})
+		}),
+		cell: ({ getValue }) => {
+			return <Tooltip content={getValue() as string}>{getValue() as string}</Tooltip>
+		}
 	})),
 	{
 		header: 'Language',


### PR DESCRIPTION
In many cases description text wasn't fitting the column witdth and was cut off without the tooltip

<img width="356" height="435" alt="Screenshot 2025-08-03 at 17 11 00" src="https://github.com/user-attachments/assets/4cea2fad-e2eb-4291-bc1f-eb662add602b" />
