### PR TITLE
feat: add 'all' and 'none' buttons to the multi series chart legend

### DIFF
--- a/src/components/ECharts/MultiSeriesChart/index.tsx
+++ b/src/components/ECharts/MultiSeriesChart/index.tsx
@@ -4,6 +4,17 @@ import { useDarkModeManager } from '~/contexts/LocalStorage'
 import { useDefaults } from '../useDefaults'
 import { mergeDeep } from '../utils'
 
+function LegendButton({ text, onClick }) {
+	return (
+		<button
+			className="pro-border hover:pro-bg1 hover:pro-text1 pro-hover-bg flex items-center gap-2 rounded-md border px-2 py-1 text-xs text-(--text-secondary) transition-colors hover:bg-(--link-hover-bg) disabled:cursor-not-allowed disabled:opacity-50"
+			onClick={onClick}
+		>
+			{text}
+		</button>
+	)
+}
+
 interface IMultiSeriesChartProps {
 	series?: Array<{
 		data: Array<[number, number]>
@@ -263,6 +274,17 @@ export default function MultiSeriesChart({
 
 	return (
 		<div className="relative">
+			<div className="flex items-center justify-start gap-2 px-1 pb-1 md:px-3 md:pb-3">
+				<LegendButton text="All" onClick={() => chartRef.current.dispatchAction({ type: 'legendAllSelect' })} />
+				<LegendButton
+					text="None"
+					onClick={() =>
+						processedSeries.forEach((serie) =>
+							chartRef.current.dispatchAction({ type: 'legendUnSelect', name: serie.name })
+						)
+					}
+				/>
+			</div>
 			<div id={id} className="my-auto min-h-[360px]" style={height ? { height } : undefined}></div>
 		</div>
 	)


### PR DESCRIPTION
I added two buttons to the multi series chart legend: 

- **All** to select every label 
- **None** to unselect every label

<img width="816" height="460" alt="Screenshot from 2025-10-04 08-26-20" src="https://github.com/user-attachments/assets/9f739440-4a80-4b66-8808-c5af7d1317c3" />
<img width="1091" height="477" alt="Screenshot from 2025-10-04 08-26-52" src="https://github.com/user-attachments/assets/344df770-d1ad-471f-9b79-cf2abf087ef3" />
<img width="1089" height="458" alt="Screenshot from 2025-10-04 08-30-56" src="https://github.com/user-attachments/assets/40f2ee10-19e6-4dc1-8fc3-4d1952523a1b" />

**On mobile:**
<img width="427" height="447" alt="Screenshot from 2025-10-04 08-32-29" src="https://github.com/user-attachments/assets/b050c53f-0d2f-44e9-8aec-61634842023d" />

https://github.com/user-attachments/assets/71bc24dd-63e8-4536-9a8f-d8ab8a53eb25