### PR TITLE
ux: make table sort arrows clickable

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -275,9 +275,9 @@ export function VirtualTable({
 													onClick={header.column.getCanSort() ? () => header.column.toggleSorting() : null}
 												>
 													{value}
+													{header.column.getCanSort() && <SortIcon dir={header.column.getIsSorted()} />}
 												</HeaderWithTooltip>
 											)}
-											{header.column.getCanSort() && <SortIcon dir={header.column.getIsSorted()} />}
 										</span>
 									</div>
 								)
@@ -385,9 +385,9 @@ export function VirtualTable({
 
 const HeaderWithTooltip = ({ children, content, onClick }) => {
 	if (onClick) {
-		if (!content) return <button onClick={onClick}>{children}</button>
+		if (!content) return <button onClick={onClick} className="flex items-center gap-1">{children}</button>
 		return (
-			<Tooltip content={content} className="underline decoration-dotted" render={<button />} onClick={onClick}>
+			<Tooltip content={content} className="underline decoration-dotted" render={<button className="flex items-center gap-1" />} onClick={onClick}>
 				{children}
 			</Tooltip>
 		)


### PR DESCRIPTION
## Description

Previously, table column headers had sort arrows rendered outside the clickable area. Clicking the column text would sort, but clicking the arrows themselves did nothing, creating a confusing UX.

This makes a more consistent experience, matches the users expectations, and larger click target. 

**Changes:**
- Move `SortIcon` inside `HeaderWithTooltip` component
- Add flex styling to button for proper icon/text layout
- Entire header (text + arrows) now clickable as single unit

This fixes sortable columns across all tables, including yields tables (APY, TVL, Reward APY, etc.)

### Design Decision

**Alternative considered:**
Make the up arrow explicitly sort ascending and down arrow explicitly sort descending (independent controls). This would give users more explicit control, but it's a bigger lift to implement and adds complexity that isn't necessary for most use cases. The standard toggle pattern (none → asc → desc → none) is what users expect from tables and is sufficient.

### Before

https://github.com/user-attachments/assets/c0a4be5b-d7be-46f3-acf3-69fcb05cba16



### After

https://github.com/user-attachments/assets/298b6f07-9d6a-4a4b-a9d5-9e82fb6bbf27

