### PR TITLE
fix: center unpin button vertically in pinned pages navigation

### DIFF
--- a/src/components/Nav/Desktop.tsx
+++ b/src/components/Nav/Desktop.tsx
@@ -95,7 +95,7 @@ export const DesktopNav = React.memo(function DesktopNav({
 				</details>
 
 				{pinnedPages.length > 0 ? (
-					<div className="">
+					<div>
 						<p className="flex items-center justify-between gap-3 rounded-md pt-1.5 text-xs opacity-65">Pinned Pages</p>
 
 						{pinnedPages.map(({ name, route }) => (
@@ -117,7 +117,7 @@ export const DesktopNav = React.memo(function DesktopNav({
 											}}
 										/>
 									}
-									className="absolute top-1 right-1 bottom-1 my-auto hidden rounded-md bg-(--error) px-1 py-1 text-white group-hover:block"
+									className="absolute top-1/2 right-1 hidden -translate-y-1/2 rounded-md bg-(--error) px-1 py-1 text-white group-hover:block"
 								>
 									<Icon name="x" className="h-4 w-4" />
 								</Tooltip>


### PR DESCRIPTION
**Before:**

<img width="574" height="281" alt="Screenshot from 2025-10-13 11-56-51" src="https://github.com/user-attachments/assets/e2f6fcb2-dcb8-4aa6-a30c-df9646effaeb" />

**After:**

<img width="381" height="230" alt="Screenshot from 2025-10-13 12-01-22" src="https://github.com/user-attachments/assets/ebe3a31d-4bc5-4556-93d9-cec78200cf33" />
