### PR TITLE
feat: add filters for hacks 

### DIFF
--- a/src/components/NestedMenu.tsx
+++ b/src/components/NestedMenu.tsx
@@ -40,28 +40,27 @@ export const NestedMenu = React.forwardRef<HTMLDivElement, NestedMenuProps>(func
 				gutter={8}
 				shift={menu.parent ? -9 : 0}
 				wrapperProps={{
-					className:
-						'max-sm:fixed! max-sm:bottom-0! max-sm:top-[unset]! max-sm:transform-none! max-sm:w-full! text-base'
+					className: 'max-sm:fixed! max-sm:bottom-0! max-sm:top-[unset]! max-sm:transform-none! max-sm:w-full!'
 				}}
-				className={`z-10 flex h-[calc(100dvh-80px)] flex-col gap-2 overflow-x-auto rounded-md border border-[hsl(204,20%,88%)] bg-(--bg-main) p-2 max-sm:rounded-b-none sm:max-h-[60dvh] dark:border-[hsl(204,3%,32%)] ${
+				className={`z-10 flex h-[calc(100dvh-80px)] flex-col overflow-x-auto rounded-md border border-[hsl(204,20%,88%)] bg-(--bg-main) p-2 max-sm:rounded-b-none sm:max-h-[60dvh] dark:border-[hsl(204,3%,32%)] ${
 					menu.parent ? 'max-sm:drawer-to-left' : 'max-sm:drawer'
 				}`}
 			>
 				<Ariakit.MenuDismiss className="ml-auto px-3 py-1">
-					<Icon name="x" height={24} width={24} />
+					<Icon name="x" height={16} width={16} />
 					<span className="sr-only">Close dialog</span>
 				</Ariakit.MenuDismiss>
 				{menu.parent ? (
 					<>
 						<div className="grid grid-cols-[1fr_auto_1fr] items-end">
 							<button
-								className="flex items-center justify-between gap-3 px-3 py-2"
+								className="-ml-1.5 flex items-center justify-between gap-3 px-3 py-2"
 								onClick={() => {
 									menu.hide()
 								}}
 								aria-label="Back to parent menu"
 							>
-								<Ariakit.MenuButtonArrow placement="left" />
+								<Icon name="chevron-left" height={20} width={20} />
 							</button>
 							<h1 className="px-3 py-1.5 text-base font-medium">{label}</h1>
 						</div>

--- a/src/containers/Hacks/filters.tsx
+++ b/src/containers/Hacks/filters.tsx
@@ -50,32 +50,30 @@ export function HacksFilters({
 	onClearAll
 }: HacksFiltersProps) {
 	return (
-		<div className="mt-3 flex flex-col gap-2 rounded-md border border-(--cards-border) bg-(--cards-bg) p-3">
+		<div className="flex flex-col gap-2 rounded-md border border-(--cards-border) bg-(--cards-bg) p-3">
 			<div className="flex min-h-9 flex-wrap gap-2 *:flex-1 sm:hidden">
 				<React.Suspense fallback={<></>}>
 					<NestedMenu label="Filters">
-						<div className="flex flex-col gap-2 p-2">
-							<Filters
-								chainOptions={chainOptions}
-								selectedChains={selectedChains}
-								setSelectedChains={setSelectedChains}
-								minLostVal={minLostVal}
-								maxLostVal={maxLostVal}
-								handleAmountSubmit={handleAmountSubmit}
-								handleAmountClear={handleAmountClear}
-								classificationOptions={classificationOptions}
-								selectedClassifications={selectedClassifications}
-								setSelectedClassifications={setSelectedClassifications}
-								techniqueOptions={techniqueOptions}
-								selectedTechniques={selectedTechniques}
-								setSelectedTechniques={setSelectedTechniques}
-								timeOptions={timeOptions}
-								selectedTimeLabel={selectedTimeLabel}
-								setSelectedTime={setSelectedTime}
-								onClearAll={onClearAll}
-								isMobile
-							/>
-						</div>
+						<Filters
+							chainOptions={chainOptions}
+							selectedChains={selectedChains}
+							setSelectedChains={setSelectedChains}
+							minLostVal={minLostVal}
+							maxLostVal={maxLostVal}
+							handleAmountSubmit={handleAmountSubmit}
+							handleAmountClear={handleAmountClear}
+							classificationOptions={classificationOptions}
+							selectedClassifications={selectedClassifications}
+							setSelectedClassifications={setSelectedClassifications}
+							techniqueOptions={techniqueOptions}
+							selectedTechniques={selectedTechniques}
+							setSelectedTechniques={setSelectedTechniques}
+							timeOptions={timeOptions}
+							selectedTimeLabel={selectedTimeLabel}
+							setSelectedTime={setSelectedTime}
+							onClearAll={onClearAll}
+							isMobile
+						/>
 					</NestedMenu>
 				</React.Suspense>
 			</div>
@@ -181,7 +179,7 @@ const Filters = ({
 			</div>
 			<button
 				onClick={onClearAll}
-				className="w-full rounded-md bg-(--btn2-bg) px-3 py-2 text-xs hover:bg-(--btn2-hover-bg) md:w-auto"
+				className="rounded-md bg-(--btn2-bg) px-3 py-2 text-xs hover:bg-(--btn2-hover-bg) max-sm:mx-3 max-sm:my-6"
 			>
 				Reset filters
 			</button>

--- a/src/containers/Hacks/filters.tsx
+++ b/src/containers/Hacks/filters.tsx
@@ -1,0 +1,190 @@
+import * as React from 'react'
+import { FilterBetweenRange } from '~/components/Filters/FilterBetweenRange'
+import { NestedMenu } from '~/components/NestedMenu'
+import { SelectWithCombobox } from '~/components/SelectWithCombobox'
+import { TagGroup } from '~/components/TagGroup'
+
+interface IOption {
+	key: string
+	name: string
+}
+
+interface HacksFiltersProps {
+	chainOptions: IOption[]
+	techniqueOptions: IOption[]
+	classificationOptions: IOption[]
+	selectedChains: string[]
+	selectedTechniques: string[]
+	selectedClassifications: string[]
+	setSelectedChains: (values: string[]) => void
+	setSelectedTechniques: (values: string[]) => void
+	setSelectedClassifications: (values: string[]) => void
+	timeOptions: string[]
+	selectedTimeLabel: string
+	setSelectedTime: (label: string) => void
+	minLostVal: number | null
+	maxLostVal: number | null
+	handleAmountSubmit: (e: any) => void
+	handleAmountClear: () => void
+	onClearAll: () => void
+	isMobile?: boolean
+}
+
+export function HacksFilters({
+	chainOptions,
+	techniqueOptions,
+	classificationOptions,
+	selectedChains,
+	selectedTechniques,
+	selectedClassifications,
+	setSelectedChains,
+	setSelectedTechniques,
+	setSelectedClassifications,
+	timeOptions,
+	selectedTimeLabel,
+	setSelectedTime,
+	minLostVal,
+	maxLostVal,
+	handleAmountSubmit,
+	handleAmountClear,
+	onClearAll
+}: HacksFiltersProps) {
+	return (
+		<div className="mt-3 flex flex-col gap-2 rounded-md border border-(--cards-border) bg-(--cards-bg) p-3">
+			<div className="flex min-h-9 flex-wrap gap-2 *:flex-1 sm:hidden">
+				<React.Suspense fallback={<></>}>
+					<NestedMenu label="Filters">
+						<div className="flex flex-col gap-2 p-2">
+							<Filters
+								chainOptions={chainOptions}
+								selectedChains={selectedChains}
+								setSelectedChains={setSelectedChains}
+								minLostVal={minLostVal}
+								maxLostVal={maxLostVal}
+								handleAmountSubmit={handleAmountSubmit}
+								handleAmountClear={handleAmountClear}
+								classificationOptions={classificationOptions}
+								selectedClassifications={selectedClassifications}
+								setSelectedClassifications={setSelectedClassifications}
+								techniqueOptions={techniqueOptions}
+								selectedTechniques={selectedTechniques}
+								setSelectedTechniques={setSelectedTechniques}
+								timeOptions={timeOptions}
+								selectedTimeLabel={selectedTimeLabel}
+								setSelectedTime={setSelectedTime}
+								onClearAll={onClearAll}
+								isMobile
+							/>
+						</div>
+					</NestedMenu>
+				</React.Suspense>
+			</div>
+
+			<div className="hidden min-h-8 flex-wrap items-center gap-2 sm:flex">
+				<Filters
+					chainOptions={chainOptions}
+					selectedChains={selectedChains}
+					setSelectedChains={setSelectedChains}
+					minLostVal={minLostVal}
+					maxLostVal={maxLostVal}
+					handleAmountSubmit={handleAmountSubmit}
+					handleAmountClear={handleAmountClear}
+					classificationOptions={classificationOptions}
+					selectedClassifications={selectedClassifications}
+					setSelectedClassifications={setSelectedClassifications}
+					techniqueOptions={techniqueOptions}
+					selectedTechniques={selectedTechniques}
+					setSelectedTechniques={setSelectedTechniques}
+					timeOptions={timeOptions}
+					selectedTimeLabel={selectedTimeLabel}
+					setSelectedTime={setSelectedTime}
+					onClearAll={onClearAll}
+				/>
+			</div>
+		</div>
+	)
+}
+
+const Filters = ({
+	chainOptions,
+	selectedChains,
+	setSelectedChains,
+	minLostVal,
+	maxLostVal,
+	handleAmountSubmit,
+	handleAmountClear,
+	classificationOptions,
+	selectedClassifications,
+	setSelectedClassifications,
+	techniqueOptions,
+	selectedTechniques,
+	setSelectedTechniques,
+	timeOptions,
+	selectedTimeLabel,
+	setSelectedTime,
+	onClearAll,
+	isMobile = false
+}: HacksFiltersProps) => {
+	return (
+		<>
+			<SelectWithCombobox
+				allValues={chainOptions}
+				selectedValues={selectedChains}
+				setSelectedValues={setSelectedChains}
+				label="Chains"
+				labelType="regular"
+				nestedMenu={isMobile}
+			/>
+			<FilterBetweenRange
+				name="Amount lost"
+				trigger={
+					minLostVal || maxLostVal ? (
+						<>
+							<span>Amount: </span>
+							<span className="text-(--link)">{`${minLostVal?.toLocaleString() ?? 'min'} - ${
+								maxLostVal?.toLocaleString() ?? 'max'
+							}`}</span>
+						</>
+					) : (
+						'Amount lost'
+					)
+				}
+				min={minLostVal}
+				max={maxLostVal}
+				onSubmit={handleAmountSubmit}
+				onClear={handleAmountClear}
+				variant="secondary"
+				placement="bottom-start"
+				triggerClassName="py-2"
+				nestedMenu={isMobile}
+			/>
+
+			<SelectWithCombobox
+				allValues={classificationOptions}
+				selectedValues={selectedClassifications}
+				setSelectedValues={setSelectedClassifications}
+				label="Classification"
+				labelType="regular"
+				nestedMenu={isMobile}
+			/>
+			<SelectWithCombobox
+				allValues={techniqueOptions}
+				selectedValues={selectedTechniques}
+				setSelectedValues={setSelectedTechniques}
+				label="Techniques"
+				labelType="regular"
+				nestedMenu={isMobile}
+			/>
+
+			<div className="px-3 py-2 md:ml-auto md:flex-row md:items-center md:px-0 md:py-0">
+				<TagGroup setValue={setSelectedTime as any} selectedValue={selectedTimeLabel} values={timeOptions} />
+			</div>
+			<button
+				onClick={onClearAll}
+				className="w-full rounded-md bg-(--btn2-bg) px-3 py-2 text-xs hover:bg-(--btn2-hover-bg) md:w-auto"
+			>
+				Reset filters
+			</button>
+		</>
+	)
+}

--- a/src/containers/Hacks/index.tsx
+++ b/src/containers/Hacks/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useRouter } from 'next/router'
 import {
 	ColumnDef,
 	ColumnFiltersState,
@@ -17,7 +18,8 @@ import { VirtualTable } from '~/components/Table/Table'
 import { TagGroup } from '~/components/TagGroup'
 import { Tooltip } from '~/components/Tooltip'
 import Layout from '~/layout'
-import { capitalizeFirstLetter, formattedNum, toNiceDayMonthAndYear } from '~/utils'
+import { capitalizeFirstLetter, formattedNum, slug, toNiceDayMonthAndYear } from '~/utils'
+import { HacksFilters } from './filters'
 import { IHacksPageData } from './queries'
 
 const PieChart = React.lazy(() => import('~/components/ECharts/PieChart')) as React.FC<IPieChartProps>
@@ -91,6 +93,7 @@ function HacksTable({ data }: { data: IHacksPageData['data'] }) {
 						className="w-full rounded-md border border-(--form-control-border) bg-white p-1 pl-7 text-black max-sm:py-0.5 dark:bg-black dark:text-white"
 					/>
 				</label>
+
 				<CSVDownloadButton prepareCsv={prepareCsv} />
 			</div>
 			<VirtualTable instance={instance} columnResizeMode={columnResizeMode} />
@@ -102,6 +105,57 @@ const chartTypeList = ['Monthly Sum', 'Total Hacked by Technique']
 
 const pageName = ['Hacks: Overview']
 
+const getTimeSinceSeconds = (timeQuery: string | undefined): number | null => {
+	if (typeof timeQuery !== 'string') return null
+
+	const nowSec = Math.floor(Date.now() / 1000)
+	switch (timeQuery) {
+		case '7d':
+			return nowSec - 7 * 24 * 60 * 60
+		case '30d':
+			return nowSec - 30 * 24 * 60 * 60
+		case '90d':
+			return nowSec - 90 * 24 * 60 * 60
+		case '1y':
+			return nowSec - 365 * 24 * 60 * 60
+		default:
+			return null
+	}
+}
+
+const applyFilters = (
+	data: IHacksPageData['data'],
+	filters: {
+		techKeys?: Set<string>
+		classKeys?: Set<string>
+		chainKeys?: Set<string>
+		since?: number | null
+		minLost?: number | null
+		maxLost?: number | null
+	}
+) => {
+	return data.filter((row) => {
+		if (filters.chainKeys && filters.chainKeys.size > 0) {
+			const rowChainKeys = new Set((row.chains || []).map((c) => slug(c)))
+			let hasAny = false
+			for (const k of filters.chainKeys) {
+				if (rowChainKeys.has(k)) {
+					hasAny = true
+					break
+				}
+			}
+			if (!hasAny) return false
+		}
+		if (filters.techKeys && filters.techKeys.size > 0 && !filters.techKeys.has(slug(row.technique))) return false
+		if (filters.classKeys && filters.classKeys.size > 0 && !filters.classKeys.has(slug(row.classification)))
+			return false
+		if (filters.since !== null && filters.since !== undefined && row.date < filters.since) return false
+		if (filters.minLost !== null && filters.minLost !== undefined && row.amount < filters.minLost) return false
+		if (filters.maxLost !== null && filters.maxLost !== undefined && row.amount > filters.maxLost) return false
+		return true
+	})
+}
+
 export const HacksContainer = ({
 	data,
 	monthlyHacksChartData,
@@ -111,6 +165,185 @@ export const HacksContainer = ({
 	pieChartData
 }: IHacksPageData) => {
 	const [chartType, setChartType] = React.useState('Monthly Sum')
+	const router = useRouter()
+
+	const chainOptions = React.useMemo(() => {
+		const {
+			tech: techQuery,
+			class: classQuery,
+			time: timeQuery,
+			minLost: minLostQuery,
+			maxLost: maxLostQuery
+		} = router.query
+
+		const selectedTechniquesLocal = Array.isArray(techQuery) ? techQuery : techQuery ? [techQuery] : []
+		const selectedClassificationsLocal = Array.isArray(classQuery) ? classQuery : classQuery ? [classQuery] : []
+		const timeQLocal = typeof timeQuery === 'string' ? timeQuery : undefined
+
+		const since = getTimeSinceSeconds(timeQLocal)
+		const minLostValLocal = typeof minLostQuery === 'string' && minLostQuery !== '' ? Number(minLostQuery) : null
+		const maxLostValLocal = typeof maxLostQuery === 'string' && maxLostQuery !== '' ? Number(maxLostQuery) : null
+
+		const techKeys = new Set(selectedTechniquesLocal.map((s) => s))
+		const classKeys = new Set(selectedClassificationsLocal.map((s) => s))
+
+		const eligible = applyFilters(data || [], {
+			techKeys,
+			classKeys,
+			since,
+			minLost: minLostValLocal,
+			maxLost: maxLostValLocal
+		})
+
+		return Array.from(new Set(eligible.flatMap((d) => d.chains || [])))
+			.filter(Boolean)
+			.sort((a, b) => a.localeCompare(b))
+			.map((name) => ({ key: slug(name), name }))
+	}, [data, router.query])
+
+	const techniqueOptions = React.useMemo(
+		() =>
+			Array.from(new Set((data || []).map((d) => d.technique).filter(Boolean)))
+				.sort((a, b) => a.localeCompare(b))
+				.map((name) => ({ key: slug(name), name })),
+		[data]
+	)
+
+	const classificationOptions = React.useMemo(
+		() =>
+			Array.from(new Set((data || []).map((d) => d.classification).filter(Boolean)))
+				.sort((a, b) => a.localeCompare(b))
+				.map((name) => ({ key: slug(name), name })),
+		[data]
+	)
+
+	const toArrayParam = (p: string | string[] | undefined): string[] => {
+		if (!p) return []
+		return Array.isArray(p) ? p.filter(Boolean) : [p].filter(Boolean)
+	}
+
+	const { chain: chainQ, tech: techQ, class: classQ, time: timeQ } = router.query
+
+	const selectedChains = React.useMemo(() => {
+		const qs = toArrayParam(chainQ)
+		const validKeys = new Set(chainOptions.map((o) => o.key))
+		return qs.filter((k) => validKeys.has(k))
+	}, [chainQ, chainOptions])
+
+	const selectedTechniques = React.useMemo(() => {
+		const qs = toArrayParam(techQ)
+		const validKeys = new Set(techniqueOptions.map((o) => o.key))
+		return qs.filter((k) => validKeys.has(k))
+	}, [techQ, techniqueOptions])
+
+	const selectedClassifications = React.useMemo(() => {
+		const qs = toArrayParam(classQ)
+		const validKeys = new Set(classificationOptions.map((o) => o.key))
+		return qs.filter((k) => validKeys.has(k))
+	}, [classQ, classificationOptions])
+
+	const updateArrayQuery = React.useCallback(
+		(key: string, values: string[]) => {
+			const nextQuery: Record<string, any> = { ...router.query }
+			if (values.length > 0) {
+				nextQuery[key] = values
+			} else {
+				delete nextQuery[key]
+			}
+			router.push({ pathname: router.pathname, query: nextQuery }, undefined, { shallow: true })
+		},
+		[router]
+	)
+
+	const setSelectedChains = React.useCallback(
+		(values: string[]) => updateArrayQuery('chain', values),
+		[updateArrayQuery]
+	)
+	const setSelectedTechniques = React.useCallback(
+		(values: string[]) => updateArrayQuery('tech', values),
+		[updateArrayQuery]
+	)
+	const setSelectedClassifications = React.useCallback(
+		(values: string[]) => updateArrayQuery('class', values),
+		[updateArrayQuery]
+	)
+
+	const timeOptions = ['All', '7D', '30D', '90D', '1Y'] as const
+	const labelToKey = {
+		All: 'all',
+		'7D': '7d',
+		'30D': '30d',
+		'90D': '90d',
+		'1Y': '1y'
+	} as const
+	const keyToLabel: Record<string, (typeof timeOptions)[number]> = {
+		all: 'All',
+		'7d': '7D',
+		'30d': '30D',
+		'90d': '90D',
+		'1y': '1Y'
+	}
+
+	const selectedTimeLabel = (typeof timeQ === 'string' && keyToLabel[timeQ]) || 'All'
+
+	const setSelectedTime = (label: (typeof timeOptions)[number]) => {
+		const key = labelToKey[label]
+		const nextQuery: Record<string, any> = { ...router.query }
+		if (key && key !== 'all') nextQuery.time = key
+		else delete nextQuery.time
+		router.push({ pathname: router.pathname, query: nextQuery }, undefined, { shallow: true })
+	}
+
+	const { minLost, maxLost } = router.query
+
+	const handleAmountSubmit = (e) => {
+		e.preventDefault()
+		const form = e.target
+		const min = form.min?.value
+		const max = form.max?.value
+		router.push({ pathname: router.pathname, query: { ...router.query, minLost: min, maxLost: max } }, undefined, {
+			shallow: true
+		})
+	}
+
+	const handleAmountClear = () => {
+		const nextQuery: Record<string, any> = { ...router.query }
+		delete nextQuery.minLost
+		delete nextQuery.maxLost
+		router.push({ pathname: router.pathname, query: nextQuery }, undefined, { shallow: true })
+	}
+
+	const minLostVal = typeof minLost === 'string' && minLost !== '' ? Number(minLost) : null
+	const maxLostVal = typeof maxLost === 'string' && maxLost !== '' ? Number(maxLost) : null
+
+	const clearAllFilters = () => {
+		const nextQuery: Record<string, any> = { ...router.query }
+		delete nextQuery.chain
+		delete nextQuery.tech
+		delete nextQuery.class
+		delete nextQuery.start
+		delete nextQuery.end
+		delete nextQuery.minLost
+		delete nextQuery.maxLost
+		delete nextQuery.time
+		router.push({ pathname: router.pathname, query: nextQuery }, undefined, { shallow: true })
+	}
+
+	const filteredData = React.useMemo(() => {
+		const chainKeys = new Set(selectedChains)
+		const techKeys = new Set(selectedTechniques)
+		const classKeys = new Set(selectedClassifications)
+		const since = getTimeSinceSeconds(typeof timeQ === 'string' ? timeQ : undefined)
+
+		return applyFilters(data || [], {
+			chainKeys,
+			techKeys,
+			classKeys,
+			since,
+			minLost: minLostVal,
+			maxLost: maxLostVal
+		})
+	}, [data, selectedChains, selectedTechniques, selectedClassifications, timeQ, minLostVal, maxLostVal])
 
 	const prepareCsv = React.useCallback(() => {
 		if (chartType === 'Monthly Sum') {
@@ -166,7 +399,26 @@ export const HacksContainer = ({
 					)}
 				</div>
 			</div>
-			<HacksTable data={data} />
+			<HacksFilters
+				chainOptions={chainOptions}
+				techniqueOptions={techniqueOptions}
+				classificationOptions={classificationOptions}
+				selectedChains={selectedChains}
+				selectedTechniques={selectedTechniques}
+				selectedClassifications={selectedClassifications}
+				setSelectedChains={setSelectedChains}
+				setSelectedTechniques={setSelectedTechniques}
+				setSelectedClassifications={setSelectedClassifications}
+				timeOptions={timeOptions as unknown as string[]}
+				selectedTimeLabel={selectedTimeLabel}
+				setSelectedTime={setSelectedTime as any}
+				minLostVal={minLostVal}
+				maxLostVal={maxLostVal}
+				handleAmountSubmit={handleAmountSubmit}
+				handleAmountClear={handleAmountClear}
+				onClearAll={clearAllFilters}
+			/>
+			<HacksTable data={filteredData} />
 		</Layout>
 	)
 }

--- a/src/containers/Hacks/queries.tsx
+++ b/src/containers/Hacks/queries.tsx
@@ -38,6 +38,8 @@ export interface IHacksPageData {
 	totalHackedDefi: string
 	totalRugs: string
 	pieChartData: Array<{ name: string; value: number }>
+	techniqueOptions: Array<{ key: string; name: string }>
+	classificationOptions: Array<{ key: string; name: string }>
 }
 
 export async function getHacksPageData(): Promise<IHacksPageData> {
@@ -105,6 +107,14 @@ export async function getHacksPageData(): Promise<IHacksPageData> {
 		monthlyHacksChartData.push([+date, monthlyHacks[date]])
 	}
 
+	const techniqueOptions = Array.from(new Set((data || []).map((d) => d.technique).filter(Boolean)))
+		.sort((a: string, b: string) => a.localeCompare(b))
+		.map((name: string) => ({ key: slug(name), name }))
+
+	const classificationOptions = Array.from(new Set((data || []).map((d) => d.classification).filter(Boolean)))
+		.sort((a: string, b: string) => a.localeCompare(b))
+		.map((name: string) => ({ key: slug(name), name }))
+
 	return {
 		data,
 		monthlyHacksChartData: {
@@ -119,7 +129,9 @@ export async function getHacksPageData(): Promise<IHacksPageData> {
 		totalHacked,
 		totalHackedDefi,
 		totalRugs,
-		pieChartData
+		pieChartData,
+		techniqueOptions,
+		classificationOptions
 	}
 }
 


### PR DESCRIPTION
This PR adds filters (by `chain`, `amount`, `technique`, `classification` and `date`) to the hacks dashboard making it easier to analyse past exploits.  The query params are updated each time a new filter is selected and all filters can be reset. 

### Screenshots
**Mobile Closed State**

<img width="428" height="933" alt="Screenshot 2025-10-03 at 16 31 08" src="https://github.com/user-attachments/assets/c68554ab-4f3d-4ee0-a7df-6ee841ac14db" />

**Mobile Open State**

<img width="430" height="931" alt="Screenshot 2025-10-03 at 16 30 42" src="https://github.com/user-attachments/assets/0d75ef27-31bc-447f-9ab5-93a3fd210921" />

**Desktop**

<img width="1537" height="1388" alt="Screenshot 2025-10-03 at 16 30 02" src="https://github.com/user-attachments/assets/efb5ec89-699e-400f-8067-4922d9720203" />
