### PR TITLE
fix: restrict theme switch clickable area

### DIFF
--- a/src/components/Nav/ThemeSwitch.tsx
+++ b/src/components/Nav/ThemeSwitch.tsx
@@ -6,7 +6,7 @@ export function ThemeSwitch() {
 	const [darkMode, toggleDarkMode] = useDarkModeManager()
 
 	return (
-		<button onClick={toggleDarkMode} className="mt-2 hidden items-center gap-2 lg:flex">
+		<button onClick={toggleDarkMode} className="hidden gap-2 items-center mt-2 lg:flex w-fit">
 			<Icon
 				name="sun"
 				height={20}


### PR DESCRIPTION
This fix improves the UX by making the interactive area match user expectations - only the visible elements (sun icon, separator, and moon icon) are now clickable.

**Before:**

<img width="1198" height="693" alt="Screenshot 2025-10-16 at 21 19 15" src="https://github.com/user-attachments/assets/1bf375cf-e33a-4e9b-a887-cc5f8f0b21f2" />

**After:**

<img width="1198" height="693" alt="Screenshot 2025-10-16 at 21 19 54" src="https://github.com/user-attachments/assets/f5c6161d-8f52-4804-81a5-8f61509caf2f" />

