### PR TITLE
fix: bar chart in narrative tracker

### DIFF
--- a/src/components/ECharts/BarChart/NonTimeSeries.tsx
+++ b/src/components/ECharts/BarChart/NonTimeSeries.tsx
@@ -31,21 +31,54 @@ export default function NonTimeSeriesBarChart({
 		valueSymbol,
 		hideLegend: true,
 		tooltipOrderBottomUp,
-		isThemeDark
+		isThemeDark,
+		hideOthersInTooltip: true,
+		tooltipValuesRelative: true
 	})
 
 	const series = useMemo(() => {
-		return [
-			{
-				data: chartData.map((item) => ({
-					value: item,
-					itemStyle: {
-						color: stackColors[item[0]]
-					}
-				})),
-				type: 'bar'
-			}
-		]
+		const series = []
+
+		const allStacks = new Set<string>()
+		chartData.forEach((item) => {
+			Object.keys(item).forEach((key) => {
+				if (key !== 'date') {
+					allStacks.add(key)
+				}
+			})
+		})
+
+		for (const stack of allStacks) {
+			series.push({
+				name: stack,
+				data: chartData.map((item) => [item.date * 1e3, item[stack] ?? null]),
+				type: 'bar',
+				stack: 'chain',
+				symbol: 'none',
+				large: true,
+				emphasis: {
+					focus: 'series',
+					shadowBlur: 10
+				},
+				itemStyle: {
+					color: null
+				},
+				areaStyle: {
+					color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+						{
+							offset: 0,
+							color: null
+						},
+						{
+							offset: 1,
+							color: isThemeDark ? 'rgba(0, 0, 0, 0.2)' : 'rgba(255, 255, 255, 0.2)'
+						}
+					])
+				}
+			})
+		}
+
+		return series
 	}, [chartData, stackColors])
 
 	const createInstance = useCallback(() => {
@@ -70,32 +103,22 @@ export default function NonTimeSeriesBarChart({
 			}
 		}
 
-		const { graphic, grid, tooltip, xAxis, yAxis, dataZoom } = defaultChartSettings
+		const { graphic, titleDefaults, tooltip, xAxis, yAxis, dataZoom } = defaultChartSettings
 
 		chartInstance.setOption({
-			graphic: {
-				...graphic
-			},
-			tooltip: {
-				...tooltip
-			},
+			graphic,
+			tooltip,
+			title: titleDefaults,
 			grid: {
 				left: 12,
 				bottom: 68,
 				top: 12,
 				right: 12,
 				outerBoundsMode: 'same',
-				outerBoundsContain: 'axisLabel',
-				...grid
+				outerBoundsContain: 'axisLabel'
 			},
-			xAxis: {
-				...xAxis,
-				type: 'category',
-				boundaryGap: true
-			},
-			yAxis: {
-				...yAxis
-			},
+			xAxis,
+			yAxis,
 			dataZoom: hideDataZoom ? [] : [...dataZoom],
 			series
 		})

--- a/src/containers/NarrativeTracker/index.tsx
+++ b/src/containers/NarrativeTracker/index.tsx
@@ -101,10 +101,10 @@ export const CategoryPerformanceContainer = ({
 			: pctChangesDenom
 
 		const sorted = [...pctChangesDenom].sort((a, b) => b[field] - a[field]).map((i) => ({ ...i, change: i[field] }))
-		const barChart = sorted.map((i) => [i.name, i[field]?.toFixed(2)])
+
 		const treemapChart = sorted.map((i) => ({ ...i, returnField: i[field] }))
 
-		let lineChart =
+		let chart =
 			cumulativeWindow === '7D'
 				? performanceTimeSeries['7']
 				: cumulativeWindow === '30D'
@@ -113,9 +113,9 @@ export const CategoryPerformanceContainer = ({
 						? performanceTimeSeries['ytd']
 						: performanceTimeSeries['365']
 
-		lineChart = denomCoin === '$' ? lineChart : calculateDenominatedChange(lineChart, denomCoin)
+		chart = denomCoin === '$' ? chart : calculateDenominatedChange(chart, denomCoin)
 
-		return { sortedPctChanges: sorted, barChart, treemapChart, lineChart }
+		return { sortedPctChanges: sorted, barChart: chart, treemapChart, lineChart: chart }
 	}, [pctChanges, groupBy, performanceTimeSeries, groupByDenom, isCoinPage])
 
 	return (


### PR DESCRIPTION
Previously, loading bar charts was failing in the category page of the narrative tracker.

After:
<img width="1655" height="741" alt="image" src="https://github.com/user-attachments/assets/9bfb12e3-7f7d-4857-b06d-9a1dd37185f9" />

