### PR TITLE
a11y(donations): add descriptive alt text to protocol logos

### DIFF
--- a/src/pages/donations.tsx
+++ b/src/pages/donations.tsx
@@ -101,7 +101,7 @@ function DonationsPage({ protocols }) {
 								rel="noopener noreferrer"
 								href={p.url}
 							>
-								<img src={p.logo} alt="" className="h-6 w-6 flex-shrink-0 rounded-full" />
+								<img src={p.logo} alt={`${p.name} logo`} className="h-6 w-6 flex-shrink-0 rounded-full" />
 								<span className="truncate text-sm text-(--blue)">{p.name}</span>
 							</a>
 						))}


### PR DESCRIPTION
## Description

Improves accessibility on the donations page by adding descriptive alt text to protocol logo images. Previously, the logos had empty `alt=""` attributes, which provides no information to screen reader users. Now each logo includes the protocol name in its alt text making the page more accessible and compliant with WCAG guidelines.

**Changes:**
- Updated `src/pages/donations.tsx` to use `alt={`${p.name} logo`}` instead of `alt=""`