### PR TITLE
Reduce subscription api calls

### DIFF
--- a/src/containers/Subscribtion/auth.tsx
+++ b/src/containers/Subscribtion/auth.tsx
@@ -563,7 +563,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 					expand: currentUserData.expand,
 					subscription_status: subscription?.status || 'inactive',
 					subscription: subscription || { id: '', expires_at: '', status: 'inactive' },
-					ethereum_email: (currentUserData as any).ethereum_email
+					ethereum_email: (currentUserData as any).ethereum_email,
+					has_active_subscription: (currentUserData as any).has_active_subscription || false
 				} as User)
 			: null,
 		login,


### PR DESCRIPTION
I already updated auth backend to allow sending subscription status requests without the subscription type, it'll reduce number of calls we make to check if user has an active sub 3->1. Also refactored the subscription hook a bit