### PR TITLE
add 30d volume to oracle pages

### DIFF
--- a/src/containers/Oracles/index.tsx
+++ b/src/containers/Oracles/index.tsx
@@ -24,7 +24,8 @@ export const OraclesByChain = ({
 	tokenLinks,
 	oraclesColors,
 	chainsByOracle,
-	chain
+	chain,
+	oracleMonthlyVolumes = {}
 }) => {
 	const { chainsWithExtraTvlsByDay, chainsWithExtraTvlsAndDominanceByDay } = useCalcGroupExtraTvlsByDay(chartData)
 	const { tokenTvls, tokensList } = React.useMemo(() => {
@@ -42,12 +43,13 @@ export const OraclesByChain = ({
 				name,
 				protocolsSecured: tokensProtocols[name],
 				tvs: value,
-				chains: chainsByOracle[name]
+				chains: chainsByOracle[name],
+				monthlyVolume: oracleMonthlyVolumes[name]
 			}
 		})
 
 		return { tokenTvls, tokensList }
-	}, [chainsWithExtraTvlsByDay, tokensProtocols, chainsByOracle])
+	}, [chainsWithExtraTvlsByDay, tokensProtocols, chainsByOracle, oracleMonthlyVolumes])
 
 	const downloadCsv = () => {
 		const header = Object.keys(tokensList[0]).join(',')
@@ -160,5 +162,15 @@ const columns: ColumnDef<IOraclesRow>[] = [
 			align: 'end',
 			headerHelperText: 'Total Value Secured by the Oracle. Excludes CeFi'
 		}
+	},
+	{
+		header: 'Perp DEXs Volume (30d)',
+		accessorKey: 'monthlyVolume',
+		cell: ({ getValue }) => <>{getValue() ? '$' + formattedNum(getValue()) : null}</>,
+		meta: {
+			align: 'end',
+			headerHelperText: 'Cumulative last 30d volume secured'
+		},
+		sortUndefined: 'last'
 	}
 ]

--- a/src/pages/oracles/[...oracle].js
+++ b/src/pages/oracles/[...oracle].js
@@ -50,7 +50,7 @@ export async function getStaticPaths() {
 	return { paths, fallback: 'blocking' }
 }
 
-const PageView = ({ chartData, tokenLinks, token, filteredProtocols, chain, chainChartData }) => {
+const PageView = ({ chartData, tokenLinks, token, filteredProtocols, chain, chainChartData, oracleMonthlyVolumes }) => {
 	const [extraTvlsEnabled] = useLocalStorageSettingsManager('tvl')
 	const { protocolsData, charts, totalValue } = useMemo(() => {
 		const dataWithTvs = formatDataWithExtraTvls({
@@ -101,6 +101,12 @@ const PageView = ({ chartData, tokenLinks, token, filteredProtocols, chain, chai
 					<p className="flex flex-col">
 						<span className="text-(--text-label)">Total Value Secured (USD)</span>
 						<span className="font-semibold text-2xl font-jetbrains">{formattedNum(totalValue, true)}</span>
+					</p>
+					<p className="flex flex-col">
+						<span className="text-(--text-label)">Total Perp DEX Volume Secured (30d)</span>
+						<span className="font-semibold text-2xl font-jetbrains">
+							{formattedNum(oracleMonthlyVolumes[token] ?? 0, true)}
+						</span>
 					</p>
 					<p className="flex flex-col">
 						<span className="text-(--text-label)">{topToken.name} Dominance</span>


### PR DESCRIPTION
TTV is a valuable metric that is currently unrepresented on the Oracles page. Given that a primary modern use-case for oracles is for perp exchanges, and that 30d volume is listed as a key metric for perp exchanges, it feels appropriate that this metric should be listed for oracles as well.

QA'd locally, no apparent issues.