### PR TITLE
moving p/s to revenue

### DIFF
--- a/src/components/Table/Defi/Protocols/index.tsx
+++ b/src/components/Table/Defi/Protocols/index.tsx
@@ -126,7 +126,7 @@ export const protocolsByChainTableColumns = [
 		category: TABLE_CATEGORIES.REVENUE,
 		period: TABLE_PERIODS.ONE_DAY
 	},
-	{ name: 'P/S', key: 'ps', category: TABLE_CATEGORIES.FEES },
+	{ name: 'P/S', key: 'ps', category: TABLE_CATEGORIES.REVENUE },
 	{ name: 'P/F', key: 'pf', category: TABLE_CATEGORIES.FEES },
 	{ name: 'Spot Volume 24h', key: 'volume_24h', category: TABLE_CATEGORIES.VOLUME, period: TABLE_PERIODS.ONE_DAY },
 	{ name: 'Spot Volume 7d', key: 'volume_7d', category: TABLE_CATEGORIES.VOLUME, period: TABLE_PERIODS.SEVEN_DAYS },
@@ -137,9 +137,24 @@ export const protocolsByChainTableColumns = [
 		period: TABLE_PERIODS.SEVEN_DAYS
 	},
 	{ name: 'Spot Cumulative Volume', key: 'cumulativeVolume', category: TABLE_CATEGORIES.VOLUME },
-	{ name: 'Perp Volume 24h', key: 'perps_volume_24h', category: TABLE_CATEGORIES.VOLUME, period: TABLE_PERIODS.ONE_DAY },
-	{ name: 'Perp Volume 7d', key: 'perps_volume_7d', category: TABLE_CATEGORIES.VOLUME, period: TABLE_PERIODS.SEVEN_DAYS },
-	{ name: 'Perp Volume 30d', key: 'perps_volume_30d', category: TABLE_CATEGORIES.VOLUME, period: TABLE_PERIODS.ONE_MONTH },
+	{
+		name: 'Perp Volume 24h',
+		key: 'perps_volume_24h',
+		category: TABLE_CATEGORIES.VOLUME,
+		period: TABLE_PERIODS.ONE_DAY
+	},
+	{
+		name: 'Perp Volume 7d',
+		key: 'perps_volume_7d',
+		category: TABLE_CATEGORIES.VOLUME,
+		period: TABLE_PERIODS.SEVEN_DAYS
+	},
+	{
+		name: 'Perp Volume 30d',
+		key: 'perps_volume_30d',
+		category: TABLE_CATEGORIES.VOLUME,
+		period: TABLE_PERIODS.ONE_MONTH
+	},
 	{
 		name: 'Perp Volume Change 7d',
 		key: 'perps_volume_change_7d',

--- a/src/containers/ChainOverview/Table.tsx
+++ b/src/containers/ChainOverview/Table.tsx
@@ -598,7 +598,7 @@ const columnOptions = [
 		key: 'cumulativeEarnings',
 		category: TABLE_CATEGORIES.REVENUE
 	},
-	{ name: 'P/S', key: 'ps', category: TABLE_CATEGORIES.FEES },
+	{ name: 'P/S', key: 'ps', category: TABLE_CATEGORIES.REVENUE },
 	{ name: 'P/F', key: 'pf', category: TABLE_CATEGORIES.FEES },
 	{ name: 'Spot Volume 24h', key: 'dex_volume_24h', category: TABLE_CATEGORIES.VOLUME, period: TABLE_PERIODS.ONE_DAY },
 	{ name: 'Spot Volume 7d', key: 'dex_volume_7d', category: TABLE_CATEGORIES.VOLUME, period: TABLE_PERIODS.SEVEN_DAYS },


### PR DESCRIPTION
It would make more sense to have P/S  (Market cap / annualized revenue) column in the revenue category instead of fees.