### PR TITLE
fix borrow aggregator when null debtceiling

### DIFF
--- a/src/containers/Yields/queries.ts
+++ b/src/containers/Yields/queries.ts
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchCoinPrices } from '~/api'
 
+export const UNBOUNDED_DEBT_CEILING_PROJECTS = ['liquity-v1', 'liquity-v2'] as const
+
 export const useGetPrice = (tokens: Array<string>) => {
 	const prices = useQuery({
 		queryKey: ['prices', tokens],

--- a/src/pages/borrow/advanced.tsx
+++ b/src/pages/borrow/advanced.tsx
@@ -1,6 +1,7 @@
 import { getAllCGTokensList, maxAgeForNext } from '~/api'
 import { Announcement } from '~/components/Announcement'
 import { BorrowAggregatorAdvanced } from '~/containers/Yields/indexOptimizer'
+import { UNBOUNDED_DEBT_CEILING_PROJECTS } from '~/containers/Yields/queries'
 import { getLendBorrowData } from '~/containers/Yields/queries/index'
 import { disclaimer } from '~/containers/Yields/utils'
 import Layout from '~/layout'
@@ -32,6 +33,7 @@ export const getStaticProps = withPerformanceLogging('borrow', async () => {
 			pools: pools.map((p) => ({ ...p, symbol: p.symbol.toUpperCase() })),
 			yieldsList: [],
 			searchData,
+			unboundedDebtCeilingProjects: [...UNBOUNDED_DEBT_CEILING_PROJECTS],
 			...data
 		},
 		revalidate: maxAgeForNext([23])


### PR DESCRIPTION
some projects (such as liquity-v2) dont have a debtceiling value, its unbounded. but we currently remove these projects IF a a min available liquidity value is set. this pr addresses this by not removing any project with unbounded available liquidity