### PR TITLE
fix: prevent check-circle icon from shrinking on Sheets page

### DIFF
--- a/src/containers/Sheets/index.tsx
+++ b/src/containers/Sheets/index.tsx
@@ -123,7 +123,7 @@ export default function SheetsContainer() {
 					<ul className="space-y-6 text-[#b4b7bc]">
 						{dataPoints.map((point, idx) => (
 							<li key={idx} className="flex items-center gap-3">
-								<Icon name="check-circle" height={16} width={16} className="text-[#5C5CF9]" />
+								<Icon name="check-circle" height={16} width={16} className="shrink-0 text-[#5C5CF9]" />
 								<span>{point}</span>
 							</li>
 						))}


### PR DESCRIPTION
**Before:**

<img width="398" height="461" alt="Screenshot from 2025-11-18 08-21-44" src="https://github.com/user-attachments/assets/744d9919-20b3-4de3-b0c4-72dbd84e3fc6" />

**After:**

<img width="397" height="474" alt="Screenshot from 2025-11-18 08-52-36" src="https://github.com/user-attachments/assets/5cae6129-6733-4572-8af3-db0fab45abce" />