### PR TITLE
feat: add compare button to protocol overview 

### DIFF
--- a/src/containers/ProtocolOverview/index.tsx
+++ b/src/containers/ProtocolOverview/index.tsx
@@ -142,9 +142,10 @@ export const ProtocolOverview = (props: IProtocolOverviewPageData) => {
 							<BasicLink
 								href={compareProtocolsUrl}
 								className="flex cursor-pointer flex-nowrap items-center gap-2 rounded-md bg-(--btn-bg) px-3 py-2 text-xs text-(--text-primary) hover:bg-(--btn-hover-bg) focus-visible:bg-(--btn-hover-bg)"
+								aria-label="Compare protocols"
 							>
 								<Icon name="repeat" className="h-3 w-3" />
-								<span>Compare</span>
+								<span className="hidden sm:inline">Compare</span>
 							</BasicLink>
 							<Bookmark readableName={props.name} />
 						</div>
@@ -174,9 +175,10 @@ export const ProtocolOverview = (props: IProtocolOverviewPageData) => {
 								<BasicLink
 									href={compareProtocolsUrl}
 									className="flex cursor-pointer flex-nowrap items-center gap-2 rounded-md bg-(--btn-bg) px-3 py-2 text-xs text-(--text-primary) hover:bg-(--btn-hover-bg) focus-visible:bg-(--btn-hover-bg)"
+									aria-label="Compare protocols"
 								>
 									<Icon name="repeat" className="h-3 w-3" />
-									<span>Compare</span>
+									<span className="hidden sm:inline">Compare</span>
 								</BasicLink>
 								<Bookmark readableName={props.name} />
 							</h1>


### PR DESCRIPTION
This PR adds a compare button to the protocol overview page to give quick access to compare stats of another protocol. Once clicked the user will be redirected to the compare protocol page with either the top competitor as the protocol comparison, protocol versions if combined item (aave -> aave v3,v2,v1) or by itself if it has neither a competitor or a is a combined protocol.

**Desktop:**
<img width="1646" height="1110" alt="Screenshot 2025-10-09 at 12 50 40" src="https://github.com/user-attachments/assets/cac47a6a-4fff-438f-b861-add1b60f5d45" />

**Mobile:**
<img width="394" height="843" alt="Screenshot 2025-10-09 at 12 50 15" src="https://github.com/user-attachments/assets/3d69fe1c-a9b2-4c55-a65b-b1e0952076a4" />

