### PR TITLE
fix: fix Raises option value in protocol flag dropdown

### DIFF
--- a/src/containers/ProtocolOverview/Flag.tsx
+++ b/src/containers/ProtocolOverview/Flag.tsx
@@ -125,7 +125,7 @@ export function Flag({
 								<option value="Governance">Governance</option>
 								<option value="Bridge Volume">Bridge Volume</option>
 								<option value="Events">Events</option>
-								<option value="Raises">Events</option>
+								<option value="Raises">Raises</option>
 							</select>
 						)}
 					</label>


### PR DESCRIPTION
Corrected the value attribute for the "Raises" option in the protocol flag dropdown from "Events" to "Raises" to ensure proper form submission and data handling.