### PR TITLE
ux: disable 'Reset All Filters' button when no filters are active

### DIFF
--- a/src/containers/Hacks/filters.tsx
+++ b/src/containers/Hacks/filters.tsx
@@ -179,7 +179,14 @@ const Filters = ({
 			</div>
 			<button
 				onClick={onClearAll}
-				className="rounded-md bg-(--btn2-bg) px-3 py-2 text-xs hover:bg-(--btn2-hover-bg) max-sm:mx-3 max-sm:my-6"
+				disabled={
+					selectedChains.length === 0 &&
+					selectedTechniques.length === 0 &&
+					selectedClassifications.length === 0 &&
+					!minLostVal &&
+					!maxLostVal
+				}
+				className="rounded-md bg-(--btn2-bg) px-3 py-2 text-xs hover:bg-(--btn2-hover-bg) disabled:cursor-not-allowed disabled:opacity-40 max-sm:mx-3 max-sm:my-6"
 			>
 				Reset filters
 			</button>

--- a/src/containers/Raises/Filters/Dropdowns.tsx
+++ b/src/containers/Raises/Filters/Dropdowns.tsx
@@ -19,6 +19,16 @@ export function RaisesFilterDropdowns({
 	nestedMenu
 }: IDropdownMenusProps) {
 	const router = useRouter()
+
+	// Check if any filters are active
+	const hasActiveFilters =
+		(selectedInvestors && selectedInvestors.length > 0) ||
+		(selectedChains && selectedChains.length > 0) ||
+		(selectedSectors && selectedSectors.length > 0) ||
+		(selectedRounds && selectedRounds.length > 0) ||
+		router.query.minRaised ||
+		router.query.maxRaised
+
 	return (
 		<>
 			{investors && investors.length > 0 && (
@@ -53,7 +63,8 @@ export function RaisesFilterDropdowns({
 				onClick={() => {
 					router.push('/raises')
 				}}
-				className="rounded-md bg-(--btn-bg) px-3 py-2 hover:bg-(--btn-hover-bg) focus-visible:bg-(--btn-hover-bg) max-sm:text-left md:text-xs"
+				disabled={!hasActiveFilters}
+				className="rounded-md bg-(--btn-bg) px-3 py-2 hover:bg-(--btn-hover-bg) focus-visible:bg-(--btn-hover-bg) max-sm:text-left disabled:cursor-not-allowed disabled:opacity-40 md:text-xs"
 			>
 				Reset all filters
 			</button>

--- a/src/containers/Stablecoins/Filters/ResetAll.tsx
+++ b/src/containers/Stablecoins/Filters/ResetAll.tsx
@@ -5,13 +5,19 @@ export function ResetAllStablecoinFilters({ pathname }: { pathname: string; nest
 	const router = useRouter()
 	const [state, updater] = useManageAppSettings()
 
+	// Check if any filters are active (query params or settings)
+	const hasActiveQueryFilters = Object.keys(router.query).length > 0
+	const hasActiveSettings = Object.values(STABLECOINS_SETTINGS).some((setting) => state[setting] === true)
+	const hasActiveFilters = hasActiveQueryFilters || hasActiveSettings
+
 	return (
 		<button
 			onClick={() => {
 				updater(Object.fromEntries(Object.values(STABLECOINS_SETTINGS).map((s) => [s, false])))
 				router.push(pathname, undefined, { shallow: true })
 			}}
-			className="relative flex cursor-pointer flex-nowrap items-center justify-between gap-2 rounded-md border border-(--form-control-border) px-2 py-1.5 text-xs font-medium text-(--text-form) hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg)"
+			disabled={!hasActiveFilters}
+			className="relative flex cursor-pointer flex-nowrap items-center justify-between gap-2 rounded-md border border-(--form-control-border) px-2 py-1.5 text-xs font-medium text-(--text-form) hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) disabled:cursor-not-allowed disabled:opacity-40"
 		>
 			Reset all filters
 		</button>

--- a/src/containers/Yields/Filters/ResetAll.tsx
+++ b/src/containers/Yields/Filters/ResetAll.tsx
@@ -16,12 +16,16 @@ export function ResetAllYieldFilters({
 		resetContext?.()
 	}
 
+	// Check if any filters are active
+	const hasActiveFilters = Object.keys(router.query).length > 0
+
 	return (
 		<button
 			onClick={handleClick}
+			disabled={!hasActiveFilters}
 			className={`rounded-md px-3 py-2 md:text-xs ${
 				nestedMenu ? 'text-left' : 'bg-(--btn-bg) hover:bg-(--btn-hover-bg) focus-visible:bg-(--btn-hover-bg)'
-			}`}
+			} disabled:cursor-not-allowed disabled:opacity-40`}
 		>
 			Reset all filters
 		</button>


### PR DESCRIPTION
## Description


- Add disabled state to reset buttons in Yields, Stablecoins, Raises, and Hacks filters
- Check for active filters/query params before enabling reset button
- Add visual feedback with opacity and cursor changes for disabled state

### Before
<img width="1776" height="584" alt="Screenshot 2025-12-28 at 3 26 06 AM" src="https://github.com/user-attachments/assets/d29521b0-c9cd-4c59-8cb4-6c0e48949141" />




### After

<img width="1706" height="580" alt="Screenshot 2025-12-28 at 3 26 15 AM" src="https://github.com/user-attachments/assets/d8bb4e4d-67eb-4abd-a413-b431e5b90188" />
