### PR TITLE
feat: add 7d and 30d values to the open interest table

### DIFF
--- a/src/containers/DimensionAdapters/AdapterByChain.tsx
+++ b/src/containers/DimensionAdapters/AdapterByChain.tsx
@@ -1164,15 +1164,43 @@ const getColumnsByType = (
 			NameColumn('Open Interest'),
 			{
 				id: 'total24h',
-				header: 'Open Interest',
+				header: 'Open Interest 24h',
 				accessorFn: (protocol) => protocol.total24h,
 				cell: (info) => <>{info.getValue() != null ? formattedNum(info.getValue(), true) : null}</>,
 				sortUndefined: 'last',
 				sortingFn: 'alphanumericFalsyLast' as any,
 				meta: {
-					align: 'end',
+					align: 'center',
 					headerHelperText:
 						'Total notional value of all outstanding perpetual futures positions, updated daily at 00:00 UTC'
+				},
+				size: 160
+			},
+			{
+				id: 'total7d',
+				header: 'Open Interest 7d',
+				accessorFn: (protocol) => protocol.total7d,
+				cell: (info) => <>{info.getValue() != null ? formattedNum(info.getValue(), true) : null}</>,
+				sortUndefined: 'last',
+				sortingFn: 'alphanumericFalsyLast' as any,
+				meta: {
+					align: 'center',
+					headerHelperText:
+						'Total notional value of all outstanding perpetual futures positions in the last 7 days'
+				},
+				size: 160
+			},
+			{
+				id: 'total30d',
+				header: 'Open Interest 30d',
+				accessorFn: (protocol) => protocol.total30d,
+				cell: (info) => <>{info.getValue() != null ? formattedNum(info.getValue(), true) : null}</>,
+				sortUndefined: 'last',
+				sortingFn: 'alphanumericFalsyLast' as any,
+				meta: {
+					align: 'center',
+					headerHelperText:
+						'Total notional value of all outstanding perpetual futures positions in the last 30 days'
 				},
 				size: 160
 			}


### PR DESCRIPTION
I added the 7 and 30 days values to the open interest table

<img width="1154" height="653" alt="Screenshot from 2025-10-07 10-29-02" src="https://github.com/user-attachments/assets/a5bf273d-46ba-4693-9944-bae6c22407ba" />
