### PR TITLE
refactor: update the GitHub name in some places

### DIFF
--- a/src/containers/Subscribtion/auth.tsx
+++ b/src/containers/Subscribtion/auth.tsx
@@ -370,8 +370,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 
 				return authData
 			} catch (error) {
-				console.log('Github sign-in error:', error)
-				throw new Error('Failed to sign in with Github')
+				console.log('GitHub sign-in error:', error)
+				throw new Error('Failed to sign in with GitHub')
 			}
 		},
 		onSuccess: () => {
@@ -380,7 +380,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 			setIsAuthenticated(true)
 		},
 		onError: (error) => {
-			const message = error instanceof Error ? error.message : 'Failed to connect with Github'
+			const message = error instanceof Error ? error.message : 'Failed to connect with GitHub'
 			toast.error(message)
 		}
 	})
@@ -393,10 +393,10 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 					queryKey: ['subscription', pb.authStore.record?.id]
 				})
 				onSuccess?.()
-				toast.success('Successfully signed in with Github')
+				toast.success('Successfully signed in with GitHub')
 				return Promise.resolve()
 			} catch (error) {
-				console.log('Github sign-in error:', error)
+				console.log('GitHub sign-in error:', error)
 				return Promise.reject(error)
 			}
 		},

--- a/src/pages/governance/[...project].tsx
+++ b/src/pages/governance/[...project].tsx
@@ -220,7 +220,7 @@ export default function Protocol({ data, governanceType }) {
 							rel="noopener noreferrer"
 							href={`https://github.com/${data.metadata.github}`}
 						>
-							<span>Github</span>
+							<span>GitHub</span>
 							<Icon name="arrow-up-right" height={14} width={14} />
 						</a>
 					)}


### PR DESCRIPTION
“GitHub” is one word, with a capital `G` and capital `H`.

> **Ref:** _https://brand.github.com/foundations/logo_

**Before:**

<img width="1141" height="234" alt="Screenshot from 2025-10-20 11-37-21" src="https://github.com/user-attachments/assets/6b9e858e-4c93-4636-97bf-da8f56f0c63d" />

**After:**

<img width="1153" height="171" alt="Screenshot from 2025-10-20 11-46-32" src="https://github.com/user-attachments/assets/02e45553-6240-494e-8df2-9b39e0ff5b72" />
