### PR TITLE
fix: checks for external link and opens in new tab

### DIFF
--- a/src/components/Metrics.tsx
+++ b/src/components/Metrics.tsx
@@ -197,6 +197,8 @@ export const LinkToMetricOrToolPage = React.memo(function LinkToMetricOrToolPage
 		return pinnedPages.includes(page.route)
 	}, [pinnedMetrics, page.route])
 
+	const isExternalLink = page.route.startsWith('http')
+
 	return (
 		<div
 			className={`relative col-span-1 flex min-h-[120px] flex-col ${page.route === '/' ? '' : 'group'}`}
@@ -205,6 +207,8 @@ export const LinkToMetricOrToolPage = React.memo(function LinkToMetricOrToolPage
 			<BasicLink
 				className="col-span-1 flex flex-1 flex-col items-start gap-1 rounded-md border border-(--cards-border) bg-(--cards-bg) p-2.5 hover:bg-(--link-button)"
 				href={page.route}
+				target={isExternalLink ? '_blank' : undefined}
+				rel={isExternalLink ? 'noopener noreferrer' : undefined}
 			>
 				<span className="flex w-full flex-wrap items-center gap-1">
 					<span className="font-medium">{page.name}</span>


### PR DESCRIPTION
This PR is checks to see if the `LinkToMetricOrToolPage` is an external link and opens in a new tab if so

**Before:**

https://github.com/user-attachments/assets/29071a6d-5bd3-44e1-9aa1-f01d17e4dfe0

**After:**

https://github.com/user-attachments/assets/340417c8-2b2e-4ad2-9c73-971e576a7d3f

