### PR TITLE
fix: only show 'see more' when there are more items

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -35,7 +35,7 @@ export function Select({
 }: ISelect) {
 	const valuesAreAnArrayOfStrings = typeof allValues[0] === 'string'
 
-	const [viewableMatches, setViewableMatches] = React.useState(5)
+	const [viewableMatches, setViewableMatches] = React.useState(6)
 
 	const canSelectOnlyOne = typeof selectedValues === 'string'
 
@@ -78,7 +78,7 @@ export function Select({
 							) : null}
 						</span>
 					) : null}
-					{allValues.slice(0, viewableMatches + 1).map((option) => (
+					{allValues.slice(0, viewableMatches).map((option) => (
 						<NestedMenuItem
 							key={valuesAreAnArrayOfStrings ? option : option.key}
 							render={<Ariakit.SelectItem value={valuesAreAnArrayOfStrings ? option : option.key} />}
@@ -182,7 +182,7 @@ export function Select({
 							</span>
 						) : null}
 
-						{allValues.slice(0, viewableMatches + 1).map((option) => (
+						{allValues.slice(0, viewableMatches).map((option) => (
 							<Ariakit.SelectItem
 								key={`${label}-${valuesAreAnArrayOfStrings ? option : option.key}`}
 								value={valuesAreAnArrayOfStrings ? option : option.key}


### PR DESCRIPTION
This PR cleans up the UX of the `Select` by only showing the 'See more' button if we have more than 6 items in the list. I have sense checked other areas of the site including tables where this component is used to hide/show columns.

- Changed `viewableMatches` to 6 so we can see the first 6 items in the list. 
- Adapted the logic that maps over the values removing the redundant `See more`

**Before:**
https://github.com/user-attachments/assets/fd895e0b-b91d-4b95-965d-dfc84e928f56

**After**
**Without additional options**

https://github.com/user-attachments/assets/f20c0ef8-8cef-4347-9f37-8e5adb843c65

**With additional options**

https://github.com/user-attachments/assets/0fba8a67-10a9-4f1c-95d5-20027214652d


