### PR TITLE
Remove lighter redirect

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -523,11 +523,6 @@ const nextConfig: NextConfig = {
 				permanent: true
 			},
 			{
-				source: '/protocol/lighter',
-				destination: '/protocol/lighter-v2',
-				permanent: true
-			},
-			{
 				source: '/subscribe',
 				destination: '/subscription',
 				permanent: true


### PR DESCRIPTION
Redirect seems outdated – I can access the /protocol/lighter from internal search or other pages, but cmd+r or pasting the link into search bar redirects to 404

https://github.com/user-attachments/assets/1beb0116-a090-445f-9593-af55551b13c9

