### PR TITLE
fix: dark mode for date input field

### DIFF
--- a/src/containers/Bridges/Transactions.tsx
+++ b/src/containers/Bridges/Transactions.tsx
@@ -130,7 +130,7 @@ export const BridgeTransactionsPage = ({ bridges }) => {
 								value={startDate}
 								onChange={(e) => handleStartDateChange(e.target.value)}
 								required
-								className="placeholder:text-opacity-40 rounded-lg bg-[#f2f2f2] px-3 py-2 text-base text-black dark:bg-black dark:text-white dark:[color-scheme:dark]"
+								className="placeholder:text-opacity-40 cursor-pointer rounded-lg bg-[#f2f2f2] px-3 py-2 text-base text-black dark:bg-black dark:text-white dark:[color-scheme:dark]"
 							/>
 						</label>
 						<label className="flex flex-col">
@@ -142,7 +142,7 @@ export const BridgeTransactionsPage = ({ bridges }) => {
 								onChange={(e) => handleEndDateChange(e.target.value)}
 								min={startDate}
 								required
-								className="placeholder:text-opacity-40 rounded-lg bg-[#f2f2f2] px-3 py-2 text-base text-black dark:bg-black dark:text-white dark:[color-scheme:dark]"
+								className="placeholder:text-opacity-40 cursor-pointer rounded-lg bg-[#f2f2f2] px-3 py-2 text-base text-black dark:bg-black dark:text-white dark:[color-scheme:dark]"
 							/>
 						</label>
 					</span>

--- a/src/containers/Cexs/DateFilter.tsx
+++ b/src/containers/Cexs/DateFilter.tsx
@@ -146,7 +146,7 @@ export const DateFilter = ({ startDate, endDate }) => {
 							<input
 								type="date"
 								name="startDate"
-								className="h-9 w-full rounded-md border border-(--form-control-border) bg-white px-3 py-1 text-black disabled:opacity-50 dark:bg-black dark:text-white dark:[color-scheme:dark]"
+								className="h-9 w-full cursor-pointer rounded-md border border-(--form-control-border) bg-white px-3 py-1 text-black disabled:opacity-50 dark:bg-black dark:text-white dark:[color-scheme:dark]"
 								value={localStartDate}
 								max={maxDate}
 								onChange={handleStartDateChange}
@@ -173,7 +173,7 @@ export const DateFilter = ({ startDate, endDate }) => {
 							<input
 								type="date"
 								name="endDate"
-								className="h-9 w-full rounded-md border border-(--form-control-border) bg-white px-3 py-1 text-black disabled:opacity-50 dark:bg-black dark:text-white dark:[color-scheme:dark]"
+								className="h-9 w-full cursor-pointer rounded-md border border-(--form-control-border) bg-white px-3 py-1 text-black disabled:opacity-50 dark:bg-black dark:text-white dark:[color-scheme:dark]"
 								value={localEndDate}
 								max={maxDate}
 								onChange={handleEndDateChange}

--- a/src/containers/TokenPnl/DateInput.tsx
+++ b/src/containers/TokenPnl/DateInput.tsx
@@ -22,7 +22,7 @@ export const DateInput = ({
 				onChange={(event) => onChange(event.target.value)}
 				min={min}
 				max={max}
-				className={`rounded-md border bg-(--bg-input) px-3 py-2.5 text-base text-black outline-0 transition-colors duration-200 focus:border-white/30 focus:ring-0 dark:text-white dark:[color-scheme:dark] ${invalid ? 'border-red-500' : 'border-(--form-control-border)'}`}
+				className={`cursor-pointer rounded-md border bg-(--bg-input) px-3 py-2.5 text-base text-black outline-0 transition-colors duration-200 focus:border-white/30 focus:ring-0 dark:text-white dark:[color-scheme:dark] ${invalid ? 'border-red-500' : 'border-(--form-control-border)'}`}
 			/>
 		</label>
 	)

--- a/src/pages/pitch.tsx
+++ b/src/pages/pitch.tsx
@@ -270,7 +270,7 @@ const VCFilterPage = ({ categories, chains, defiCategories, roundTypes, lastRoun
 							<span className="">Minimum last investment time:</span>
 							<input
 								type="date"
-								className="rounded-md border border-(--form-control-border) bg-white p-1.5 text-base text-black dark:bg-black dark:text-white dark:[color-scheme:dark]"
+								className="cursor-pointer rounded-md border border-(--form-control-border) bg-white p-1.5 text-base text-black dark:bg-black dark:text-white dark:[color-scheme:dark]"
 								value={unixToDateString(filters.minLastRoundTime)}
 								onChange={handleDateChange}
 								max={new Date().toISOString().split('T')[0]}

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -650,7 +650,6 @@
 	html.dark input[type='date']::-webkit-calendar-picker-indicator {
 		filter: brightness(0) saturate(100%) invert(76%) sepia(0%) saturate(0%) hue-rotate(0deg) brightness(95%)
 			contrast(88%);
-		cursor: pointer;
 		opacity: 1 !important;
 	}
 


### PR DESCRIPTION
The date input field was still showing as light when the site is in dark mode. This was happening on multiple pages: `/bridges-transactions`, `/token-pnl`, `/cexs` and `/pitches`. 

- added `dark:[color-scheme:dark]` class to the input fields so the input field can determine when dark mode is active 
- modified the existing tailwind class to display a light grey icon color, and cursor pointer

**Before:**
<img width="338" height="411" alt="Screenshot 2025-12-12 at 13 20 54" src="https://github.com/user-attachments/assets/72d20de7-7df1-4a0e-ad7c-89c9fe38dd69" />
<img width="364" height="515" alt="Screenshot 2025-12-12 at 15 45 12" src="https://github.com/user-attachments/assets/95099eda-f7ea-4ae9-9091-bb58def2358c" />
<img width="816" height="557" alt="Screenshot 2025-12-12 at 15 44 04" src="https://github.com/user-attachments/assets/198d5fd8-0584-4d50-9e9c-870fe8435d47" />

**After:**
<img width="417" height="482" alt="Screenshot 2025-12-12 at 16 03 14" src="https://github.com/user-attachments/assets/503c411b-227d-4900-b004-2c4af2f970bd" />
<img width="347" height="502" alt="Screenshot 2025-12-12 at 16 15 11" src="https://github.com/user-attachments/assets/35a39101-47f7-4e35-81c3-eba93c9b6a2e" />
<img width="533" height="478" alt="Screenshot 2025-12-12 at 16 15 58" src="https://github.com/user-attachments/assets/784b9b43-53fa-4a27-9d04-8220f5cc6478" />


