### PR TITLE
fix: Handle 0 as valid filter value for numeric range filters

### DIFF
--- a/src/containers/ChainsByCategory/index.tsx
+++ b/src/containers/ChainsByCategory/index.tsx
@@ -216,7 +216,7 @@ export const useGroupAndFormatChains = ({
 					mcaptvl: chain.mcap && finalTvl ? +formatNum(+chain.mcap.toFixed(2) / +finalTvl.toFixed(2)) : null
 				}
 			})
-			.filter((chain) => (minTvl ? chain.tvl >= minTvl : true) && (maxTvl ? chain.tvl <= maxTvl : true))
+			.filter((chain) => (minTvl != null ? chain.tvl >= minTvl : true) && (maxTvl != null ? chain.tvl <= maxTvl : true))
 
 		if (!showByGroup) return { showByGroup, chainsTableData: data }
 		const trackedSubChains = new Set<string>()

--- a/src/containers/Raises/hooks.tsx
+++ b/src/containers/Raises/hooks.tsx
@@ -138,8 +138,8 @@ export function useRaisesData({ raises, investors, rounds, sectors, chains }) {
 			const raisedAmount = raise.amount ? Number(raise.amount) * 1_000_000 : 0
 
 			const isInRange =
-				(minimumAmountRaised ? raisedAmount >= minimumAmountRaised : true) &&
-				(maximumAmountRaised ? raisedAmount <= maximumAmountRaised : true)
+				(minimumAmountRaised != null ? raisedAmount >= minimumAmountRaised : true) &&
+				(maximumAmountRaised != null ? raisedAmount <= maximumAmountRaised : true)
 
 			if (isValidTvlRange && !isInRange) {
 				toFilter = false

--- a/src/containers/RecentProtocols/index.tsx
+++ b/src/containers/RecentProtocols/index.tsx
@@ -131,7 +131,7 @@ export function RecentProtocols({ protocols, chainList, forkedList, claimableAir
 
 		if (isValidTvlRange) {
 			const filteredProtocols = data.filter(
-				(protocol) => (minTvl ? protocol.tvl >= minTvl : true) && (maxTvl ? protocol.tvl <= maxTvl : true)
+				(protocol) => (minTvl != null ? protocol.tvl >= minTvl : true) && (maxTvl != null ? protocol.tvl <= maxTvl : true)
 			)
 
 			return { data: filteredProtocols, selectedChains }

--- a/src/containers/Stablecoins/StablecoinsByChain.tsx
+++ b/src/containers/Stablecoins/StablecoinsByChain.tsx
@@ -116,7 +116,7 @@ export function StablecoinsByChain({
 			const isValidMcapRange = minMcap != null && maxMcap != null
 
 			if (isValidMcapRange) {
-				toFilter = toFilter && (minMcap ? curr.mcap > minMcap : true) && (maxMcap ? curr.mcap < maxMcap : true)
+				toFilter = toFilter && (minMcap != null ? curr.mcap > minMcap : true) && (maxMcap != null ? curr.mcap < maxMcap : true)
 			}
 
 			if (toFilter) {

--- a/src/containers/Yields/utils.ts
+++ b/src/containers/Yields/utils.ts
@@ -126,11 +126,11 @@ export function toFilterPool({
 	const isValidApyRange = minApy != null || maxApy != null
 
 	if (isValidTvlRange) {
-		toFilter = toFilter && (minTvl ? curr.tvlUsd >= minTvl : true) && (maxTvl ? curr.tvlUsd <= maxTvl : true)
+		toFilter = toFilter && (minTvl != null ? curr.tvlUsd >= minTvl : true) && (maxTvl != null ? curr.tvlUsd <= maxTvl : true)
 	}
 
 	if (isValidApyRange) {
-		toFilter = toFilter && (minApy ? curr.apy > minApy : true) && (maxApy ? curr.apy < maxApy : true)
+		toFilter = toFilter && (minApy != null ? curr.apy > minApy : true) && (maxApy != null ? curr.apy < maxApy : true)
 	}
 
 	return toFilter
@@ -537,7 +537,7 @@ export const filterPool = ({
 	const isValidTvlRange = minTvl != null || maxTvl != null
 
 	if (isValidTvlRange) {
-		toFilter = toFilter && (minTvl ? pool.farmTvlUsd >= minTvl : true) && (maxTvl ? pool.tvlUsd <= maxTvl : true)
+		toFilter = toFilter && (minTvl != null ? pool.farmTvlUsd >= minTvl : true) && (maxTvl != null ? pool.tvlUsd <= maxTvl : true)
 	}
 
 	const isValidAvailableRange = minAvailable != null || maxAvailable != null
@@ -545,8 +545,8 @@ export const filterPool = ({
 	if (isValidAvailableRange) {
 		toFilter =
 			toFilter &&
-			(minAvailable ? +(pool.borrow.totalAvailableUsd || 0) >= +minAvailable : true) &&
-			(maxAvailable ? +(pool.borrow.totalAvailableUsd || 0) <= +maxAvailable : true)
+			(minAvailable != null ? +(pool.borrow.totalAvailableUsd || 0) >= +minAvailable : true) &&
+			(maxAvailable != null ? +(pool.borrow.totalAvailableUsd || 0) <= +maxAvailable : true)
 	}
 
 	const isValidLtvValue = customLTV != null

--- a/src/hooks/data/defi.tsx
+++ b/src/hooks/data/defi.tsx
@@ -738,7 +738,7 @@ export const formatProtocolsList2 = ({
 					const mcaptvl =
 						child.mcap && defaultTvl.tvl ? +formatNum(+child.mcap.toFixed(2) / +defaultTvl.tvl.toFixed(2)) : null
 
-					if ((minTvl ? defaultTvl.tvl >= minTvl : true) && (maxTvl ? defaultTvl.tvl <= maxTvl : true)) {
+					if ((minTvl != null ? defaultTvl.tvl >= minTvl : true) && (maxTvl != null ? defaultTvl.tvl <= maxTvl : true)) {
 						childProtocols.push({
 							...child,
 							strikeTvl,
@@ -748,7 +748,7 @@ export const formatProtocolsList2 = ({
 						})
 					}
 				}
-				if ((minTvl ? defaultTvl.tvl >= minTvl : true) && (maxTvl ? defaultTvl.tvl <= maxTvl : true)) {
+				if ((minTvl != null ? defaultTvl.tvl >= minTvl : true) && (maxTvl != null ? defaultTvl.tvl <= maxTvl : true)) {
 					final.push({
 						...protocol,
 						strikeTvl,
@@ -759,7 +759,7 @@ export const formatProtocolsList2 = ({
 					})
 				}
 			} else {
-				if ((minTvl ? defaultTvl.tvl >= minTvl : true) && (maxTvl ? defaultTvl.tvl <= maxTvl : true)) {
+				if ((minTvl != null ? defaultTvl.tvl >= minTvl : true) && (maxTvl != null ? defaultTvl.tvl <= maxTvl : true)) {
 					final.push({
 						...protocol,
 						strikeTvl,


### PR DESCRIPTION
## Description

Changed truthiness checks to null checks so 0 is treated as a valid filter value instead of being ignored


### Before


https://github.com/user-attachments/assets/c930ca44-4059-4122-9028-b0431a00bc80


### After 

https://github.com/user-attachments/assets/70c25c84-1412-431f-8acb-f9580272db73

