### PR TITLE
Fix pinned list hover

### DIFF
--- a/src/components/Nav/Desktop.tsx
+++ b/src/components/Nav/Desktop.tsx
@@ -68,7 +68,10 @@ export const DesktopNav = ({
 						<p className="flex items-center justify-between gap-3 rounded-md text-xs opacity-65">Pinned Pages</p>
 						<div>
 							{pinnedPages.map(({ name, route }) => (
-								<span key={`pinned-page-${name}-${route}`} className="group relative flex flex-wrap items-center gap-1">
+								<span
+									key={`pinned-page-${name}-${route}`}
+									className="group/pinned relative flex flex-wrap items-center gap-1"
+								>
 									<BasicLink
 										href={route}
 										data-linkactive={route === asPath.split('/?')[0].split('?')[0]}
@@ -92,7 +95,7 @@ export const DesktopNav = ({
 												}}
 											/>
 										}
-										className="absolute top-1 right-1 bottom-1 my-auto hidden rounded-md bg-(--error) px-1 py-1 text-white group-hover:block"
+										className="absolute top-1 right-1 bottom-1 my-auto hidden rounded-md bg-(--error) px-1 py-1 text-white group-hover/pinned:block"
 									>
 										<Icon name="x" className="h-4 w-4" />
 									</Tooltip>


### PR DESCRIPTION
Now hover only triggers the tooltip on one item instead of whole list

before
<img width="252" height="203" alt="Screenshot 2025-08-22 at 19 47 51" src="https://github.com/user-attachments/assets/253a17d7-0837-4a57-a1bb-4704c20cd7ab" />

after
<img width="271" height="170" alt="Screenshot 2025-08-22 at 19 49 25" src="https://github.com/user-attachments/assets/dbb3562d-3199-4c7f-9234-7b4519a76895" />
