### PR TITLE
Fix redirects

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -348,11 +348,6 @@ const nextConfig: NextConfig = {
 				permanent: true
 			},
 			{
-				source: '/perp',
-				destination: '/perps',
-				permanent: true
-			},
-			{
 				source: '/perps/chain',
 				destination: '/perps/chains',
 				permanent: true
@@ -489,17 +484,17 @@ const nextConfig: NextConfig = {
 			},
 			{
 				source: '/compare',
-				destination: '/comapre-chains',
+				destination: '/compare-chains',
+				permanent: true
+			},
+			{
+				source: '/comapre-chains',
+				destination: '/compare-chains',
 				permanent: true
 			},
 			{
 				source: '/comparison',
 				destination: '/compare-protocols',
-				permanent: true
-			},
-			{
-				source: '/compare-chain',
-				destination: '/comapre-chains',
 				permanent: true
 			},
 			{


### PR DESCRIPTION
This PR fixes some redirects:

* Removed duplicate `/perp -> /perps` redirect. Another identical entry already exists around lines 225-229.
* Fixed typo in `/compare -> /comapre-chains` redirect.
* Added `/comapre-chains -> /compare-chains` redirect in case any existing links use the misspelled path.
* Removed unreachable and incorrect `/compare-chain -> /comapre-chains` redirect; `/compare-chain -> /compare-chains` redirect remains around lines 255-259.