### PR TITLE
Fix comment typos

### DIFF
--- a/public/game/index.js
+++ b/public/game/index.js
@@ -1203,7 +1203,7 @@
 	 * @param {Obstacle.type} type
 	 * @param {Object} spritePos Obstacle position in sprite.
 	 * @param {Object} dimensions
-	 * @param {number} gapCoefficient Mutipler in determining the gap.
+     * @param {number} gapCoefficient Multiplier in determining the gap.
 	 * @param {number} speed
 	 * @param {number} opt_xOffset
 	 */
@@ -1570,7 +1570,7 @@
 
 		/**
 		 * Setter for the jump velocity.
-		 * The approriate drop velocity is also set.
+		 * The appropriate drop velocity is also set.
 		 */
 		setJumpVelocity: function (setting) {
 			this.config.INIITAL_JUMP_VELOCITY = -setting
@@ -2036,7 +2036,7 @@
 		},
 
 		/**
-		 * Set the highscore as a array string.
+         * Set the high score as an array string.
 		 * Position of char in the sprite: H - 10, I - 11.
 		 * @param {number} distance Distance ran in pixels.
 		 */
@@ -2156,7 +2156,7 @@
 	//******************************************************************************
 
 	/**
-	 * Nightmode shows a moon and stars on the horizon.
+     * Night mode shows a moon and stars on the horizon.
 	 */
 	function NightMode(canvas, spritePos, containerWidth) {
 		this.spritePos = spritePos

--- a/src/containers/Unlocks/Table.tsx
+++ b/src/containers/Unlocks/Table.tsx
@@ -422,7 +422,7 @@ const columnOptions = [
 	{ name: 'Next Event', key: 'upcomingEvent' }
 ]
 
-// these are mising in emissionsColumns
+// these are missing in emissionsColumns
 // { name: 'Token Symbol', key: 'symbol' },
 // { name: 'Next Unlock Date', key: 'nextUnlockDate' },
 // { name: 'Token Amount', key: 'unlockAmount' },


### PR DESCRIPTION
Cleaning up some typos in the document:
- `public/game/index.js`:
  - `Mutipler` → `Multiplier` 
  - `approriate ` → `appropriate` 
  - `Nightmode` → `Night mode` 
  - `highscore as a array` → `high score as an array`
- `src/containers/Unlocks/Table.tsx`:
  - `mising` → `missing` 