### PR TITLE
fix: align close button with text in Announcement component

### DIFF
--- a/src/components/Announcement.tsx
+++ b/src/components/Announcement.tsx
@@ -69,13 +69,13 @@ export function Announcement({
 
 	return (
 		<div
-			className="flex items-center justify-between gap-2 rounded-md border border-(--link-bg) bg-(--link-bg) p-2 text-sm"
+			className="flex min-h-[38px] items-center justify-between gap-2 rounded-md border border-(--link-bg) bg-(--link-bg) p-1.5 text-sm"
 			style={{ '--bg': warning ? '#41440d' : 'hsl(215deg 79% 51% / 12%)' } as any}
 		>
 			<span className="flex-1 text-center">{children}</span>
 			{!notCancellable ? (
 				<button
-					className="flex h-8 w-8 flex-shrink-0 items-center justify-center self-start rounded-md hover:bg-(--bg-input)"
+					className="flex h-6 w-6 flex-shrink-0 items-center justify-center self-start rounded-md hover:bg-(--bg-input)"
 					onClick={closeAnnouncement}
 				>
 					<Icon name="x" height={16} width={16} />


### PR DESCRIPTION
Refactored the `Announcement` component to use flexbox layout instead of absolute positioning for better alignment of the close button with the announcement text.

**Before:**

<img width="406" height="686" alt="Screenshot from 2025-10-21 11-26-53" src="https://github.com/user-attachments/assets/01abe1f4-3c98-45a5-8d88-633380abe7ab" />

**After:**

<img width="400" height="689" alt="Screenshot from 2025-10-21 11-31-44" src="https://github.com/user-attachments/assets/79556af3-f0d2-4f2e-8a61-8a4b90183876" />
