### PR TITLE
fix: add spacing between announcement text and link on unlocks page

### DIFF
--- a/src/pages/unlocks/index.tsx
+++ b/src/pages/unlocks/index.tsx
@@ -82,7 +82,7 @@ export default function Protocols({ data, unlockStats }) {
 	return (
 		<Layout title={`Unlocks - DefiLlama`} defaultSEO>
 			<Announcement notCancellable>
-				<span>Are we missing any protocol?</span>
+				<span>Are we missing any protocol?</span>{' '}
 				<a
 					href="https://airtable.com/shrD1bSGYNcdFQ6kd"
 					className="text-(--blue) underline font-medium"


### PR DESCRIPTION
**Before**:

<img width="461" height="139" alt="Screenshot from 2025-08-13 15-14-00" src="https://github.com/user-attachments/assets/833ca015-199d-4c58-952d-65b65c355746" />

**After**:

<img width="415" height="125" alt="Screenshot from 2025-08-13 15-16-23" src="https://github.com/user-attachments/assets/c2a07e16-cd49-4acb-990b-1928c5d444a1" />
