### PR TITLE
fix the pro dashboard buttons on mobile

### DIFF
--- a/src/pages/pro.tsx
+++ b/src/pages/pro.tsx
@@ -137,7 +137,7 @@ function ProContent({
 						</BasicLink>
 					)}
 				</div>
-				<div className="ml-auto flex flex-wrap justify-end gap-2">
+				<div className="mr-auto md:mr-0 ml-auto flex justify-end gap-2">
 					{
 						<button
 							onClick={
@@ -147,7 +147,7 @@ function ProContent({
 										? () => setShowGenerateDashboardModal(true)
 										: () => setShowSubscribeModal(true)
 							}
-							className="pro-btn-blue flex items-center gap-1 rounded-md px-4 py-2"
+							className="pro-btn-blue flex items-center gap-1 rounded-md px-4 py-2 text-xs md:text-sm"
 						>
 							<Icon name="sparkles" height={16} width={16} />
 							Generate with LlamaAI
@@ -161,7 +161,7 @@ function ProContent({
 									? createNewDashboard
 									: () => setShowSubscribeModal(true)
 						}
-						className="pro-btn-purple flex items-center gap-1 rounded-md px-4 py-2"
+						className="pro-btn-purple flex items-center gap-1 rounded-md px-4 py-2 text-xs md:text-sm"
 					>
 						<Icon name="plus" height={16} width={16} />
 						Create New Dashboard


### PR DESCRIPTION
This PR fixes the layout of the pro dashboard buttons by reducing their font size and removing flex-wrap from the container

**Before:**

<img width="398" height="561" alt="Screenshot from 2025-10-25 07-59-10" src="https://github.com/user-attachments/assets/4b31cb1a-3a7e-4e8c-a6f6-f2e80bddc2b9" />

**After:**

<img width="397" height="560" alt="Screenshot from 2025-10-25 07-59-25" src="https://github.com/user-attachments/assets/50ee7261-77ea-45c0-9531-c29604ab7656" />


