### PR TITLE
feat: add missing L2s to gas token config

### DIFF
--- a/src/constants/chainTokens.ts
+++ b/src/constants/chainTokens.ts
@@ -43,5 +43,25 @@ export const chainCoingeckoIdsForGasNotMcap = {
 		geckoId: 'ethereum',
 		symbol: 'ETH',
 		cmcId: '1027'
+	},
+	Linea: {
+		geckoId: 'ethereum',
+		symbol: 'ETH',
+		cmcId: '1027'
+	},
+	Scroll: {
+		geckoId: 'ethereum',
+		symbol: 'ETH',
+		cmcId: '1027'
+	},
+	Blast: {
+		geckoId: 'ethereum',
+		symbol: 'ETH',
+		cmcId: '1027'
+	},
+	Mode: {
+		geckoId: 'ethereum',
+		symbol: 'ETH',
+		cmcId: '1027'
 	}
 }


### PR DESCRIPTION
 Added Linea, Scroll, Blast, and Mode to `chainCoingeckoIdsForGasNotMcap`.

These L2s use ETH as their gas token but were missing from this configuration. This fix ensures their gas costs are calculated correctly using the Ethereum price rather than potentially falling back to incorrect governance token prices or null values.