### PR TITLE
fix: restrict pinned pages drag to vertical axis only

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 	"dependencies": {
 		"@ariakit/react": "0.4.18",
 		"@dnd-kit/core": "6.0.8",
+		"@dnd-kit/modifiers": "^9.0.0",
 		"@dnd-kit/sortable": "7.0.2",
 		"@marsidev/react-turnstile": "1.1.0",
 		"@meilisearch/instant-meilisearch": "0.27.0",

--- a/src/components/Nav/Desktop/PinnedPages.tsx
+++ b/src/components/Nav/Desktop/PinnedPages.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
+import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { Icon } from '~/components/Icon'
@@ -65,7 +66,11 @@ export const PinnedPages = React.memo(function PinnedPages({
 				) : null}
 			</div>
 			{isReordering ? <p className="text-[11px] text-(--text-tertiary)">Drag to reorder, click X to unpin</p> : null}
-			<DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+			<DndContext
+				sensors={sensors}
+				onDragEnd={handleDragEnd}
+				modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+			>
 				<SortableContext items={pinnedPages.map(({ route }) => route)} strategy={verticalListSortingStrategy}>
 					<div className="flex flex-col">
 						{pinnedPages.map((page) => (

--- a/src/components/Nav/Mobile/Menu.tsx
+++ b/src/components/Nav/Mobile/Menu.tsx
@@ -3,6 +3,7 @@ import { Suspense, useState } from 'react'
 import { useRouter } from 'next/router'
 import * as Ariakit from '@ariakit/react'
 import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
+import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { Icon } from '~/components/Icon'
@@ -208,7 +209,11 @@ const PinnedPagesSection = React.memo(function PinnedPagesSection({
 			{isReordering ? (
 				<p className="mt-1 text-[11px] text-(--text-tertiary)">Drag to reorder, tap remove to unpin</p>
 			) : null}
-			<DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+			<DndContext
+				sensors={sensors}
+				onDragEnd={handleDragEnd}
+				modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+			>
 				<SortableContext items={pinnedPages.map(({ route }) => route)} strategy={verticalListSortingStrategy}>
 					<div className="mt-1 flex flex-col gap-1">
 						{pinnedPages.map((page) => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,6 +198,14 @@
     "@dnd-kit/utilities" "^3.2.1"
     tslib "^2.0.0"
 
+"@dnd-kit/modifiers@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz#96a0280c77b10c716ef79d9792ce7ad04370771d"
+  integrity sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
 "@dnd-kit/sortable@7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-7.0.2.tgz#791d550872457f3f3c843e00d159b640f982011c"
@@ -206,7 +214,7 @@
     "@dnd-kit/utilities" "^3.2.0"
     tslib "^2.0.0"
 
-"@dnd-kit/utilities@^3.2.0", "@dnd-kit/utilities@^3.2.1":
+"@dnd-kit/utilities@^3.2.0", "@dnd-kit/utilities@^3.2.1", "@dnd-kit/utilities@^3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz#5a32b6af356dc5f74d61b37d6f7129a4040ced7b"
   integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==


### PR DESCRIPTION
## Summary

- Closes https://github.com/DefiLlama/defillama-app/issues/2287

Added a custom `restrictToVerticalAxis` and `restrictToParentElement` modifier to the `DndContext` to constrain dragging to vertical movement only.

This prevents horizontal drag movement while maintaining the intended vertical reordering functionality, which aligns with the `verticalListSortingStrategy` already in use.

