### PR TITLE
fix: add missing dark mode styles for nav section hover states

### DIFF
--- a/src/components/Nav/Desktop.tsx
+++ b/src/components/Nav/Desktop.tsx
@@ -141,7 +141,7 @@ const NavDetailsSection = React.memo(function NavDetailsSection({
 				}
 			}}
 		>
-			<summary className="-ml-1.5 flex items-center justify-between gap-3 rounded-md p-1.5 hover:bg-black/5 focus-visible:bg-black/5">
+			<summary className="-ml-1.5 flex items-center justify-between gap-3 rounded-md p-1.5 hover:bg-black/5 focus-visible:bg-black/5 dark:hover:bg-white/10 dark:focus-visible:bg-white/10">
 				<span>{category}</span>
 				<Icon name="chevron-up" className="h-4 w-4 shrink-0 group-open:rotate-180" />
 			</summary>


### PR DESCRIPTION
This change ensures that the navigation section summary elements (like "More", "About Us", etc.) have proper hover and focus states in both light and dark themes, improving the user experience and visual consistency across different theme modes.

**Before:**


https://github.com/user-attachments/assets/eda8d51d-d6bc-4ab2-b2b2-26131d87188b

**After:**

https://github.com/user-attachments/assets/6c674420-473d-48ec-81ba-7682d2d50568
