### PR TITLE
Feat: add defillama logo on pie charts

### DIFF
--- a/src/components/ECharts/PieChart/index.tsx
+++ b/src/components/ECharts/PieChart/index.tsx
@@ -6,6 +6,9 @@ import { GridComponent, TitleComponent, TooltipComponent, GraphicComponent, Lege
 import type { IPieChartProps } from '../types'
 import { useDarkModeManager } from '~/contexts/LocalStorage'
 import { formattedNum } from '~/utils'
+import { useMedia } from '~/hooks/useMedia'
+import logoLight from '~/public/defillama-press-kit/defi/PNG/defillama-light-neutral.png'
+import logoDark from '~/public/defillama-press-kit/defi/PNG/defillama-dark-neutral.png'
 
 echarts.use([
 	CanvasRenderer,
@@ -34,6 +37,19 @@ export default function PieChart({
 }: IPieChartProps) {
 	const id = useId()
 	const [isDark] = useDarkModeManager()
+	const isSmall = useMedia(`(max-width: 37.5rem)`)
+
+	const graphic = {
+		type: 'image',
+		z: 999,
+		style: {
+			image: isDark ? logoLight.src : logoDark.src,
+			height: 40,
+			opacity: 0.3
+		},
+		left: isSmall ? '35%' : '40%',
+		top: '160px'
+	}
 
 	const series = useMemo(() => {
 		const series: Record<string, any> = {
@@ -84,6 +100,7 @@ export default function PieChart({
 		const chartInstance = createInstance()
 
 		chartInstance.setOption({
+			graphic,
 			tooltip: {
 				trigger: 'item',
 				confine: true,


### PR DESCRIPTION
Was sending chart to a freind and noticed that while we have defillama's logos on every areachart, they're missing on piecharts

BEFORE:
<img width="1268" height="410" alt="Screenshot 2025-08-09 at 21 56 31" src="https://github.com/user-attachments/assets/e0aee5c4-e0e0-4d28-a5a8-bc3646606aa3" />

AFTER:
<img width="1274" height="494" alt="Screenshot 2025-08-09 at 21 50 30" src="https://github.com/user-attachments/assets/06014db2-f221-4858-8210-b485e4bbb4a4" />
<img width="1270" height="457" alt="Screenshot 2025-08-09 at 21 50 34" src="https://github.com/user-attachments/assets/7be89706-57c7-4c49-a484-e942bac3e0f4" />
<img width="493" height="754" alt="Screenshot 2025-08-09 at 21 51 01" src="https://github.com/user-attachments/assets/b2452a5f-2aa5-4e2e-87c9-69b22330e88e" />
