### PR TITLE
 Fix typos in comments

### DIFF
--- a/src/components/ButtonStyled/ChartExportButton.tsx
+++ b/src/components/ButtonStyled/ChartExportButton.tsx
@@ -239,7 +239,7 @@ export const ChartExportButton = memo(function ChartExportButton({
 					// Set options on the temporary chart with any modifications you want
 					tempChart.setOption(currentOptions)
 
-					// need to set seperately for some reason
+					// need to set separately for some reason
 					tempChart.setOption({
 						legend: {
 							show: true,

--- a/src/containers/Yields/Tables/Pools.tsx
+++ b/src/containers/Yields/Tables/Pools.tsx
@@ -182,7 +182,7 @@ const columns: ColumnDef<IYieldTableRow>[] = [
 		size: 100,
 		meta: {
 			align: 'end',
-			headerHelperText: `7d Impermanent Loss: the percentage loss between LPing for the last 7days vs hodling the underlying assets instead. ${uniswapV3}`
+			headerHelperText: `7d Impermanent Loss: the percentage loss between LPing for the last 7days vs holding the underlying assets instead. ${uniswapV3}`
 		}
 	},
 	{


### PR DESCRIPTION
 - Fix typo: `seperately` → `separately` in ChartExportButton.tsx
  - Replace informal term: `hodling` → `holding` in Pools.tsx tooltip