### PR TITLE
feat: add compare button to the chain overview

### DIFF
--- a/src/containers/ChainOverview/Stats.tsx
+++ b/src/containers/ChainOverview/Stats.tsx
@@ -186,9 +186,10 @@ export const Stats = memo(function Stats(props: IStatsProps) {
 								<BasicLink
 									href={compareUrl}
 									className="flex cursor-pointer flex-nowrap items-center gap-2 rounded-md bg-(--btn-bg) px-3 py-2 text-xs text-(--text-primary) hover:bg-(--btn-hover-bg) focus-visible:bg-(--btn-hover-bg)"
+									aria-label="Compare chains"
 								>
 									<Icon name="repeat" className="h-3 w-3" />
-									<span>Compare</span>
+									<span className="hidden sm:inline">Compare</span>
 								</BasicLink>
 							)}
 							<Bookmark readableName={props.metadata.name} isChain />


### PR DESCRIPTION
PR adds a compare button to the chain overview page once clicked the user will be directed to the compare chains page with the chain pre-selected and the highest in the chain array excluding itself.

**Desktop: **
<img width="1627" height="981" alt="Screenshot 2025-10-09 at 13 03 10" src="https://github.com/user-attachments/assets/f0dd9e10-bcc3-4480-a716-1efbd29e906d" />

**Mobile: **
<img width="364" height="792" alt="Screenshot 2025-10-09 at 13 03 20" src="https://github.com/user-attachments/assets/cfb51956-cd0c-467d-96af-0be4d94f254f" />

