### PR TITLE
 Move capitalize helper before use

### DIFF
--- a/scripts/pullMetadata.js
+++ b/scripts/pullMetadata.js
@@ -30,6 +30,8 @@ try {
 
 const fetchJson = async (url) => fetch(url).then((res) => res.json())
 
+const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1)
+
 async function pullData() {
 	const endAt = Date.now()
 	const startAt = endAt - 1000 * 60 * 60 * 24 * 90
@@ -209,5 +211,3 @@ if (shouldPullData()) {
 	console.log('Metadata was pulled recently. No need to pull again.')
 	process.exit(0) // Exit successfully
 }
-
-const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1)


### PR DESCRIPTION
 - Fixed a latent ReferenceError in `scripts/pullMetadata.js` where `capitalize` was used in trending route mapping before it was defined; when `trendingRoutes` is non-empty the script crashes.
  - Hoisted the helper definition so metadata pulls can complete.