### PR TITLE
[fix] /yield/pool infinite loop crash

### DIFF
--- a/src/components/ECharts/AreaChart/index.tsx
+++ b/src/components/ECharts/AreaChart/index.tsx
@@ -42,7 +42,10 @@ export default function AreaChart({
 	...props
 }: IChartProps) {
 	const id = useId()
-	const shouldEnableExport = enableImageExport ?? (!!title && !hideDownloadButton)
+	const shouldEnableExport = useMemo(
+		() => enableImageExport ?? (!!title && !hideDownloadButton),
+		[enableImageExport, title, hideDownloadButton]
+	)
 	const { chartInstance: exportChartInstance, handleChartReady } = useChartImageExport()
 
 	const [legendOptions, setLegendOptions] = useState(customLegendOptions)

--- a/src/pages/yields/pool/[pool].tsx
+++ b/src/pages/yields/pool/[pool].tsx
@@ -562,7 +562,6 @@ const PageView = (props) => {
 									enableImageExport={true}
 									imageExportFilename={`${query.pool}-pool-liquidity`}
 									imageExportTitle="Pool Liquidity"
-									onReady={handlePoolLiquidityChartReady}
 								/>
 							</Suspense>
 						</LazyChart>


### PR DESCRIPTION
# This PR 
Fixes issue with infinite loop of AreaChart in `Yield/Pool` ([Test here](https://defillama.com/yields/pool/f981a304-bb6c-45b8-b0c5-fd2f515ad23a))

`handleChartReady`being called in the same useEffect twice
- [here](https://github.com/DefiLlama/defillama-app/blob/main/src/components/ECharts/AreaChart/index.tsx#L307) - the callback for `useChartImageExport` 
- [here](https://github.com/DefiLlama/defillama-app/blob/main/src/pages/yields/pool/%5Bpool%5D.tsx#L565) - calling the same callback ([here](https://github.com/DefiLlama/defillama-app/blob/main/src/pages/yields/pool/%5Bpool%5D.tsx#L79C3-L79C22))

Also memoizes the `shouldEnableExport`