### PR TITLE
fix type issue in StablecoinsDataset

### DIFF
--- a/src/containers/ProDashboard/components/datasets/StablecoinsDataset/columns.tsx
+++ b/src/containers/ProDashboard/components/datasets/StablecoinsDataset/columns.tsx
@@ -48,7 +48,7 @@ export const stablecoinsDatasetColumns: ColumnDef<IPeggedAssetRow>[] = [
 		header: 'Price',
 		accessorKey: 'price',
 		cell: ({ getValue, row }) => {
-			const value = getValue() as number
+			const value = parseFloat(getValue() as string)
 			const pegDeviation = row.original.pegDeviation
 
 			return (


### PR DESCRIPTION
The StablecoinsDataset table was crashing because some of the prices are strings, I parsed the prices to fix it