### PR TITLE
fix: remove blank space in settings popover

### DIFF
--- a/src/components/Nav/Mobile/Settings.tsx
+++ b/src/components/Nav/Mobile/Settings.tsx
@@ -21,7 +21,7 @@ export function Settings({ metricFilters = [] }: { metricFilters?: { name: strin
 				wrapperProps={{
 					className: 'max-sm:fixed! max-sm:bottom-0! max-sm:top-[unset]! max-sm:transform-none! max-sm:w-full!'
 				}}
-				className="max-sm:drawer z-10 flex h-[calc(100dvh-80px)] min-w-[180px] flex-col overflow-auto overscroll-contain rounded-md border border-[hsl(204,20%,88%)] bg-(--bg-main) max-sm:rounded-b-none sm:max-h-[60dvh] lg:h-full lg:max-h-(--popover-available-height) dark:border-[hsl(204,3%,32%)]"
+				className="max-sm:drawer z-10 flex min-w-[180px] flex-col overflow-auto overscroll-contain rounded-md border border-[hsl(204,20%,88%)] bg-(--bg-main) max-sm:h-[calc(100dvh-80px)] max-sm:rounded-b-none sm:max-h-[min(400px,60dvh)] lg:max-h-(--popover-available-height) dark:border-[hsl(204,3%,32%)]"
 			>
 				<Ariakit.PopoverDismiss className="ml-auto p-2 opacity-50 sm:hidden">
 					<Icon name="x" className="h-5 w-5" />


### PR DESCRIPTION
### Problem:

- The `h-[calc(100dvh-80px)]` was applying to **ALL** screen sizes, forcing a tall fixed height on tablet/desktop
- This created blank space when the content (Settings + menu items + Dark Mode) didn't fill the entire height

<img width="601" height="800" alt="Screenshot from 2025-10-10 15-56-38" src="https://github.com/user-attachments/assets/ffabee35-c80e-4687-b322-a8a9545f9f83" />

### Solution:

- Scoped the full-height behavior to mobile only: `max-sm:h-[calc(100dvh-80px)]`
- Added a more appropriate max-height for tablet/desktop: `sm:max-h-[min(400px,60dvh)]`

This allows the popover to naturally fit its content without forcing extra space:

<img width="600" height="786" alt="Screenshot from 2025-10-10 16-40-34" src="https://github.com/user-attachments/assets/bf5f3b6d-d493-4e8d-aeec-65b520412b66" />

