### PR TITLE
ui: fix sign-in modal message overlap with buttons

### DIFF
--- a/src/containers/Subscribtion/SignIn.tsx
+++ b/src/containers/Subscribtion/SignIn.tsx
@@ -392,7 +392,7 @@ export const SignInForm = ({
 						</div>
 
 						{pendingActionMessage && (
-							<div className="mb-3 rounded-lg border border-[#5C5CF9]/30 bg-[#5C5CF9]/10 p-2.5 sm:mb-4 sm:p-3">
+							<div className="mt-3 mb-3 rounded-lg border border-[#5C5CF9]/30 bg-[#5C5CF9]/10 p-2.5 sm:mt-4 sm:mb-4 sm:p-3">
 								<p className="text-center text-xs text-[#b4b7bc] sm:text-sm">{pendingActionMessage}</p>
 							</div>
 						)}


### PR DESCRIPTION
## Description

fix overlap in the sign-in modal 

### Before
<img width="1046" height="1148" alt="Screenshot 2025-12-28 at 4 35 49 AM" src="https://github.com/user-attachments/assets/784e4793-3db3-48e8-b1c1-d3fd444d497e" />

### After 

<img width="1206" height="1134" alt="Screenshot 2025-12-28 at 4 35 41 AM" src="https://github.com/user-attachments/assets/1a28e265-ea45-4984-9463-b2ac50d1df8b" />
