### PR TITLE
fix: enterprise button overflow

### DIFF
--- a/src/components/SubscribeCards/FreeCard.tsx
+++ b/src/components/SubscribeCards/FreeCard.tsx
@@ -11,7 +11,7 @@ export function FreeCard({ context = 'page' }: FreeCardProps) {
 	const shouldShowLightMode = isModal && !isDarkMode
 	return (
 		<div
-			className={`flex w-[92vw] shrink-0 snap-center flex-col px-4 py-8 md:w-auto md:max-w-[400px] md:flex-1 md:shrink md:snap-none md:px-5 ${
+			className={`flex w-full shrink-0 snap-center flex-col px-4 py-8 md:w-auto md:max-w-[400px] md:flex-1 md:shrink md:snap-none md:px-5 ${
 				shouldShowLightMode ? 'border-[#e5e7eb] bg-[#f8f9fa]' : 'border-[#4a4a50] bg-[#22242930]'
 			} relative overflow-hidden rounded-xl border shadow-md backdrop-blur-md transition-all duration-300${
 				isModal ? '' : 'hover:transform md:hover:scale-[1.02]'

--- a/src/components/SubscribeCards/SubscribeEnterpriseCard.tsx
+++ b/src/components/SubscribeCards/SubscribeEnterpriseCard.tsx
@@ -3,7 +3,7 @@ import { Icon } from '~/components/Icon'
 export function SubscribeEnterpriseCard({ active = false }: { active?: boolean }) {
 	return (
 		<div
-			className={`relative flex w-[92vw] shrink-0 snap-center flex-col overflow-hidden rounded-xl border border-[#4a4a50] bg-[#22242930] px-5 py-8 shadow-md backdrop-blur-md transition-all duration-300 hover:transform md:w-auto md:max-w-[400px] md:flex-1 md:shrink md:snap-none md:px-5 md:hover:scale-[1.02]`}
+			className={`relative flex w-full shrink-0 snap-center flex-col overflow-hidden rounded-xl border border-[#4a4a50] bg-[#22242930] px-5 py-8 shadow-md backdrop-blur-md transition-all duration-300 hover:transform md:w-auto md:max-w-[400px] md:flex-1 md:shrink md:snap-none md:px-5 md:hover:scale-[1.02]`}
 		>
 			<div className="absolute top-0 left-0 h-1 w-full bg-linear-to-r from-transparent via-gray-500 to-transparent opacity-20"></div>
 			<div className="absolute top-[-30px] right-[-30px] h-[80px] w-[80px] rounded-full bg-gray-600 opacity-5 blur-2xl"></div>

--- a/src/components/SubscribeCards/SubscribePlusCard.tsx
+++ b/src/components/SubscribeCards/SubscribePlusCard.tsx
@@ -21,7 +21,7 @@ export function SubscribePlusCard({
 	const shouldShowLightMode = isModal && !isDarkMode
 	return (
 		<div
-			className={`flex w-[92vw] shrink-0 snap-center flex-col px-4 py-8 md:w-auto md:max-w-[400px] md:flex-1 md:shrink md:snap-none md:px-5 ${
+			className={`flex w-full shrink-0 snap-center flex-col px-4 py-8 md:w-auto md:max-w-[400px] md:flex-1 md:shrink md:snap-none md:px-5 ${
 				shouldShowLightMode ? 'border-[#e5e7eb] bg-[#f8f9fa]' : 'border-[#4a4a50] bg-[#22242930]'
 			} relative overflow-hidden rounded-xl border shadow-md backdrop-blur-md transition-all duration-300${
 				isModal ? '' : 'hover:transform md:hover:scale-[1.02]'

--- a/src/components/SubscribeCards/SubscribeProCard.tsx
+++ b/src/components/SubscribeCards/SubscribeProCard.tsx
@@ -19,7 +19,7 @@ export function SubscribeProCard({
 	const shouldShowLightMode = isModal && !isDarkMode
 	return (
 		<div
-			className={`flex w-[92vw] shrink-0 snap-center flex-col px-4 py-8 md:w-auto md:max-w-[400px] md:flex-1 md:shrink md:snap-none md:px-5 ${
+			className={`flex w-full shrink-0 snap-center flex-col px-4 py-8 md:w-auto md:max-w-[400px] md:flex-1 md:shrink md:snap-none md:px-5 ${
 				shouldShowLightMode ? 'border-[#e5e7eb] bg-[#f8f9fa]' : 'border-[#4a4a50] bg-[#22242930]'
 			} relative overflow-hidden rounded-xl border shadow-md backdrop-blur-md transition-all duration-300${
 				isModal ? '' : 'hover:transform md:hover:scale-[1.02]'

--- a/src/containers/Subscribtion/Home.tsx
+++ b/src/containers/Subscribtion/Home.tsx
@@ -273,7 +273,7 @@ export function SubscribeHome({ returnUrl, isTrial }: { returnUrl?: string; isTr
 							<div
 								className={`col-span-full rounded-xl border border-[#4a4a50] bg-[#22242930] px-5 py-8 shadow-md backdrop-blur-md transition-all duration-300 hover:transform md:px-5 md:hover:scale-[1.02]`}
 							>
-								<span className="mx-auto flex w-[92vw] flex-col md:w-auto md:max-w-[400px]">
+								<span className="mx-auto flex w-full flex-col md:w-auto md:max-w-[400px]">
 									<h2 className="text-center text-[2rem] font-extrabold whitespace-nowrap">Enterprise</h2>
 									<EnterpriseCardContent />
 								</span>


### PR DESCRIPTION
This PR fixes the overflow issue from occurring on the subscription cards in mobile view. Added to all cards for consistency. 

**Before:**

<img width="390" height="845" alt="Screenshot 2025-10-04 at 08 38 02" src="https://github.com/user-attachments/assets/a9ebdb08-1f78-49f9-89b7-2790ee2aeb6b" />
<img width="1541" height="1387" alt="Screenshot 2025-10-04 at 08 37 25" src="https://github.com/user-attachments/assets/a4bdf087-a703-46f8-9d7b-c96731205f96" />

**After**

<img width="393" height="848" alt="Screenshot 2025-10-04 at 08 40 03" src="https://github.com/user-attachments/assets/3778b558-e98b-4bfe-b819-c955965ca33c" />
<img width="1651" height="1394" alt="Screenshot 2025-10-04 at 08 47 37" src="https://github.com/user-attachments/assets/4383d1d8-67b2-49ff-91f8-8b66912bfc89" />
