### PR TITLE
fix: display icons in mobile navigation menu

### DIFF
--- a/src/components/Nav/Mobile/Menu.tsx
+++ b/src/components/Nav/Mobile/Menu.tsx
@@ -47,10 +47,11 @@ export const Menu = React.memo(function Menu({
 						<div key={`mobile-nav-${category}`} className="group mb-3 flex flex-col first:mb-auto">
 							<p className="mb-1 text-xs opacity-65">{category}</p>
 							<hr className="border-black/20 dark:border-white/20" />
-							{pages.map(({ name, route, attention }) => (
+							{pages.map(({ name, route, icon, attention }) => (
 								<LinkToPage
 									route={route}
 									name={name}
+									icon={icon}
 									attention={attention}
 									key={`mobile-nav-${name}-${route}`}
 									asPath={asPath}
@@ -75,10 +76,11 @@ export const Menu = React.memo(function Menu({
 												<Icon name="chevron-down" className="h-4 w-4 shrink-0 group-open/second:rotate-180" />
 											</summary>
 											<div className="border-l border-black/20 pl-2 dark:border-white/20">
-												{pages.map(({ name, route }) => (
+												{pages.map(({ name, route, icon }) => (
 													<LinkToPage
 														route={route}
 														name={name}
+														icon={icon}
 														key={`mobile-nav-old-${name}-${route}`}
 														asPath={asPath}
 														setShow={setShow}
@@ -108,10 +110,11 @@ export const Menu = React.memo(function Menu({
 						<div className="group mb-3 flex flex-col first:mb-auto">
 							<p className="mb-1 text-xs opacity-65">Your Dashboards</p>
 							<hr className="border-black/20 dark:border-white/20" />
-							{userDashboards.map(({ name, route }) => (
+							{userDashboards.map(({ name, route, icon }) => (
 								<LinkToPage
 									route={route}
 									name={name}
+									icon={icon}
 									key={`mobile-nav-${name}-${route}`}
 									asPath={asPath}
 									setShow={setShow}
@@ -124,10 +127,11 @@ export const Menu = React.memo(function Menu({
 						<div key={`mobile-nav-${category}`} className="group mb-3 flex flex-col first:mb-auto">
 							<p className="mb-1 text-xs opacity-65">{category}</p>
 							<hr className="border-black/20 dark:border-white/20" />
-							{pages.map(({ name, route }) => (
+							{pages.map(({ name, route, icon }) => (
 								<LinkToPage
 									route={route}
 									name={name}
+									icon={icon}
 									key={`mobile-nav-${name}-${route}`}
 									asPath={asPath}
 									setShow={setShow}


### PR DESCRIPTION
## Description

Pass icon prop from page data to LinkToPage component in mobile menu to match desktop menu icon behavior

### Before
<img width="624" height="946" alt="Screenshot 2025-12-28 at 2 53 38 AM" src="https://github.com/user-attachments/assets/f48c0e41-5ada-40be-bd60-8a66fcfd28b6" />


### After 
<img width="622" height="1098" alt="Screenshot 2025-12-28 at 2 53 03 AM" src="https://github.com/user-attachments/assets/98e4e187-8747-48d1-950b-6842fcf890b1" />
