### PR TITLE
fix the pagination logic

### DIFF
--- a/src/containers/ProDashboard/components/DashboardDiscovery.tsx
+++ b/src/containers/ProDashboard/components/DashboardDiscovery.tsx
@@ -92,15 +92,17 @@ export function DashboardDiscovery() {
 	}
 
 	const pagesToShow = useMemo(() => {
+		let pages: number[]
 		if (selectedPage === 1) {
-			return [1, 2, 3]
+			pages = [1, 2, 3]
 		}
-
-		if (selectedPage === totalPages) {
-			return [totalPages - 2, totalPages - 1, totalPages]
+		else if (selectedPage === totalPages) {
+			pages = [totalPages - 2, totalPages - 1, totalPages]
 		}
-
-		return [selectedPage - 1, selectedPage, selectedPage + 1]
+		else {
+			pages = [selectedPage - 1, selectedPage, selectedPage + 1]
+		}
+		return pages.filter(page => page > 0 && page <= totalPages)
 	}, [totalPages, selectedPage])
 
 	return (


### PR DESCRIPTION
I added a filter to only show pages greater than 0 and smaller or equal to the total

Before: 
<img width="238" height="81" alt="Screenshot from 2025-10-23 08-29-31" src="https://github.com/user-attachments/assets/83af49d7-0a96-471f-976e-08b76e0e52d7" />
<img width="247" height="91" alt="Screenshot from 2025-10-23 08-29-52" src="https://github.com/user-attachments/assets/0993d488-0ed4-492a-ad69-480861cd9bdd" />

After: 
<img width="214" height="93" alt="Screenshot from 2025-10-23 08-30-00" src="https://github.com/user-attachments/assets/2eb237ce-77b8-40c0-b908-57e864178264" />
<img width="173" height="86" alt="Screenshot from 2025-10-23 08-30-07" src="https://github.com/user-attachments/assets/9765a2b9-2dcd-4311-bc1c-d437dfb4f8b0" />
