### PR TITLE
feat: improved the borrows page

### DIFF
--- a/src/pages/borrow.tsx
+++ b/src/pages/borrow.tsx
@@ -99,7 +99,7 @@ export default function YieldBorrow(data) {
 			pageName={pageName}
 		>
 			<Announcement>{disclaimer}</Announcement>
-			<div className="relative mx-auto flex flex-col md:flex-row w-full items-start gap-3 rounded-md bg-(--cards-bg) p-3">
+			<div className="relative mx-auto flex flex-col md:flex-row w-full items-start gap-3 rounded-md bg-(--cards-bg) p-3 max-w-450">
 				<div className="flex w-full md:w-1/3 mx-auto flex-col gap-2 overflow-y-auto p-3 max-w-100">
 					<TokensSelect
 						label="Borrow"


### PR DESCRIPTION
I wrapped the project name in a link, added table headers, added a link to the pool and changed the styles of the borrows page

**Desktop:** 
<img width="1365" height="767" alt="Screenshot from 2025-10-08 10-51-39" src="https://github.com/user-attachments/assets/c1ae1038-d8eb-426b-9992-cdd5edd40ede" />

**Mobile:** 
<img width="486" height="632" alt="Screenshot from 2025-10-08 11-00-37" src="https://github.com/user-attachments/assets/a22b04d7-3127-43a6-bb6e-2f632df6a77e" />
