### PR TITLE
fix: prevent deselecting last chart in chain overview

### DIFF
--- a/src/containers/ChainOverview/Stats.tsx
+++ b/src/containers/ChainOverview/Stats.tsx
@@ -746,7 +746,9 @@ export const Stats = memo(function Stats(props: IStatsProps) {
 										value={tchart}
 										checked={true}
 										onChange={() => {
-											updateRoute(chainCharts[tchart], toggledCharts.includes(tchart) ? 'false' : 'true', router)
+											if (toggledCharts.length > 1) {
+												updateRoute(chainCharts[tchart], toggledCharts.includes(tchart) ? 'false' : 'true', router)
+											}
 										}}
 										className="peer absolute h-[1em] w-[1em] opacity-[0.00001]"
 									/>


### PR DESCRIPTION
This prevents the UI from entering an invalid state where no charts are displayed, improving user experience by maintaining a minimum of one visible chart at all times.

**Before:**

<img width="1107" height="416" alt="Screenshot from 2025-10-23 11-29-11" src="https://github.com/user-attachments/assets/74810fa1-b2d0-4479-af79-ab43abc0d249" />

**After:**

<img width="1105" height="421" alt="Screenshot from 2025-10-23 11-55-21" src="https://github.com/user-attachments/assets/7c0ab68f-7d02-4b74-b21e-1771629e8540" />
