### PR TITLE
fix: show empty state when no table columns selected

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -229,7 +229,7 @@ export function VirtualTable({
 				<div className="flex flex-col gap-2">
 					<h3 className="text-lg font-semibold text-(--text-primary)">No columns selected</h3>
 					<p className="text-sm text-(--text-secondary)">
-						Please select at least one column from the columns menu to view the table data.
+						Please select at least one column from the Columns menu to view the table data.
 					</p>
 				</div>
 			</div>


### PR DESCRIPTION
## Description

Fixes the UX issue where toggling off all table columns resulted in a black screen with lots of scrolling. 

Users now see a helpful empty state message that clearly explains why the table is empty and how to fix it.

### Before

https://github.com/user-attachments/assets/46bab17e-1053-4a4c-bc51-8cba88ca4220


### After


https://github.com/user-attachments/assets/a6e91944-5b8f-41b5-baa7-895a1b7a5e17

