### PR TITLE
Update/compare chain UI/ux

### DIFF
--- a/src/containers/CompareChains/index.tsx
+++ b/src/containers/CompareChains/index.tsx
@@ -140,20 +140,11 @@ export function CompareChains({ chains }) {
 		)
 	}, [data, router.query, tvlCharts])
 
-	const sortedChains = React.useMemo(() => {
-		const selectedValues = new Set(selectedChains.map((c) => c.value))
-		const isSelected = (chain) => selectedValues.has(chain.value)
-
-		const sorted = [...chains].sort((a, b) => (isSelected(a) === isSelected(b) ? 0 : isSelected(a) ? -1 : 1))
-
-		return sorted
-	}, [selectedChains, chains])
-
 	return (
 		<>
 			<div className="flex items-center gap-3 rounded-md border border-(--cards-border) bg-(--cards-bg)">
 				<MultiSelectCombobox
-					data={sortedChains}
+					data={chains}
 					placeholder="Select Chains..."
 					selectedValues={selectedChains.map((chain) => chain.value)}
 					setSelectedValues={(values) => {


### PR DESCRIPTION
update two user experience improvements on the compare chain page:

**1. update styles for consistent grid card layout**
before:
<img width="428" height="355" alt="image" src="https://github.com/user-attachments/assets/1217a61f-32f8-46e2-aaea-011c6ae04d3e" />

after:
<img width="428" height="355" alt="image" src="https://github.com/user-attachments/assets/1ffb8cd9-73b5-4465-85cd-a95a77dc9801" />

**2. Added sorting so selected chains appear at the top of the list**
<img width="177" height="293" alt="image" src="https://github.com/user-attachments/assets/72ea10cc-f2c6-4117-97d0-0ae271ebeac5" />
