### PR TITLE
fix: add external link logic for navigation links

### DIFF
--- a/src/components/Nav/Desktop.tsx
+++ b/src/components/Nav/Desktop.tsx
@@ -210,11 +210,14 @@ const LinkToPage = React.memo(function LinkToPage({
 	asPath: string
 }) {
 	const isActive = route === asPath.split('/?')[0].split('?')[0]
+	const isExternal = route.startsWith('http')
 
 	return (
 		<BasicLink
 			href={route}
 			data-linkactive={isActive}
+			target={isExternal ? '_blank' : undefined}
+			rel={isExternal ? 'noopener noreferrer' : undefined}
 			className="group/link -ml-1.5 flex flex-1 items-center gap-3 rounded-md p-1.5 hover:bg-black/5 focus-visible:bg-black/5 data-[linkactive=true]:bg-(--link-active-bg) data-[linkactive=true]:text-white dark:hover:bg-white/10 dark:focus-visible:bg-white/10"
 		>
 			{icon ? (

--- a/src/components/Nav/Mobile/Menu.tsx
+++ b/src/components/Nav/Mobile/Menu.tsx
@@ -168,9 +168,13 @@ const LinkToPage = React.memo(function LinkToPage({
 	setShow: (show: boolean) => void
 }) {
 	const isActive = route === asPath.split('/?')[0].split('?')[0]
+	const isExternal = route.startsWith('http')
+
 	return (
 		<BasicLink
 			href={route}
+			target={isExternal ? '_blank' : undefined}
+			rel={isExternal ? 'noopener noreferrer' : undefined}
 			data-linkactive={isActive}
 			className="-ml-1.5 flex items-center gap-3 rounded-md p-1.5 hover:bg-black/5 focus-visible:bg-black/5 data-[linkactive=true]:bg-(--link-active-bg) data-[linkactive=true]:text-white dark:hover:bg-white/10 dark:focus-visible:bg-white/10"
 			onClick={() => setShow(false)}


### PR DESCRIPTION
There were multiple pages in the lower navigation section that navigate to a different website but stay in the same window. I have resolved this by adding the external link logic to both the dekstop and mobile navigation components.

**Before:**

https://github.com/user-attachments/assets/49715a5c-5347-430a-9f7e-9afda395f97c

**After:**

https://github.com/user-attachments/assets/09c9ee25-b6fa-4e5d-b3f5-e8c99cace597


