### PR TITLE
fix: pass in an unfiltered list of protocols to RecentlyListedProtoco…

### DIFF
--- a/src/containers/RecentProtocols/Table.tsx
+++ b/src/containers/RecentProtocols/Table.tsx
@@ -26,12 +26,14 @@ import { formattedNum, toNiceDaysAgo } from '~/utils'
 
 export function RecentlyListedProtocolsTable({
 	data,
+	fullProtocolList,
 	queries,
 	selectedChains,
 	chainList,
 	forkedList
 }: {
 	data: Array<IProtocolRow>
+	fullProtocolList: Array<IProtocolRow>
 	queries: {
 		[key: string]: string | string[]
 	}
@@ -184,7 +186,7 @@ export function RecentlyListedProtocolsTable({
 
 				<div className="flex items-start gap-2 max-sm:w-full max-sm:flex-col sm:items-center">
 					<div className="flex w-full items-center gap-2 sm:w-auto">
-						<ProtocolCategoryFilter protocols={data} />
+						<ProtocolCategoryFilter protocols={fullProtocolList} />
 						<SelectWithCombobox
 							label="Chains"
 							allValues={chainList}

--- a/src/containers/RecentProtocols/index.tsx
+++ b/src/containers/RecentProtocols/index.tsx
@@ -322,6 +322,7 @@ export function RecentProtocols({ protocols, chainList, forkedList, claimableAir
 
 			<RecentlyListedProtocolsTable
 				data={protocolsData}
+				fullProtocolList={protocols}
 				queries={queries}
 				selectedChains={selectedChains}
 				chainList={chainList}


### PR DESCRIPTION
smol fix for part of https://github.com/DefiLlama/defillama-app/pull/2316

If you chose to hide a category from the table the category would vanish from the filter, preventing you from re-selecting it unless you clicked "Toggle All" or refresh. Now an unfiltered list of protocols is passed into the RecentlyListedProtocolsTable to prevent this.