### PR TITLE
fix: readable name for yield watchlist toast

### DIFF
--- a/src/components/Bookmark.tsx
+++ b/src/components/Bookmark.tsx
@@ -6,41 +6,43 @@ import { useWatchlistManager } from '~/contexts/LocalStorage'
 
 interface IBookmarkProps {
 	readableName: string
+	configID?: string
 	isChain?: boolean
 	[key: string]: any
 }
 
-export function Bookmark({ readableName, isChain, ...props }: IBookmarkProps) {
+export function Bookmark({ readableName, configID, isChain, ...props }: IBookmarkProps) {
 	const router = useRouter()
 
-	const watchlistType = isChain ? 'chains' : router.pathname.includes('/yields') ? 'yields' : 'defi'
+	const isYieldsPage = router.pathname.includes('/yields')
+	const urlPath = isYieldsPage ? '/yields/watchlist' : '/watchlist'
+
+	const watchlistType = isChain ? 'chains' : isYieldsPage ? 'yields' : 'defi'
+	const watchlistNameKey = isYieldsPage ? configID : readableName
 
 	const { savedProtocols, addProtocol, removeProtocol } = useWatchlistManager(watchlistType)
 
-	const isSaved: boolean = savedProtocols.has(readableName)
+	const isSaved: boolean = savedProtocols.has(watchlistNameKey)
+
+	const showToast = (action: 'Added' | 'Removed') => {
+		toast.success(
+			<span>
+				{action} {readableName} {action === 'Added' ? 'to' : 'from'}{' '}
+				<Link href={urlPath} className="font-medium underline">
+					watchlist
+				</Link>
+			</span>
+		)
+	}
 
 	const onClick = isSaved
 		? () => {
-				removeProtocol(readableName)
-				toast.success(
-					<span>
-						Removed {readableName} from{' '}
-						<Link href="/watchlist" className="font-medium underline">
-							watchlist
-						</Link>
-					</span>
-				)
+				removeProtocol(watchlistNameKey)
+				showToast('Removed')
 			}
 		: () => {
-				addProtocol(readableName)
-				toast.success(
-					<span>
-						Added {readableName} to{' '}
-						<Link href="/watchlist" className="font-medium underline">
-							watchlist
-						</Link>
-					</span>
-				)
+				addProtocol(watchlistNameKey)
+				showToast('Added')
 			}
 
 	return (

--- a/src/containers/Yields/Tables/Name.tsx
+++ b/src/containers/Yields/Tables/Name.tsx
@@ -58,7 +58,7 @@ export function NameYieldPool({
 
 	return (
 		<span className="flex items-center gap-2">
-			{bookmark ? <Bookmark readableName={configID} data-lgonly /> : null}
+			{bookmark ? <Bookmark readableName={value} configID={configID} data-lgonly /> : null}
 
 			<span className="shrink-0">{index}</span>
 


### PR DESCRIPTION
**The issue**: adding or removing a yield asset to the watchlist would result in the configID displaying within the toast message  

- Added a separate prop for the `configID`  only to be used for yield assets
- Added a ternary for the `urlPath`  so we now go to `/watchlist` for defi/chains and `/yields/watchlist` for yield assets
- Modified the toast to reduce repeat code


**Before:**
<img width="1247" height="600" alt="Screenshot 2025-10-24 at 17 01 35" src="https://github.com/user-attachments/assets/cdb22d49-4560-4644-88f4-705fbb0cf66e" />

**After:**
<img width="1496" height="519" alt="Screenshot 2025-10-24 at 17 08 04" src="https://github.com/user-attachments/assets/76f20c48-621e-4ba4-a311-468ceebe7a2f" />
