### PR TITLE
fix: combobox blinking

### DIFF
--- a/src/containers/LlamaAI/index.tsx
+++ b/src/containers/LlamaAI/index.tsx
@@ -1469,16 +1469,18 @@ const PromptInput = memo(function PromptInput({
 
 		const trigger = getTrigger(event.target)
 		const searchValue = getSearchValue(event.target)
-		// If there's a trigger character, we'll show the combobox popover. This can
-		// be true both when the trigger character has just been typed and when
-		// content has been deleted (e.g., with backspace) and the character right
-		// before the caret is the trigger.
-		if (trigger) {
+		const triggerOffset = getTriggerOffset(event.target)
+		// Only show combobox if there's a valid trigger offset (@ is isolated) and search value
+		// This prevents showing combobox in emails like "test@gmail.com"
+		if (triggerOffset !== -1 && searchValue.length > 0) {
 			combobox.show()
 		}
-		// There will be no trigger and no search value if the trigger character has
-		// just been deleted.
-		else if (!searchValue) {
+		// If user just typed @ (trigger exists but no search value yet), don't show combobox
+		else if (trigger && searchValue.length === 0) {
+			combobox.hide()
+		}
+		// If no valid trigger offset, hide and clear
+		else if (triggerOffset === -1) {
 			combobox.setValue('')
 			combobox.hide()
 		}


### PR DESCRIPTION
**Issue:**  
After selecting an item in the combobox, typing `@` immediately causes the suggestions list to appear and then quickly disappear (blink).

**Solution:**  
1. Add `triggerOffset` check to ensure a valid trigger position  
   - Uses `getTriggerOffset()` to verify that `@` is isolated (not part of an email or word).  
   - Example:  
     - ✅ `@solana` → valid trigger.  
     - ❌ `test@gmail.com` → invalid trigger (ignored).
2. Show combobox only when there’s search input after `@`  
   - Prevents showing an empty list immediately after typing `@`, avoiding blinking.
3. Hide and clear combobox if trigger is invalid  
   - When the trigger offset is `-1`, clear combobox and hide it to keep the UI clean.
