### PR TITLE
feat: separate rank from name into its own dedicated column

### DIFF
--- a/src/components/Table/Bridges/Bridges/columns.tsx
+++ b/src/components/Table/Bridges/Bridges/columns.tsx
@@ -18,13 +18,25 @@ import type { IBridge, IBridgeChain } from './types'
 
 export const bridgesColumn: ColumnDef<IBridge>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			return <span className="font-bold">{row.index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		accessorKey: 'displayName',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const value = getValue() as string
 			const linkValue = slug(value)
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 			const rowValues = row.original
 			const icon = rowValues.icon
 			let iconLink
@@ -35,7 +47,6 @@ export const bridgesColumn: ColumnDef<IBridge>[] = [
 
 			return (
 				<span className="flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
 					{icon && <TokenLogo logo={iconLink} data-lgonly />}
 					<BasicLink
 						href={`/bridge/${linkValue}`}
@@ -107,15 +118,26 @@ export const bridgesColumn: ColumnDef<IBridge>[] = [
 
 export const bridgeChainsColumn: ColumnDef<IBridgeChain>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			return <span className="font-bold">{row.index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const value = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 			return (
 				<span className="flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
 					<TokenLogo logo={chainIconUrl(value)} data-lgonly />
 					<BasicLink
 						href={`/bridges/${value}`}
@@ -445,12 +467,13 @@ export const bridgeAddressesColumn: ColumnDef<IBridge>[] = [
 // key: min width of window/screen
 // values: table columns order
 export const bridgesColumnOrders = formatColumnOrder({
-	0: ['displayName', 'lastDailyVolume', 'change_1d', 'weeklyVolume', 'monthlyVolume', 'chains', 'txsPrevDay'],
-	1024: ['displayName', 'chains', 'change_1d', 'lastDailyVolume', 'weeklyVolume', 'monthlyVolume', 'txsPrevDay']
+	0: ['rank', 'displayName', 'lastDailyVolume', 'change_1d', 'weeklyVolume', 'monthlyVolume', 'chains', 'txsPrevDay'],
+	1024: ['rank', 'displayName', 'chains', 'change_1d', 'lastDailyVolume', 'weeklyVolume', 'monthlyVolume', 'txsPrevDay']
 })
 
 export const bridgeChainsColumnOrders = formatColumnOrder({
 	0: [
+		'rank',
 		'name',
 		'prevDayUsdWithdrawals',
 		'prevDayUsdDeposits',
@@ -461,6 +484,7 @@ export const bridgeChainsColumnOrders = formatColumnOrder({
 		'topTokenWithdrawnSymbol'
 	],
 	1024: [
+		'rank',
 		'name',
 		'topTokenWithdrawnSymbol',
 		'prevDayUsdWithdrawals',

--- a/src/components/Table/Defi/Protocols/columns.tsx
+++ b/src/components/Table/Defi/Protocols/columns.tsx
@@ -22,11 +22,10 @@ export const protocolsByChainColumns: ColumnDef<IProtocolRow>[] = [
 		accessorKey: 'rank',
 		size: 60,
 		enableSorting: false,
-		cell: ({ row, table }) => {
+		cell: ({ row }) => {
 			// Only show ranks for top-level protocols (depth 0), not for child protocols
 			if (row.depth > 0) return null
-			const index = table.getSortedRowModel().rows.findIndex((x) => x.id === row.id)
-			return <span className="font-bold">{index + 1}</span>
+			return <span className="font-bold">{row.index + 1}</span>
 		},
 		meta: {
 			align: 'center' as const
@@ -952,11 +951,10 @@ export const protocolsColumns: ColumnDef<IProtocolRow>[] = [
 		accessorKey: 'rank',
 		size: 60,
 		enableSorting: false,
-		cell: ({ row, table }) => {
+		cell: ({ row }) => {
 			// Only show ranks for top-level protocols (depth 0), not for child protocols
 			if (row.depth > 0) return null
-			const index = table.getSortedRowModel().rows.findIndex((x) => x.id === row.id)
-			return <span className="font-bold">{index + 1}</span>
+			return <span className="font-bold">{row.index + 1}</span>
 		},
 		meta: {
 			align: 'center' as const
@@ -1118,11 +1116,10 @@ export const protocolsOracleColumns: ColumnDef<IProtocolRow>[] = [
 		accessorKey: 'rank',
 		size: 60,
 		enableSorting: false,
-		cell: ({ row, table }) => {
+		cell: ({ row }) => {
 			// Only show ranks for top-level protocols (depth 0), not for child protocols
 			if (row.depth > 0) return null
-			const index = table.getSortedRowModel().rows.findIndex((x) => x.id === row.id)
-			return <span className="font-bold">{index + 1}</span>
+			return <span className="font-bold">{row.index + 1}</span>
 		},
 		meta: {
 			align: 'center' as const
@@ -1239,11 +1236,10 @@ export const categoryProtocolsColumns: ColumnDef<IProtocolRowWithCompare>[] = [
 		accessorKey: 'rank',
 		size: 60,
 		enableSorting: false,
-		cell: ({ row, table }) => {
+		cell: ({ row }) => {
 			// Only show ranks for top-level protocols (depth 0), not for child protocols
 			if (row.depth > 0) return null
-			const index = table.getSortedRowModel().rows.findIndex((x) => x.id === row.id)
-			return <span className="font-bold">{index + 1}</span>
+			return <span className="font-bold">{row.index + 1}</span>
 		},
 		meta: {
 			align: 'center' as const
@@ -1424,11 +1420,10 @@ export const topGainersAndLosersColumns: ColumnDef<IProtocolRow>[] = [
 		accessorKey: 'rank',
 		size: 60,
 		enableSorting: false,
-		cell: ({ row, table }) => {
+		cell: ({ row }) => {
 			// Only show ranks for top-level protocols (depth 0), not for child protocols
 			if (row.depth > 0) return null
-			const index = table.getSortedRowModel().rows.findIndex((x) => x.id === row.id)
-			return <span className="font-bold">{index + 1}</span>
+			return <span className="font-bold">{row.index + 1}</span>
 		},
 		meta: {
 			align: 'center' as const

--- a/src/components/Table/Defi/columns.tsx
+++ b/src/components/Table/Defi/columns.tsx
@@ -21,11 +21,10 @@ export const forksColumn: ColumnDef<IForksRow>[] = [
 		accessorKey: 'rank',
 		size: 60,
 		enableSorting: false,
-		cell: ({ row, table }) => {
+		cell: ({ row }) => {
 			// Only show ranks for top-level protocols (depth 0), not for child protocols
 			if (row.depth > 0) return null
-			const index = table.getSortedRowModel().rows.findIndex((x) => x.id === row.id)
-			return <span className="font-bold">{index + 1}</span>
+			return <span className="font-bold">{row.index + 1}</span>
 		},
 		meta: {
 			align: 'center' as const
@@ -383,11 +382,10 @@ export const governanceColumns: ColumnDef<IGovernance>[] = [
 		accessorKey: 'rank',
 		size: 60,
 		enableSorting: false,
-		cell: ({ row, table }) => {
+		cell: ({ row }) => {
 			// Only show ranks for top-level protocols (depth 0), not for child protocols
 			if (row.depth > 0) return null
-			const index = table.getSortedRowModel().rows.findIndex((x) => x.id === row.id)
-			return <span className="font-bold">{index + 1}</span>
+			return <span className="font-bold">{row.index + 1}</span>
 		},
 		meta: {
 			align: 'center' as const
@@ -484,11 +482,10 @@ export const LSDColumn: ColumnDef<ILSDRow>[] = [
 		accessorKey: 'rank',
 		size: 60,
 		enableSorting: false,
-		cell: ({ row, table }) => {
+		cell: ({ row }) => {
 			// Only show ranks for top-level protocols (depth 0), not for child protocols
 			if (row.depth > 0) return null
-			const index = table.getSortedRowModel().rows.findIndex((x) => x.id === row.id)
-			return <span className="font-bold">{index + 1}</span>
+			return <span className="font-bold">{row.index + 1}</span>
 		},
 		meta: {
 			align: 'center' as const

--- a/src/components/Table/Liquidations/columns.tsx
+++ b/src/components/Table/Liquidations/columns.tsx
@@ -11,13 +11,25 @@ import { ILiquidablePositionsRow, ILiquidableProtocolRow } from './types'
 
 export const liquidatableProtocolsColumns: ColumnDef<ILiquidableProtocolRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			return <span className="font-bold">{row.index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const value = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-			return <NameCell value={value} index={index} />
+			return <NameCell value={value} />
 		},
 		size: 120
 	},
@@ -88,13 +100,25 @@ export const liquidatableProtocolsColumns: ColumnDef<ILiquidableProtocolRow>[] =
 ]
 export const liquidatablePositionsColumns: ColumnDef<ILiquidablePositionsRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			return <span className="font-bold">{row.index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Protocol',
 		accessorKey: 'protocolName',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const value = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-			return <ProtocolName value={value} index={index} />
+			return <ProtocolName value={value} />
 		},
 		size: 120
 	},
@@ -174,7 +198,7 @@ const fetchApi = async (url: string) => {
 		throw new Error(error instanceof Error ? error.message : `Failed to fetch ${url}`)
 	}
 }
-const ProtocolName = ({ value, index }: { value: string; index: number }) => {
+const ProtocolName = ({ value }: { value: string }) => {
 	let _value: string
 
 	switch (value) {
@@ -218,7 +242,6 @@ const ProtocolName = ({ value, index }: { value: string; index: number }) => {
 
 	return (
 		<span className="flex items-center gap-2">
-			<span className="shrink-0">{index + 1}</span>
 			<TokenLogo logo={data.logo} data-lgonly />
 			<BasicLink
 				href={`/protocol/${_value}`}
@@ -230,7 +253,7 @@ const ProtocolName = ({ value, index }: { value: string; index: number }) => {
 	)
 }
 
-const ChainName = ({ value, index }: { value: string; index?: number }) => {
+const ChainName = ({ value }: { value: string }) => {
 	const { data } = useQuery({
 		queryKey: [`${CHAINS_API}`],
 		queryFn: () => fetchApi(`${CHAINS_API}`),
@@ -255,7 +278,6 @@ const ChainName = ({ value, index }: { value: string; index?: number }) => {
 
 	return (
 		<span className="flex items-center gap-2">
-			{(index || index === 0) && <span className="shrink-0">{index + 1}</span>}
 			<TokenLogo logo={chainIconUrl(name)} data-lgonly />
 			<BasicLink
 				href={`/chain/${_name}`}
@@ -267,7 +289,7 @@ const ChainName = ({ value, index }: { value: string; index?: number }) => {
 	)
 }
 
-const NameCell = (props: { value: string; index: number }) => {
+const NameCell = (props: { value: string }) => {
 	const stackBy = useStackBy()
 
 	if (stackBy === 'protocols') {

--- a/src/components/Table/Nfts/Marketplaces/columns.tsx
+++ b/src/components/Table/Nfts/Marketplaces/columns.tsx
@@ -5,18 +5,28 @@ import type { INftMarketplace } from '../types'
 
 export const columns: ColumnDef<INftMarketplace>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			return <span className="font-bold">{row.index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		accessorKey: 'exchangeName',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-
 			const name = getValue()
 			const icon = row.original.exchangeName.toLowerCase().replace(' aggregator', '').replace(' ', '-')
 
 			return (
 				<span className="flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
 					<TokenLogo logo={`https://icons.llamao.fi/icons/protocols/${icon}`} data-lgonly />
 					<span className="overflow-hidden text-ellipsis whitespace-nowrap hover:underline">{name as string}</span>
 				</span>

--- a/src/containers/BridgedTVL/BridgedTVLChainsList.tsx
+++ b/src/containers/BridgedTVL/BridgedTVLChainsList.tsx
@@ -71,15 +71,26 @@ interface IBridgedRow {
 
 const bridgedColumns: ColumnDef<IBridgedRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: () => 'Name',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-
 			return (
 				<span className="relative flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
 					<TokenLogo logo={chainIconUrl(getValue())} />
 					<BasicLink
 						href={`/bridged/${slug(getValue() as string)}`}

--- a/src/containers/Cexs/index.tsx
+++ b/src/containers/Cexs/index.tsx
@@ -97,15 +97,26 @@ export const Cexs = ({ cexs }: { cexs: Array<ICex> }) => {
 
 const columns: ColumnDef<ICex>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-
 			return (
 				<span className="relative flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
 					{row.original.slug === undefined ? (
 						(getValue() as string | null)
 					) : (

--- a/src/containers/ChainOverview/Table.tsx
+++ b/src/containers/ChainOverview/Table.tsx
@@ -609,18 +609,16 @@ const columns: ColumnDef<IProtocol>[] = [
 	{
 		id: 'rank',
 		header: 'Rank',
-		accessorKey: 'name',
+		accessorKey: 'rank',
+		size: 60,
 		enableSorting: false,
-		cell: ({ row, table }) => {
-			// Only show ranks for top-level protocols (depth 0), not for child protocols
-			if (row.depth > 0) return null
-			const index = table.getSortedRowModel().rows.findIndex((x) => x.id === row.id)
+		cell: ({ row }) => {
+			const index = row.index
 			return <span className="font-bold">{index + 1}</span>
 		},
 		meta: {
 			align: 'center' as const
-		},
-		size: 60
+		}
 	},
 	{
 		id: 'name',

--- a/src/containers/ChainsByCategory/Table.tsx
+++ b/src/containers/ChainsByCategory/Table.tsx
@@ -265,6 +265,7 @@ export function ChainsByCategoryTable({
 // values: table columns order
 const chainsTableColumnOrders = formatColumnOrder({
 	0: [
+		'rank',
 		'name',
 		'tvl',
 		'chainAssets',
@@ -280,6 +281,7 @@ const chainsTableColumnOrders = formatColumnOrder({
 		'mcaptvl'
 	],
 	400: [
+		'rank',
 		'name',
 		'change_7d',
 		'tvl',
@@ -295,6 +297,7 @@ const chainsTableColumnOrders = formatColumnOrder({
 		'mcaptvl'
 	],
 	600: [
+		'rank',
 		'name',
 		'protocols',
 		'tvl',
@@ -310,6 +313,7 @@ const chainsTableColumnOrders = formatColumnOrder({
 		'mcaptvl'
 	],
 	900: [
+		'rank',
 		'name',
 		'protocols',
 		'tvl',
@@ -328,12 +332,24 @@ const chainsTableColumnOrders = formatColumnOrder({
 
 const columns: ColumnDef<IFormattedDataWithExtraTvl>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		accessorKey: 'name',
 		enableSorting: true,
 		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-
 			return (
 				<span
 					className="relative flex items-center gap-2"
@@ -361,7 +377,6 @@ const columns: ColumnDef<IFormattedDataWithExtraTvl>[] = [
 					) : (
 						<Bookmark readableName={getValue() as string} isChain data-bookmark className="absolute -left-0.5" />
 					)}
-					<span className="shrink-0">{index + 1}</span>
 
 					<TokenLogo logo={chainIconUrl(getValue())} />
 					<BasicLink
@@ -552,6 +567,6 @@ const columns: ColumnDef<IFormattedDataWithExtraTvl>[] = [
 	}
 ]
 
-const columnOptions = columns.map((c: any) => ({ name: c.header, key: c.accessorKey }))
+const columnOptions = columns.map((c: any) => ({ name: c.header, key: c.id || c.accessorKey }))
 
 const defaultColumns = JSON.stringify(Object.fromEntries(columnOptions.map((c) => [c.key, true])))

--- a/src/containers/DeFiWatchlist/index.tsx
+++ b/src/containers/DeFiWatchlist/index.tsx
@@ -797,7 +797,7 @@ function TopMovers({ protocols }: TopMoversProps) {
 										className="flex items-center justify-between rounded bg-(--bg-main) p-2 transition-colors"
 									>
 										<div className="flex min-w-0 flex-1 items-center gap-2">
-											<span className="w-4 shrink-0 text-xs font-medium text-(--text-secondary)">#{index + 1}</span>
+											<span className="w-4 shrink-0 text-xs font-bold text-(--text-secondary)">{index + 1}</span>
 											<span className="truncate text-sm font-medium text-(--text-primary)">{mover.name}</span>
 										</div>
 										<div className="ml-2 flex shrink-0 items-center gap-1">

--- a/src/containers/DimensionAdapters/AdapterByChain.tsx
+++ b/src/containers/DimensionAdapters/AdapterByChain.tsx
@@ -547,8 +547,8 @@ const columnSizes = Object.entries({
 }).sort((a, b) => Number(b[0]) - Number(a[0]))
 
 const columnOrders = Object.entries({
-	0: ['name', 'total24h', 'open_interest', 'total7d', 'total30d', 'category', 'definition'],
-	640: ['name', 'category', 'definition', 'total24h', 'open_interest', 'total7d', 'total30d']
+	0: ['rank', 'name', 'total24h', 'open_interest', 'total7d', 'total30d', 'category', 'definition'],
+	640: ['rank', 'name', 'category', 'definition', 'total24h', 'open_interest', 'total7d', 'total30d']
 }).sort((a, b) => Number(b[0]) - Number(a[0]))
 
 const protocolChartsKeys: Partial<Record<IProps['type'], (typeof protocolCharts)[keyof typeof protocolCharts]>> = {
@@ -629,7 +629,6 @@ const NameColumn = (type: IProps['type']): ColumnDef<IAdapterByChainPageData['pr
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const value = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 			const Chains = () => (
 				<span className="flex flex-col gap-1">
 					{row.original.chains.map((chain) => (
@@ -673,10 +672,6 @@ const NameColumn = (type: IProps['type']): ColumnDef<IAdapterByChainPageData['pr
 						</button>
 					) : null}
 
-					<span className="shrink-0" onClick={row.getToggleExpandedHandler()}>
-						{index + 1}
-					</span>
-
 					<TokenLogo logo={row.original.logo} data-lgonly />
 
 					<span className="-my-2 flex flex-col">
@@ -703,6 +698,20 @@ const getColumnsByType = (
 ): Record<IProps['type'], ColumnDef<IAdapterByChainPageData['protocols'][0]>[]> => {
 	return {
 		Fees: [
+			{
+				id: 'rank',
+				header: 'Rank',
+				accessorKey: 'rank',
+				size: 60,
+				enableSorting: false,
+				cell: ({ row }) => {
+					const index = row.index
+					return <span className="font-bold">{index + 1}</span>
+				},
+				meta: {
+					align: 'center' as const
+				}
+			},
 			NameColumn('Fees'),
 			{
 				id: 'category',
@@ -777,6 +786,20 @@ const getColumnsByType = (
 			}
 		],
 		Revenue: [
+			{
+				id: 'rank',
+				header: 'Rank',
+				accessorKey: 'rank',
+				size: 60,
+				enableSorting: false,
+				cell: ({ row }) => {
+					const index = row.index
+					return <span className="font-bold">{index + 1}</span>
+				},
+				meta: {
+					align: 'center' as const
+				}
+			},
 			NameColumn('Revenue'),
 			{
 				id: 'category',
@@ -851,6 +874,20 @@ const getColumnsByType = (
 			}
 		],
 		'Holders Revenue': [
+			{
+				id: 'rank',
+				header: 'Rank',
+				accessorKey: 'rank',
+				size: 60,
+				enableSorting: false,
+				cell: ({ row }) => {
+					const index = row.index
+					return <span className="font-bold">{index + 1}</span>
+				},
+				meta: {
+					align: 'center' as const
+				}
+			},
 			NameColumn('Holders Revenue'),
 			{
 				id: 'category',
@@ -925,6 +962,20 @@ const getColumnsByType = (
 			}
 		],
 		'Options Premium Volume': [
+			{
+				id: 'rank',
+				header: 'Rank',
+				accessorKey: 'rank',
+				size: 60,
+				enableSorting: false,
+				cell: ({ row }) => {
+					const index = row.index
+					return <span className="font-bold">{index + 1}</span>
+				},
+				meta: {
+					align: 'center' as const
+				}
+			},
 			NameColumn('Options Premium Volume'),
 			{
 				id: 'total24h',
@@ -967,6 +1018,20 @@ const getColumnsByType = (
 			}
 		],
 		'Options Notional Volume': [
+			{
+				id: 'rank',
+				header: 'Rank',
+				accessorKey: 'rank',
+				size: 60,
+				enableSorting: false,
+				cell: ({ row }) => {
+					const index = row.index
+					return <span className="font-bold">{index + 1}</span>
+				},
+				meta: {
+					align: 'center' as const
+				}
+			},
 			NameColumn('Options Notional Volume'),
 			{
 				id: 'total24h',
@@ -1009,6 +1074,20 @@ const getColumnsByType = (
 			}
 		],
 		'DEX Volume': [
+			{
+				id: 'rank',
+				header: 'Rank',
+				accessorKey: 'rank',
+				size: 60,
+				enableSorting: false,
+				cell: ({ row }) => {
+					const index = row.index
+					return <span className="font-bold">{index + 1}</span>
+				},
+				meta: {
+					align: 'center' as const
+				}
+			},
 			NameColumn('DEX Volume'),
 			{
 				id: 'total24h',
@@ -1081,6 +1160,20 @@ const getColumnsByType = (
 			}
 		],
 		'Perp Volume': [
+			{
+				id: 'rank',
+				header: 'Rank',
+				accessorKey: 'rank',
+				size: 60,
+				enableSorting: false,
+				cell: ({ row }) => {
+					const index = row.index
+					return <span className="font-bold">{index + 1}</span>
+				},
+				meta: {
+					align: 'center' as const
+				}
+			},
 			NameColumn('Perp Volume'),
 			{
 				id: 'total24h',
@@ -1214,6 +1307,20 @@ const getColumnsByType = (
 			}
 		],
 		'Open Interest': [
+			{
+				id: 'rank',
+				header: 'Rank',
+				accessorKey: 'rank',
+				size: 60,
+				enableSorting: false,
+				cell: ({ row }) => {
+					const index = row.index
+					return <span className="font-bold">{index + 1}</span>
+				},
+				meta: {
+					align: 'center' as const
+				}
+			},
 			NameColumn('Open Interest'),
 			{
 				id: 'total24h',
@@ -1230,6 +1337,20 @@ const getColumnsByType = (
 			}
 		],
 		'Perp Aggregator Volume': [
+			{
+				id: 'rank',
+				header: 'Rank',
+				accessorKey: 'rank',
+				size: 60,
+				enableSorting: false,
+				cell: ({ row }) => {
+					const index = row.index
+					return <span className="font-bold">{index + 1}</span>
+				},
+				meta: {
+					align: 'center' as const
+				}
+			},
 			NameColumn('Perp Aggregator Volume'),
 			{
 				id: 'total24h',
@@ -1282,6 +1403,20 @@ const getColumnsByType = (
 			}
 		],
 		'Bridge Aggregator Volume': [
+			{
+				id: 'rank',
+				header: 'Rank',
+				accessorKey: 'rank',
+				size: 60,
+				enableSorting: false,
+				cell: ({ row }) => {
+					const index = row.index
+					return <span className="font-bold">{index + 1}</span>
+				},
+				meta: {
+					align: 'center' as const
+				}
+			},
 			NameColumn('Bridge Aggregator Volume'),
 			{
 				id: 'total24h',
@@ -1334,6 +1469,20 @@ const getColumnsByType = (
 			}
 		],
 		'DEX Aggregator Volume': [
+			{
+				id: 'rank',
+				header: 'Rank',
+				accessorKey: 'rank',
+				size: 60,
+				enableSorting: false,
+				cell: ({ row }) => {
+					const index = row.index
+					return <span className="font-bold">{index + 1}</span>
+				},
+				meta: {
+					align: 'center' as const
+				}
+			},
 			NameColumn('DEX Aggregator Volume'),
 			{
 				id: 'total24h',
@@ -1386,6 +1535,20 @@ const getColumnsByType = (
 			}
 		],
 		Earnings: [
+			{
+				id: 'rank',
+				header: 'Rank',
+				accessorKey: 'rank',
+				size: 60,
+				enableSorting: false,
+				cell: ({ row }) => {
+					const index = row.index
+					return <span className="font-bold">{index + 1}</span>
+				},
+				meta: {
+					align: 'center' as const
+				}
+			},
 			NameColumn('Earnings'),
 			{
 				id: 'category',
@@ -1446,6 +1609,20 @@ const getColumnsByType = (
 			}
 		],
 		'P/F': [
+			{
+				id: 'rank',
+				header: 'Rank',
+				accessorKey: 'rank',
+				size: 60,
+				enableSorting: false,
+				cell: ({ row }) => {
+					const index = row.index
+					return <span className="font-bold">{index + 1}</span>
+				},
+				meta: {
+					align: 'center' as const
+				}
+			},
 			NameColumn('Fees'),
 			{
 				id: 'category',
@@ -1483,6 +1660,20 @@ const getColumnsByType = (
 			}
 		],
 		'P/S': [
+			{
+				id: 'rank',
+				header: 'Rank',
+				accessorKey: 'rank',
+				size: 60,
+				enableSorting: false,
+				cell: ({ row }) => {
+					const index = row.index
+					return <span className="font-bold">{index + 1}</span>
+				},
+				meta: {
+					align: 'center' as const
+				}
+			},
 			NameColumn('Revenue'),
 			{
 				id: 'category',

--- a/src/containers/DimensionAdapters/ChainsByAdapter.tsx
+++ b/src/containers/DimensionAdapters/ChainsByAdapter.tsx
@@ -183,9 +183,9 @@ const NameColumn = (route: string): ColumnDef<IChainsByAdapterPageData['chains']
 		header: 'Name',
 		accessorFn: (protocol) => protocol.name,
 		enableSorting: false,
-		cell: ({ getValue, row, table }) => {
+		cell: ({ getValue, row }) => {
 			const value = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
+			const index = row.index
 
 			return (
 				<span className="relative flex items-center gap-2">

--- a/src/containers/NarrativeTracker/index.tsx
+++ b/src/containers/NarrativeTracker/index.tsx
@@ -233,14 +233,26 @@ interface CoinPerformanceRow {
 
 const CoinPerformanceColumn: ColumnDef<CoinPerformanceRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Coin',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 			return (
 				<span className="relative flex items-center gap-2">
-					<span>{index + 1}.</span>
 					<BasicLink
 						href={`https://www.coingecko.com/en/coins/${row.original.id}`}
 						target="_blank"
@@ -285,15 +297,26 @@ const CoinPerformanceColumn: ColumnDef<CoinPerformanceRow>[] = [
 
 const CategoryPerformanceColumn: ColumnDef<CategoryPerformanceRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Category',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-
 			return (
 				<span className="relative flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
 					{['bitcoin', 'ethereum', 'solana'].includes(row.original.id) ? (
 						<BasicLink
 							href={`https://www.coingecko.com/en/coins/${row.original.id}`}

--- a/src/containers/Oracles/index.tsx
+++ b/src/containers/Oracles/index.tsx
@@ -120,15 +120,26 @@ interface IOraclesRow {
 
 const columns: ColumnDef<IOraclesRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-
 			return (
 				<span className="relative flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
 					<BasicLink
 						href={`/oracles/${getValue()}`}
 						className="overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-(--link-text)"

--- a/src/containers/Pool2/Pool2ByChain.tsx
+++ b/src/containers/Pool2/Pool2ByChain.tsx
@@ -67,13 +67,26 @@ export function Pool2ProtocolsTVLByChain(props: IPool2ProtocolsTVLByChainPageDat
 
 const columns: ColumnDef<IPool2ProtocolsTVLByChainPageData['protocols'][0]>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		id: 'name',
 		header: 'Name',
 		accessorFn: (protocol) => protocol.name,
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const value = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 			const Chains = () => (
 				<span className="flex flex-col gap-1">
 					{row.original.chains.map((chain) => (
@@ -86,7 +99,7 @@ const columns: ColumnDef<IPool2ProtocolsTVLByChainPageData['protocols'][0]>[] = 
 			)
 
 			return (
-				<span className={`relative flex items-center gap-2 ${row.depth > 0 ? 'pl-12' : 'pl-6'}`}>
+				<span className={`relative flex items-center gap-2 ${row.depth > 0 ? 'pl-6' : ''}`}>
 					{row.subRows?.length > 0 ? (
 						<button
 							className="absolute -left-0.5"
@@ -107,8 +120,6 @@ const columns: ColumnDef<IPool2ProtocolsTVLByChainPageData['protocols'][0]>[] = 
 							)}
 						</button>
 					) : null}
-
-					<span className="shrink-0">{index + 1}</span>
 
 					<TokenLogo logo={row.original.logo} data-lgonly />
 

--- a/src/containers/ProDashboard/components/datasets/CexDataset/columns.tsx
+++ b/src/containers/ProDashboard/components/datasets/CexDataset/columns.tsx
@@ -26,20 +26,29 @@ interface ICexRow {
 
 export const cexDatasetColumns: ColumnDef<ICexRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			return <span className="font-bold">{row.index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		id: 'name',
 		accessorFn: (row) => row.name,
 		enableSorting: false,
 		cell: ({ getValue, row }) => {
-			// Use row.index which is already calculated by tanstack table
-			const index = row.index
 			const name = getValue() as string
 			const coinSymbol = row.original.coinSymbol
 
 			return (
 				<span className="relative flex items-center gap-2 pl-6">
-					<span className="shrink-0">{index + 1}</span>
-
 					<BasicLink
 						href={`/cex/${row.original.slug || name}`}
 						className="overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-(--link-text)"

--- a/src/containers/ProDashboard/components/datasets/EarningsDataset/columns.tsx
+++ b/src/containers/ProDashboard/components/datasets/EarningsDataset/columns.tsx
@@ -21,17 +21,28 @@ interface IEarningsRow {
 
 export const earningsDatasetColumns: ColumnDef<IEarningsRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			return <span className="font-bold">{row.index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		id: 'name',
 		accessorFn: (row) => row.displayName || row.name,
 		enableSorting: false,
 		cell: ({ getValue, row }) => {
-			const index = row.index
 			const name = getValue() as string
 
 			return (
 				<span className="relative flex items-center gap-2 pl-6">
-					<span className="shrink-0">{index + 1}</span>
 					<TokenLogo size={20} logo={tokenIconUrl(slug(name))} data-lgonly />
 					<BasicLink
 						href={`/earnings/${row.original.slug}`}

--- a/src/containers/ProDashboard/components/datasets/FeesDataset/columns.tsx
+++ b/src/containers/ProDashboard/components/datasets/FeesDataset/columns.tsx
@@ -22,16 +22,27 @@ interface IFeesRow {
 
 export const feesDatasetColumns: ColumnDef<IFeesRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			return <span className="font-bold">{row.index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		id: 'name',
 		accessorFn: (row) => row.displayName || row.name,
 		enableSorting: false,
 		cell: ({ getValue, row }) => {
-			const index = row.index
 			const name = getValue() as string
 			return (
 				<span className="relative flex items-center gap-2 pl-6">
-					<span className="shrink-0">{index + 1}</span>
 					<TokenLogo size={20} logo={tokenIconUrl(slug(name))} data-lgonly />
 					<BasicLink
 						href={`/fees/${row.original.slug}`}

--- a/src/containers/ProDashboard/components/datasets/HoldersRevenueDataset/columns.tsx
+++ b/src/containers/ProDashboard/components/datasets/HoldersRevenueDataset/columns.tsx
@@ -21,18 +21,29 @@ interface IHoldersRevenueRow {
 
 export const holdersRevenueDatasetColumns: ColumnDef<IHoldersRevenueRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			return <span className="font-bold">{row.index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		id: 'name',
 		accessorFn: (row) => row.displayName || row.name,
 		enableSorting: false,
 		cell: ({ getValue, row }) => {
-			const index = row.index
 			const name = getValue() as string
 			const logo = row.original.logo
 
 			return (
 				<span className="relative flex items-center gap-2 pl-6">
-					<span className="shrink-0">{index + 1}</span>
 					<TokenLogo size={20} logo={tokenIconUrl(slug(name))} data-lgonly />
 					<BasicLink
 						href={`/holders-revenue/${row.original.slug}`}

--- a/src/containers/ProDashboard/components/datasets/RevenueDataset/columns.tsx
+++ b/src/containers/ProDashboard/components/datasets/RevenueDataset/columns.tsx
@@ -22,16 +22,27 @@ interface IRevenueRow {
 
 export const revenueDatasetColumns: ColumnDef<IRevenueRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			return <span className="font-bold">{row.index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		id: 'name',
 		accessorFn: (row) => row.displayName || row.name,
 		enableSorting: false,
 		cell: ({ getValue, row }) => {
-			const index = row.index
 			const name = getValue() as string
 			return (
 				<span className="relative flex items-center gap-2 pl-6">
-					<span className="shrink-0">{index + 1}</span>
 					<TokenLogo size={20} logo={tokenIconUrl(slug(name))} data-lgonly />
 					<BasicLink
 						href={`/revenue/${row.original.slug}`}

--- a/src/containers/ProDashboard/components/datasets/TokenUsageDataset/columns.tsx
+++ b/src/containers/ProDashboard/components/datasets/TokenUsageDataset/columns.tsx
@@ -18,16 +18,28 @@ export const getColumns = (tokenSymbols: string[]): ColumnDef<TokenUsageRow>[] =
 
 	const baseColumns: ColumnDef<TokenUsageRow>[] = [
 		{
+			id: 'rank',
+			header: 'Rank',
+			accessorKey: 'rank',
+			size: 60,
+			enableSorting: false,
+			cell: ({ row }) => {
+				const index = row.index
+				return <span className="font-bold">{index + 1}</span>
+			},
+			meta: {
+				align: 'center' as const
+			}
+		},
+		{
 			header: 'Protocol',
 			accessorKey: 'name',
 			enableSorting: false,
-			cell: ({ getValue, row, table }) => {
+			cell: ({ getValue, row }) => {
 				const value = getValue() as string
-				const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 
 				return (
 					<div className="flex items-center gap-2">
-						<span className="min-w-[30px] shrink-0 text-sm font-medium text-(--text-tertiary)">{index + 1}</span>
 						<TokenLogo logo={tokenIconUrl(value)} data-lgonly />
 						<BasicLink
 							href={`/protocol/${slug(value)}`}

--- a/src/containers/ProtocolsByCategoryOrTag/index.tsx
+++ b/src/containers/ProtocolsByCategoryOrTag/index.tsx
@@ -285,10 +285,10 @@ const rankColumn: Column = {
 	accessorFn: (protocol) => protocol.name,
 	size: 60,
 	enableSorting: false,
-	cell: ({ row, table }) => {
+	cell: ({ row }) => {
 		// Only show ranks for top-level protocols (depth 0), not for child protocols
 		if (row.depth > 0) return null
-		const index = table.getSortedRowModel().rows.findIndex((x) => x.id === row.id)
+		const index = row.index
 		return <span className="font-bold">{index + 1}</span>
 	},
 	meta: {

--- a/src/containers/ProtocolsWithTokens/index.tsx
+++ b/src/containers/ProtocolsWithTokens/index.tsx
@@ -177,13 +177,26 @@ const defaultColumns = (
 ): ColumnDef<IProtocolsWithTokensByChainPageData['protocols'][0]>[] => {
 	return [
 		{
+			id: 'rank',
+			header: 'Rank',
+			accessorKey: 'rank',
+			size: 60,
+			enableSorting: false,
+			cell: ({ row }) => {
+				const index = row.index
+				return <span className="font-bold">{index + 1}</span>
+			},
+			meta: {
+				align: 'center' as const
+			}
+		},
+		{
 			id: 'name',
 			header: 'Name',
 			accessorFn: (protocol) => protocol.name,
 			enableSorting: false,
 			cell: ({ getValue, row, table }) => {
 				const value = getValue() as string
-				const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 				const Chains = () => (
 					<span className="flex flex-col gap-1">
 						{row.original.chains.map((chain) => (
@@ -222,10 +235,6 @@ const defaultColumns = (
 								)}
 							</button>
 						) : null}
-
-						<span className="shrink-0" onClick={row.getToggleExpandedHandler()}>
-							{index + 1}
-						</span>
 
 						<TokenLogo logo={row.original.logo} data-lgonly />
 

--- a/src/containers/Stablecoins/Table/columns.tsx
+++ b/src/containers/Stablecoins/Table/columns.tsx
@@ -11,12 +11,25 @@ import type { IPeggedAssetByChainRow, IPeggedAssetsRow, IPeggedChain } from './t
 
 export const peggedAssetsByChainColumns: ColumnDef<IPeggedAssetByChainRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			if (row.original.name.startsWith('Bridged from')) return null
+			return <span className="font-bold">{row.index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		id: 'name',
 		accessorFn: (row) => `${row.name}${row.symbol && row.symbol !== '-' ? ` (${row.symbol})` : ''}`,
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 			const isSubRow = row.original.name.startsWith('Bridged from')
 
 			return (
@@ -52,7 +65,6 @@ export const peggedAssetsByChainColumns: ColumnDef<IPeggedAssetByChainRow>[] = [
 						</>
 					) : (
 						<>
-							<span className="shrink-0">{index + 1}</span>
 							<TokenLogo logo={chainIconUrl(row.original.name)} data-lgonly />
 							<BasicLink
 								href={`/stablecoins/${row.original.name}`}
@@ -149,9 +161,9 @@ export const peggedAssetsByChainColumns: ColumnDef<IPeggedAssetByChainRow>[] = [
 // key: min width of window/screen
 // values: table columns order
 export const assetsByChainColumnOrders = formatColumnOrder({
-	0: ['name', 'change_7d', 'circulating', 'change_1d', 'change_1m', 'bridgeInfo', 'bridgedAmount'],
-	480: ['name', 'change_7d', 'circulating', 'change_1d', 'change_1m', 'bridgeInfo', 'bridgedAmount'],
-	1024: ['name', 'bridgeInfo', 'bridgedAmount', 'change_1d', 'change_7d', 'change_1m', 'circulating']
+	0: ['rank', 'name', 'change_7d', 'circulating', 'change_1d', 'change_1m', 'bridgeInfo', 'bridgedAmount'],
+	480: ['rank', 'name', 'change_7d', 'circulating', 'change_1d', 'change_1m', 'bridgeInfo', 'bridgedAmount'],
+	1024: ['rank', 'name', 'bridgeInfo', 'bridgedAmount', 'change_1d', 'change_7d', 'change_1m', 'circulating']
 })
 
 export const assetsByChainColumnSizes = {
@@ -177,16 +189,26 @@ export const assetsByChainColumnSizes = {
 
 export const peggedAssetsColumns: ColumnDef<IPeggedAssetsRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			return <span className="font-bold">{row.index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		id: 'name',
 		accessorFn: (row) => `${row.name}${row.symbol && row.symbol !== '-' ? ` (${row.symbol})` : ''}`,
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-
 			return (
 				<span className="flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
 					<TokenLogo logo={peggedAssetIconUrl(row.original.name)} data-lgonly />
 					{row.original?.deprecated ? (
 						<BasicLink
@@ -387,8 +409,8 @@ export const peggedAssetsColumns: ColumnDef<IPeggedAssetsRow>[] = [
 // key: min width of window/screen
 // values: table columns order
 export const assetsColumnOrders = formatColumnOrder({
-	0: ['name', 'mcap', 'change_1d', 'change_7d', 'change_1m', 'price', 'pegDeviation', 'pegDeviation_1m', 'chains'],
-	1024: ['name', 'chains', 'pegDeviation', 'pegDeviation_1m', 'price', 'change_1d', 'change_7d', 'change_1m', 'mcap']
+	0: ['rank', 'name', 'mcap', 'change_1d', 'change_7d', 'change_1m', 'price', 'pegDeviation', 'pegDeviation_1m', 'chains'],
+	1024: ['rank', 'name', 'chains', 'pegDeviation', 'pegDeviation_1m', 'price', 'change_1d', 'change_7d', 'change_1m', 'mcap']
 })
 
 export const assetsColumnSizes = {
@@ -526,12 +548,26 @@ function pegDeviationText(pegDeviationInfo) {
 
 export const peggedChainsColumns: ColumnDef<IPeggedChain>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const value = row.original.name
+			if (value.startsWith('Bridged from')) return null
+			return <span className="font-bold">{row.index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const value = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 			const isSubRow = value.startsWith('Bridged from')
 
 			return (
@@ -562,12 +598,11 @@ export const peggedChainsColumns: ColumnDef<IPeggedChain>[] = [
 
 					{isSubRow ? (
 						<>
-							<span className="shrink-0">{index + 1}</span>
+							<span>-</span>
 							<span>{value}</span>
 						</>
 					) : (
 						<>
-							<span className="shrink-0">{index + 1}</span>
 							<TokenLogo logo={chainIconUrl(value)} data-lgonly />
 							<BasicLink
 								href={`/stablecoins/${value}`}

--- a/src/containers/TotalBorrowed/BorrowedByChain.tsx
+++ b/src/containers/TotalBorrowed/BorrowedByChain.tsx
@@ -67,13 +67,26 @@ export function BorrowedProtocolsTVLByChain(props: ITotalBorrowedByChainPageData
 
 const columns: ColumnDef<ITotalBorrowedByChainPageData['protocols'][0]>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		id: 'name',
 		header: 'Name',
 		accessorFn: (protocol) => protocol.name,
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const value = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 			const Chains = () => (
 				<span className="flex flex-col gap-1">
 					{row.original.chains.map((chain) => (
@@ -86,7 +99,7 @@ const columns: ColumnDef<ITotalBorrowedByChainPageData['protocols'][0]>[] = [
 			)
 
 			return (
-				<span className={`relative flex items-center gap-2 ${row.depth > 0 ? 'pl-12' : 'pl-6'}`}>
+				<span className={`relative flex items-center gap-2 ${row.depth > 0 ? 'pl-6' : ''}`}>
 					{row.subRows?.length > 0 ? (
 						<button
 							className="absolute -left-0.5"
@@ -107,8 +120,6 @@ const columns: ColumnDef<ITotalBorrowedByChainPageData['protocols'][0]>[] = [
 							)}
 						</button>
 					) : null}
-
-					<span className="shrink-0">{index + 1}</span>
 
 					<TokenLogo logo={row.original.logo} data-lgonly />
 

--- a/src/containers/TotalStaked/StakedByChain.tsx
+++ b/src/containers/TotalStaked/StakedByChain.tsx
@@ -67,13 +67,26 @@ export function StakedProtocolsTVLByChain(props: ITotalStakedByChainPageData) {
 
 const columns: ColumnDef<ITotalStakedByChainPageData['protocols'][0]>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		id: 'name',
 		header: 'Name',
 		accessorFn: (protocol) => protocol.name,
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const value = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 			const Chains = () => (
 				<span className="flex flex-col gap-1">
 					{row.original.chains.map((chain) => (
@@ -86,7 +99,7 @@ const columns: ColumnDef<ITotalStakedByChainPageData['protocols'][0]>[] = [
 			)
 
 			return (
-				<span className={`relative flex items-center gap-2 ${row.depth > 0 ? 'pl-12' : 'pl-6'}`}>
+				<span className={`relative flex items-center gap-2 ${row.depth > 0 ? 'pl-6' : ''}`}>
 					{row.subRows?.length > 0 ? (
 						<button
 							className="absolute -left-0.5"
@@ -107,8 +120,6 @@ const columns: ColumnDef<ITotalStakedByChainPageData['protocols'][0]>[] = [
 							)}
 						</button>
 					) : null}
-
-					<span className="shrink-0">{index + 1}</span>
 
 					<TokenLogo logo={row.original.logo} data-lgonly />
 

--- a/src/containers/Treasuries/index.tsx
+++ b/src/containers/Treasuries/index.tsx
@@ -79,18 +79,29 @@ export function Treasuries({ data, entity }) {
 
 export const columns: ColumnDef<any>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-
 			const name = (getValue() as string).split(' (treasury)')[0]
 			const slug = (row.original.slug as string).split('-(treasury)')[0]
 
 			return (
 				<span className="relative flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
 					<TokenLogo logo={tokenIconUrl(name)} data-lgonly />
 					<BasicLink
 						href={`/protocol/${slug}?treasury=true&tvl=false`}

--- a/src/containers/Yields/Tables/Borrow.tsx
+++ b/src/containers/Yields/Tables/Borrow.tsx
@@ -12,18 +12,29 @@ import type { IYieldsTableProps, IYieldTableRow } from './types'
 
 const columns: ColumnDef<IYieldTableRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Pool',
 		accessorKey: 'pool',
 		enableSorting: false,
-		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-
+		cell: ({ getValue, row }) => {
 			return (
 				<NameYieldPool
 					value={getValue() as string}
 					configID={row.original.configID}
 					url={row.original.url}
-					index={index + 1}
 					borrow={true}
 				/>
 			)
@@ -249,6 +260,7 @@ const columns: ColumnDef<IYieldTableRow>[] = [
 // values: table columns order
 const columnOrders = {
 	0: [
+		'rank',
 		'pool',
 		'project',
 		'chains',
@@ -263,6 +275,7 @@ const columnOrders = {
 		'totalAvailableUsd'
 	],
 	400: [
+		'rank',
 		'pool',
 		'project',
 		'chains',
@@ -277,6 +290,7 @@ const columnOrders = {
 		'totalAvailableUsd'
 	],
 	640: [
+		'rank',
 		'pool',
 		'project',
 		'chains',
@@ -291,6 +305,7 @@ const columnOrders = {
 		'totalAvailableUsd'
 	],
 	1280: [
+		'rank',
 		'pool',
 		'project',
 		'chains',
@@ -307,6 +322,7 @@ const columnOrders = {
 }
 const columnSizes = {
 	0: {
+		rank: 60,
 		pool: 200,
 		project: 200,
 		chain: 60,
@@ -321,6 +337,7 @@ const columnSizes = {
 		totalAvailableUsd: 120
 	},
 	812: {
+		rank: 60,
 		pool: 200,
 		project: 200,
 		chain: 60,
@@ -335,6 +352,7 @@ const columnSizes = {
 		totalAvailableUsd: 120
 	},
 	1536: {
+		rank: 60,
 		pool: 240,
 		project: 200,
 		chain: 60,
@@ -349,6 +367,7 @@ const columnSizes = {
 		totalAvailableUsd: 120
 	},
 	1600: {
+		rank: 60,
 		pool: 280,
 		project: 200,
 		chain: 60,
@@ -363,6 +382,7 @@ const columnSizes = {
 		totalAvailableUsd: 120
 	},
 	1640: {
+		rank: 60,
 		pool: 320,
 		project: 200,
 		chain: 60,
@@ -377,6 +397,7 @@ const columnSizes = {
 		totalAvailableUsd: 120
 	},
 	1720: {
+		rank: 60,
 		pool: 420,
 		project: 200,
 		chain: 60,

--- a/src/containers/Yields/Tables/Loop.tsx
+++ b/src/containers/Yields/Tables/Loop.tsx
@@ -12,18 +12,29 @@ import type { IYieldsTableProps, IYieldTableRow } from './types'
 
 const columns: ColumnDef<IYieldTableRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Pool',
 		accessorKey: 'pool',
 		enableSorting: false,
-		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-
+		cell: ({ getValue, row }) => {
 			return (
 				<NameYieldPool
 					value={getValue() as string}
 					configID={row.original.configID}
 					url={row.original.url}
-					index={index + 1}
 					borrow={true}
 				/>
 			)
@@ -204,6 +215,7 @@ const columns: ColumnDef<IYieldTableRow>[] = [
 // values: table columns order
 const columnOrders = {
 	0: [
+		'rank',
 		'pool',
 		'apy',
 		'project',
@@ -217,6 +229,7 @@ const columnOrders = {
 		'totalAvailableUsd'
 	],
 	400: [
+		'rank',
 		'pool',
 		'apy',
 		'project',
@@ -230,6 +243,7 @@ const columnOrders = {
 		'totalAvailableUsd'
 	],
 	640: [
+		'rank',
 		'pool',
 		'apy',
 		'project',
@@ -243,6 +257,7 @@ const columnOrders = {
 		'totalAvailableUsd'
 	],
 	1280: [
+		'rank',
 		'pool',
 		'apy',
 		'project',
@@ -259,6 +274,7 @@ const columnOrders = {
 
 const columnSizes = {
 	0: {
+		rank: 60,
 		pool: 160,
 		project: 180,
 		chain: 60,
@@ -271,6 +287,7 @@ const columnSizes = {
 		totalAvailableUsd: 80
 	},
 	812: {
+		rank: 60,
 		pool: 200,
 		project: 160,
 		chain: 60,
@@ -283,6 +300,7 @@ const columnSizes = {
 		totalAvailableUsd: 80
 	},
 	1536: {
+		rank: 60,
 		pool: 240,
 		project: 160,
 		chain: 60,
@@ -295,6 +313,7 @@ const columnSizes = {
 		totalAvailableUsd: 80
 	},
 	1600: {
+		rank: 60,
 		pool: 280,
 		project: 160,
 		chain: 60,
@@ -307,6 +326,7 @@ const columnSizes = {
 		totalAvailableUsd: 80
 	},
 	1640: {
+		rank: 60,
 		pool: 320,
 		project: 160,
 		chain: 60,
@@ -319,6 +339,7 @@ const columnSizes = {
 		totalAvailableUsd: 80
 	},
 	1720: {
+		rank: 60,
 		pool: 420,
 		project: 160,
 		chain: 60,

--- a/src/containers/Yields/Tables/Optimizer.tsx
+++ b/src/containers/Yields/Tables/Optimizer.tsx
@@ -13,13 +13,25 @@ import type { IYieldsOptimizerTableRow } from './types'
 
 const columns: ColumnDef<IYieldsOptimizerTableRow, number>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Pool',
 		accessorKey: 'pool',
 		enableSorting: false,
-		cell: ({ row, table }) => {
+		cell: ({ row }) => {
 			const name = `${row.original.symbol} ➞ ${row.original.borrow.symbol}`
-
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 
 			return (
 				<NameYieldPool
@@ -27,7 +39,6 @@ const columns: ColumnDef<IYieldsOptimizerTableRow, number>[] = [
 					value={name}
 					configID={row.original.configID}
 					url={row.original.url}
-					index={index + 1}
 					borrow={true}
 				/>
 			)
@@ -306,6 +317,7 @@ const columns: ColumnDef<IYieldsOptimizerTableRow, number>[] = [
 // values: table columns order
 const columnOrders = {
 	0: [
+		'rank',
 		'pool',
 		'project',
 		'chains',
@@ -323,6 +335,7 @@ const columnOrders = {
 		'totalBorrowUsd'
 	],
 	400: [
+		'rank',
 		'pool',
 		'project',
 		'chains',
@@ -340,6 +353,7 @@ const columnOrders = {
 		'totalBorrowUsd'
 	],
 	640: [
+		'rank',
 		'pool',
 		'project',
 		'chains',
@@ -357,6 +371,7 @@ const columnOrders = {
 		'totalBorrowUsd'
 	],
 	1280: [
+		'rank',
 		'pool',
 		'project',
 		'chains',
@@ -377,6 +392,7 @@ const columnOrders = {
 
 const columnSizes = {
 	0: {
+		rank: 60,
 		pool: 160,
 		project: 180,
 		chain: 60,
@@ -392,6 +408,7 @@ const columnSizes = {
 		totalBorrowUsd: 100
 	},
 	812: {
+		rank: 60,
 		pool: 210,
 		project: 180,
 		chain: 60,
@@ -407,6 +424,7 @@ const columnSizes = {
 		totalBorrowUsd: 120
 	},
 	1536: {
+		rank: 60,
 		pool: 240,
 		project: 180,
 		chain: 60,
@@ -422,6 +440,7 @@ const columnSizes = {
 		totalBorrowUsd: 120
 	},
 	1600: {
+		rank: 60,
 		pool: 280,
 		project: 180,
 		chain: 60,
@@ -437,6 +456,7 @@ const columnSizes = {
 		totalBorrowUsd: 120
 	},
 	1640: {
+		rank: 60,
 		pool: 320,
 		project: 180,
 		chain: 60,
@@ -452,6 +472,7 @@ const columnSizes = {
 		totalBorrowUsd: 120
 	},
 	1720: {
+		rank: 60,
 		pool: 420,
 		project: 180,
 		chain: 60,

--- a/src/containers/Yields/Tables/Pools.tsx
+++ b/src/containers/Yields/Tables/Pools.tsx
@@ -15,17 +15,29 @@ const uniswapV3 = 'For Uniswap V3 we assume a price range of +/- 30% (+/- 0.1% f
 
 const columns: ColumnDef<IYieldTableRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Pool',
 		accessorKey: 'pool',
 		enableSorting: false,
-		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
+		cell: ({ getValue, row }) => {
 			return (
 				<NameYieldPool
 					value={getValue() as string}
 					configID={row.original.configID}
 					url={row.original.url}
-					index={index + 1}
 					poolMeta={row.original.poolMeta}
 				/>
 			)
@@ -437,6 +449,7 @@ const columns: ColumnDef<IYieldTableRow>[] = [
 // values: table columns order
 const columnOrders = {
 	0: [
+		'rank',
 		'pool',
 		'apy',
 		'apyIncludingLsdApy',
@@ -463,6 +476,7 @@ const columnOrders = {
 		'totalAvailableUsd'
 	],
 	400: [
+		'rank',
 		'pool',
 		'project',
 		'apy',
@@ -489,6 +503,7 @@ const columnOrders = {
 		'totalAvailableUsd'
 	],
 	640: [
+		'rank',
 		'pool',
 		'project',
 		'tvl',
@@ -515,6 +530,7 @@ const columnOrders = {
 		'totalAvailableUsd'
 	],
 	1280: [
+		'rank',
 		'pool',
 		'project',
 		'chains',
@@ -544,6 +560,7 @@ const columnOrders = {
 
 const columnSizes = {
 	0: {
+		rank: 60,
 		pool: 120,
 		project: 200,
 		chain: 60,
@@ -570,6 +587,7 @@ const columnSizes = {
 		totalAvailableUsd: 120
 	},
 	812: {
+		rank: 60,
 		pool: 200,
 		project: 200,
 		chain: 60,
@@ -596,6 +614,7 @@ const columnSizes = {
 		totalAvailableUsd: 120
 	},
 	1280: {
+		rank: 60,
 		pool: 240,
 		project: 200,
 		chain: 60,
@@ -622,6 +641,7 @@ const columnSizes = {
 		totalAvailableUsd: 120
 	},
 	1536: {
+		rank: 60,
 		pool: 280,
 		project: 200,
 		chain: 60,
@@ -648,6 +668,7 @@ const columnSizes = {
 		totalAvailableUsd: 120
 	},
 	1600: {
+		rank: 60,
 		pool: 320,
 		project: 200,
 		chain: 60,
@@ -674,6 +695,7 @@ const columnSizes = {
 		totalAvailableUsd: 120
 	},
 	1640: {
+		rank: 60,
 		pool: 360,
 		project: 200,
 		chain: 60,
@@ -700,6 +722,7 @@ const columnSizes = {
 		totalAvailableUsd: 120
 	},
 	1720: {
+		rank: 60,
 		pool: 420,
 		project: 200,
 		chain: 60,

--- a/src/containers/Yields/Tables/Strategy.tsx
+++ b/src/containers/Yields/Tables/Strategy.tsx
@@ -12,13 +12,25 @@ import type { IYieldsStrategyTableRow } from './types'
 
 const columns: ColumnDef<IYieldsStrategyTableRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Strategy',
 		accessorKey: 'strategy',
 		enableSorting: false,
-		cell: ({ row, table }) => {
+		cell: ({ row }) => {
 			const name = `${row.original.symbol} ➞ ${row.original.borrow.symbol} ➞ ${row.original.farmSymbol}`
-
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 
 			return (
 				<div className="flex flex-col gap-2 text-xs">
@@ -27,7 +39,6 @@ const columns: ColumnDef<IYieldsStrategyTableRow>[] = [
 						// in case of cdp row.original.pool === row.original.borrow.pool
 						configID={`${row.original.pool}_${row.original.borrow.pool}_${row.original.farmPool}`}
 						url={row.original.url}
-						index={index + 1}
 						strategy={true}
 						maxCharacters={50}
 						bookmark={false}
@@ -38,7 +49,6 @@ const columns: ColumnDef<IYieldsStrategyTableRow>[] = [
 						project2={row.original.farmProjectName}
 						airdropProject2={false}
 						chain={row.original.chains[0]}
-						index={index + 1}
 					/>
 				</div>
 			)
@@ -170,14 +180,15 @@ const columns: ColumnDef<IYieldsStrategyTableRow>[] = [
 // key: min width of window/screen
 // values: table columns order
 const columnOrders = {
-	0: ['strategy', 'totalApy', 'delta', 'ltv', 'borrowAvailableUsd', 'farmTvlUsd'],
-	400: ['strategy', 'totalApy', 'delta', 'ltv', 'borrowAvailableUsd', 'farmTvlUsd'],
-	640: ['strategy', 'totalApy', 'delta', 'ltv', 'borrowAvailableUsd', 'farmTvlUsd'],
-	1280: ['strategy', 'totalApy', 'delta', 'ltv', 'borrowAvailableUsd', 'farmTvlUsd']
+	0: ['rank', 'strategy', 'totalApy', 'delta', 'ltv', 'borrowAvailableUsd', 'farmTvlUsd'],
+	400: ['rank', 'strategy', 'totalApy', 'delta', 'ltv', 'borrowAvailableUsd', 'farmTvlUsd'],
+	640: ['rank', 'strategy', 'totalApy', 'delta', 'ltv', 'borrowAvailableUsd', 'farmTvlUsd'],
+	1280: ['rank', 'strategy', 'totalApy', 'delta', 'ltv', 'borrowAvailableUsd', 'farmTvlUsd']
 }
 
 const columnSizes = {
 	0: {
+		rank: 60,
 		strategy: 250,
 		totalApy: 150,
 		delta: 100,
@@ -186,6 +197,7 @@ const columnSizes = {
 		farmTvlUsd: 100
 	},
 	812: {
+		rank: 60,
 		strategy: 300,
 		totalApy: 150,
 		delta: 100,

--- a/src/containers/Yields/Tables/StrategyFR.tsx
+++ b/src/containers/Yields/Tables/StrategyFR.tsx
@@ -12,13 +12,25 @@ import type { IYieldsStrategyTableRow } from './types'
 
 const columns: ColumnDef<IYieldsStrategyTableRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Strategy',
 		accessorKey: 'strategy',
 		enableSorting: false,
-		cell: ({ row, table }) => {
+		cell: ({ row }) => {
 			const name = `Long ${row.original.symbol} | Short ${row.original.symbolPerp}`
-
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 
 			return (
 				<div className="flex flex-col gap-2 text-xs">
@@ -27,7 +39,6 @@ const columns: ColumnDef<IYieldsStrategyTableRow>[] = [
 						configID={row.original.pool}
 						withoutLink={true}
 						url={row.original.url}
-						index={index + 1}
 						strategy={true}
 						maxCharacters={50}
 						bookmark={false}
@@ -38,7 +49,6 @@ const columns: ColumnDef<IYieldsStrategyTableRow>[] = [
 						project2={row.original.marketplace}
 						airdropProject2={false}
 						chain={row.original.chains[0]}
-						index={index + 1}
 					/>
 				</div>
 			)
@@ -191,14 +201,15 @@ const columns: ColumnDef<IYieldsStrategyTableRow>[] = [
 // key: min width of window/screen
 // values: table columns order
 const columnOrders = {
-	0: ['strategy', 'strategyAPY', 'apy', 'afr', 'fr8hCurrent', 'fundingRate7dAverage', 'tvlUsd', 'openInterest'],
-	400: ['strategy', 'strategyAPY', 'apy', 'afr', 'fr8hCurrent', 'fundingRate7dAverage', 'tvlUsd', 'openInterest'],
-	640: ['strategy', 'strategyAPY', 'apy', 'afr', 'fr8hCurrent', 'fundingRate7dAverage', 'tvlUsd', 'openInterest'],
-	1280: ['strategy', 'strategyAPY', 'apy', 'afr', 'fr8hCurrent', 'fundingRate7dAverage', 'tvlUsd', 'openInterest']
+	0: ['rank', 'strategy', 'strategyAPY', 'apy', 'afr', 'fr8hCurrent', 'fundingRate7dAverage', 'tvlUsd', 'openInterest'],
+	400: ['rank', 'strategy', 'strategyAPY', 'apy', 'afr', 'fr8hCurrent', 'fundingRate7dAverage', 'tvlUsd', 'openInterest'],
+	640: ['rank', 'strategy', 'strategyAPY', 'apy', 'afr', 'fr8hCurrent', 'fundingRate7dAverage', 'tvlUsd', 'openInterest'],
+	1280: ['rank', 'strategy', 'strategyAPY', 'apy', 'afr', 'fr8hCurrent', 'fundingRate7dAverage', 'tvlUsd', 'openInterest']
 }
 
 const columnSizes = {
 	0: {
+		rank: 60,
 		strategy: 250,
 		strategyAPY: 145,
 		apy: 125,
@@ -209,6 +220,7 @@ const columnSizes = {
 		openInterest: 140
 	},
 	812: {
+		rank: 60,
 		strategy: 300,
 		strategyAPY: 145,
 		apy: 125,

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -268,15 +268,26 @@ export default function Protocols({ emissions }) {
 
 export const calendarColumns: ColumnDef<any>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-
 			return (
 				<span className="relative flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
 					{row.original.type === 'Unlock' ? (
 						<BasicLink
 							href={`/unlocks/${slug(row.original.link)}`}

--- a/src/pages/categories.tsx
+++ b/src/pages/categories.tsx
@@ -386,12 +386,24 @@ interface ICategoryRow {
 
 const categoriesColumn: ColumnDef<ICategoryRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Category',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-
 			return (
 				<span className={`relative flex items-center gap-2 ${row.depth > 0 ? 'pl-8' : 'pl-4'}`}>
 					{row.subRows?.length > 0 ? (
@@ -414,7 +426,6 @@ const categoriesColumn: ColumnDef<ICategoryRow>[] = [
 							)}
 						</button>
 					) : null}
-					<span className="shrink-0">{index + 1}</span>{' '}
 					{row.depth > 0 ? (
 						<BasicLink
 							href={`/protocols/${slug(getValue() as string)}`}

--- a/src/pages/digital-asset-treasuries/[...asset].tsx
+++ b/src/pages/digital-asset-treasuries/[...asset].tsx
@@ -199,15 +199,27 @@ const columns = ({
 	symbol: string
 }): ColumnDef<IDATOverviewDataByAssetProps['institutions'][number]>[] => [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Institution',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const name = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 			return (
 				<span className="relative flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
 					<BasicLink
 						href={`/digital-asset-treasury/${slug(row.original.ticker)}`}
 						title={name}

--- a/src/pages/digital-asset-treasuries/index.tsx
+++ b/src/pages/digital-asset-treasuries/index.tsx
@@ -230,15 +230,26 @@ export default function TreasuriesByInstitution({ allAssets, institutions, daily
 
 const columns: ColumnDef<IDATOverviewPageProps['institutions'][0]>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			return <span className="font-bold">{row.index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Institution',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const name = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 			return (
 				<span className="relative flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
 					<BasicLink
 						href={`/digital-asset-treasury/${slug(row.original.ticker)}`}
 						title={name}

--- a/src/pages/etfs.tsx
+++ b/src/pages/etfs.tsx
@@ -254,15 +254,26 @@ interface IETFRow {
 
 export const columns: ColumnDef<IETFRow>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Ticker',
 		accessorKey: 'ticker',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-
 			return (
 				<span className="relative flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
 					<BasicLink
 						href={row.original.url}
 						className="overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-(--link-text) hover:underline"

--- a/src/pages/expenses.tsx
+++ b/src/pages/expenses.tsx
@@ -66,15 +66,26 @@ export default function Protocols(props) {
 
 const columns: ColumnDef<any>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
-
 			return (
 				<span className="relative flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
 					<TokenLogo logo={tokenIconUrl(getValue())} data-lgonly />
 					<BasicLink
 						href={`/protocol/${slug(getValue() as string)}`}

--- a/src/pages/hacks/total-value-lost.tsx
+++ b/src/pages/hacks/total-value-lost.tsx
@@ -26,6 +26,7 @@ const pageName = ['Protocols', 'ranked by', 'Total Value Lost in Hacks']
 
 export default function TotalLostInHacks({ protocols }: IProtocolTotalValueLostInHacksByProtocol) {
 	const [selectedColumns, setSelectedColumns] = React.useState<Array<string>>([
+		'Rank',
 		'Name',
 		'Total Hacked',
 		'Returned Funds',
@@ -90,17 +91,26 @@ export default function TotalLostInHacks({ protocols }: IProtocolTotalValueLostI
 
 const columns: ColumnDef<IProtocolTotalValueLostInHacksByProtocol['protocols'][number]>[] = [
 	{
+		id: 'Rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		accessorFn: (row) => row.name,
 		id: 'Name',
 		cell: ({ row, getValue, table }) => {
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 			return (
 				<span className={`relative flex items-center gap-2 ${row.depth > 0 ? 'pl-6' : 'pl-0'}`}>
-					<span className="shrink-0" onClick={row.getToggleExpandedHandler()}>
-						{index + 1}
-					</span>
-
 					<TokenLogo logo={tokenIconUrl(row.original.slug)} data-lgonly />
 
 					<BasicLink

--- a/src/pages/net-project-treasury/index.tsx
+++ b/src/pages/net-project-treasury/index.tsx
@@ -66,18 +66,28 @@ const NetProjectTreasuries = (props) => {
 
 const columns: ColumnDef<INetProjectTreasuryByChain['protocols'][0]>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			return <span className="font-bold">{row.index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		id: 'name',
 		header: 'Name',
 		accessorFn: (protocol) => protocol.name,
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const value = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 
 			return (
 				<span className="relative flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
-
 					<TokenLogo logo={row.original.logo} data-lgonly />
 
 					<span className="-my-2 flex flex-col">

--- a/src/pages/nfts/chains.tsx
+++ b/src/pages/nfts/chains.tsx
@@ -60,18 +60,29 @@ export default function NftsOnAllChains(props) {
 
 const columns: ColumnDef<any>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		id: 'name',
 		header: 'Name',
 		accessorFn: (protocol) => protocol.name,
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const value = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 
 			return (
 				<span className="relative flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
-
 					<TokenLogo logo={row.original.logo} data-lgonly />
 
 					<BasicLink

--- a/src/pages/nfts/earnings.tsx
+++ b/src/pages/nfts/earnings.tsx
@@ -60,12 +60,27 @@ interface IEarnings {
 
 const earningsColumns: ColumnDef<IEarnings>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			if (row.depth === 0) {
+				return <span className="font-bold">{row.index + 1}</span>
+			}
+			return null
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const value = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 			const logo = row.original.logo ?? row.subRows?.[0]?.original?.logo
 
 			return (
@@ -93,8 +108,6 @@ const earningsColumns: ColumnDef<IEarnings>[] = [
 							)}
 						</button>
 					) : null}
-
-					<span className="shrink-0">{index + 1}</span>
 
 					{logo ? <TokenLogo logo={logo} data-lgonly /> : <FallbackLogo />}
 

--- a/src/pages/rev/chains.tsx
+++ b/src/pages/rev/chains.tsx
@@ -49,18 +49,29 @@ const REVByChain = (props: IChainsByREVPageData) => {
 
 const columns: ColumnDef<IChainsByREVPageData['chains'][0]>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		id: 'name',
 		header: 'Name',
 		accessorFn: (protocol) => protocol.name,
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const value = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 
 			return (
 				<span className="relative flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
-
 					<TokenLogo logo={row.original.logo} data-lgonly />
 
 					<span className="-my-2 flex flex-col">

--- a/src/pages/safe-harbor-agreements.tsx
+++ b/src/pages/safe-harbor-agreements.tsx
@@ -94,13 +94,26 @@ const columns: ColumnDef<{
 	dexVolume: number
 }>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		id: 'name',
 		header: 'Name',
 		accessorFn: (protocol) => protocol.name,
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const value = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 			const Chains = () => (
 				<span className="flex flex-col gap-1">
 					{row.original.chains.map((chain) => (
@@ -134,10 +147,6 @@ const columns: ColumnDef<{
 							)}
 						</button>
 					) : null}
-
-					<span className="shrink-0" onClick={row.getToggleExpandedHandler()}>
-						{index + 1}
-					</span>
 
 					<TokenLogo logo={row.original.logo} data-lgonly />
 

--- a/src/pages/token-usage.tsx
+++ b/src/pages/token-usage.tsx
@@ -151,16 +151,28 @@ function Table({ data }: { data: Array<{ name: string; amountUsd: number }> }) {
 
 const columns: ColumnDef<{ name: string; amountUsd: number }>[] = [
 	{
+		id: 'rank',
+		header: 'Rank',
+		accessorKey: 'rank',
+		size: 60,
+		enableSorting: false,
+		cell: ({ row }) => {
+			const index = row.index
+			return <span className="font-bold">{index + 1}</span>
+		},
+		meta: {
+			align: 'center' as const
+		}
+	},
+	{
 		header: 'Name',
 		accessorKey: 'name',
 		enableSorting: false,
 		cell: ({ getValue, row, table }) => {
 			const value = getValue() as string
-			const index = row.depth === 0 ? table.getSortedRowModel().rows.findIndex((x) => x.id === row.id) : row.index
 
 			return (
 				<span className="flex items-center gap-2">
-					<span className="shrink-0">{index + 1}</span>
 					<TokenLogo logo={tokenIconUrl(value)} data-lgonly />
 					<BasicLink
 						href={`/protocol/${slug(value)}`}


### PR DESCRIPTION
## Description

- Separates rank numbers from protocol names into dedicated rank columns across all table
  components in the DeFiLlama application. This change affects the home page Protocol Rankings,
  category protocol listings, chain-specific tables, and specialized protocol tables (governance,
  LSD, forks, etc.).

## Motivation

- Improved Data Clarity: Separating rank from name eliminates visual clutter and makes both pieces
   of information easier to scan and process.

- Enhanced UX Consistency: Users now see the same table structure across all DeFiLlama ranking
  pages, creating a cohesive experience.

- Better Information Architecture: Distinct columns allow users to focus on either ranking
  position or protocol details independently.

- Professional Appearance: Clean column separation gives tables a more structured, professional
  look that aligns with modern data visualization standards.

- Accessibility: Clear separation improves readability and makes ranking information more
  accessible to screen readers and users scanning large datasets.


## Before

<img width="2228" height="1252" alt="Screenshot 2026-01-04 at 6 49 06 PM" src="https://github.com/user-attachments/assets/091ca8e7-433d-46e9-b630-dea2fd5deaa3" />



## After


<img width="2240" height="1258" alt="Screenshot 2026-01-04 at 6 54 18 PM" src="https://github.com/user-attachments/assets/2fdd3223-55d4-463b-83d3-4d59adee270b" />

## btw 

I have an incoming PR after this merges to refactor the rank functions but wanted to keep this PR change isolated and focused since the rank functions were already like this anyways (wasn't introduced in this change) so I will refactor that in a separate PR 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visible Rank column across many tables (protocols, bridges, liquidations, datasets, yields, pages, etc.) to show 1-based row ranking.

* **Improvements**
  * Rank reflects current table sort order and is non-sortable itself.
  * Removed inline index badges from name cells; rank is now consistently shown in the dedicated column.
  * Minor layout and responsive updates to accommodate the new column.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->