### PR TITLE
fix: resolve ESLint no-unused-vars conflict with TypeScript files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,19 +17,28 @@ const eslintConfig = [
 	},
 	{
 		rules: {
-			'no-undef': 1,
-			'no-unused-vars': 1,
 			'react/no-unescaped-entities': 0,
 			'@next/next/no-img-element': 0,
 			'@typescript-eslint/no-explicit-any': 0,
-			'@typescript-eslint/no-unused-vars': 1,
 			'prefer-const': 0
+		}
+	},
+	{
+		files: ['**/*.js', '**/*.jsx'],
+		rules: {
+			'no-undef': 1,
+			'no-unused-vars': 1
 		}
 	},
 	{
 		files: ['**/*.ts', '**/*.tsx'],
 		languageOptions: {
 			parser: typescriptParser
+		},
+		rules: {
+			'no-undef': 0, // TypeScript handles this
+			'no-unused-vars': 0, // Disable base rule for TypeScript files
+			'@typescript-eslint/no-unused-vars': 1 // Use TypeScript-specific rule instead
 		}
 	}
 ]


### PR DESCRIPTION
## Summary

This was caused by a conflict between the base JavaScript `no-unused-vars` rule and the TypeScript-specific `@typescript-eslint/no-unused-vars` rule being applied simultaneously to TypeScript files.

- Closes: https://github.com/DefiLlama/defillama-app/issues/2256

## Solution
Updated `eslint.config.mjs` to properly separate linting rules by file type:

- **JavaScript files** (`.js`, `.jsx`): Use base ESLint rules (`no-unused-vars`, `no-undef`)
- **TypeScript files** (`.ts`, `.tsx`): Explicitly disable base rules and use TypeScript-specific rules instead
  - Disabled `no-undef` (TypeScript compiler handles this)
  - Disabled `no-unused-vars` (conflicts with TypeScript enum syntax)
  - Enabled `@typescript-eslint/no-unused-vars` (TypeScript-aware version)