### PR TITLE
fix multi select combobox

### DIFF
--- a/src/components/MultiSelectCombobox.tsx
+++ b/src/components/MultiSelectCombobox.tsx
@@ -128,6 +128,7 @@ export const MultiSelectCombobox = ({
 						<Ariakit.ComboboxItem
 							value="__see_more__"
 							setValueOnClick={false}
+							selectValueOnClick={false}
 							hideOnClick={false}
 							className="w-full cursor-pointer px-3 py-4 text-(--link) hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) data-active-item:bg-(--link-hover-bg)"
 							onClick={handleSeeMore}


### PR DESCRIPTION
Fix multi select combobox bug that include "See more" as a value

**before**:
if user click see more on search filter it will be included
<img width="651" height="365" alt="image" src="https://github.com/user-attachments/assets/a16b3d33-e36e-4df0-9941-66e674671a1d" />