### PR TITLE
fix: add hover wiggle animation to LlamaAI icon

### DIFF
--- a/src/components/Nav/Desktop/shared.tsx
+++ b/src/components/Nav/Desktop/shared.tsx
@@ -45,7 +45,7 @@ export const NavItemContent = React.memo(function NavItemContent({
 			{icon ? (
 				<Icon name={icon as any} className="group-hover/link:animate-wiggle h-4 w-4 shrink-0" />
 			) : name === 'LlamaAI' ? (
-				<svg className="h-4 w-4 shrink-0">
+				<svg className="group-hover/link:animate-wiggle h-4 w-4 shrink-0">
 					<use href="/icons/ask-llamaai-3.svg#ai-icon" />
 				</svg>
 			) : null}

--- a/src/components/Nav/Mobile/Menu.tsx
+++ b/src/components/Nav/Mobile/Menu.tsx
@@ -351,7 +351,7 @@ const NavItemContent = React.memo(function NavItemContent({
 			{icon ? (
 				<Icon name={icon as any} className="group-hover/link:animate-wiggle h-4 w-4 shrink-0" />
 			) : name === 'LlamaAI' ? (
-				<svg className="h-4 w-4 shrink-0">
+				<svg className="group-hover/link:animate-wiggle h-4 w-4 shrink-0">
 					<use href="/icons/ask-llamaai-3.svg#ai-icon" />
 				</svg>
 			) : null}


### PR DESCRIPTION
## Description

The LlamaAI icon was missing the group-hover/link:animate-wiggle class that other sidebar icons have. Added the animation class to both desktop and mobile navigation components for consistency.

### Before

https://github.com/user-attachments/assets/600a7809-1428-4c63-b1f2-697516e33eed


### After 

https://github.com/user-attachments/assets/3c1f87f3-bf1f-4aa4-b719-b850e6636609


