### PR TITLE
feat: add hacks as metric to protocol charts

### DIFF
--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -2,6 +2,8 @@ export const oldBlue = '#1f67d2'
 
 export const purple = '#9333ea' // Purple color for negative values
 
+export const HACKS_COLOR = '#DC2626' // Red color for hacks
+
 export const CHART_COLORS = [
 	oldBlue,
 	'#E91E63', // Hot Pink

--- a/src/containers/ProtocolOverview/Chart/ProtocolChart.tsx
+++ b/src/containers/ProtocolOverview/Chart/ProtocolChart.tsx
@@ -77,7 +77,9 @@ export const ProtocolChart = memo(function ProtocolChart(props: IProtocolOvervie
 
 		const toggledMetrics = {
 			...chartsByVisibility,
-			denomination: typeof queryParams.denomination === 'string' ? queryParams.denomination : null
+			denomination: typeof queryParams.denomination === 'string' ? queryParams.denomination : null,
+			events: queryParams.events === 'true' ? 'true' : 'false',
+			hacks: queryParams.hacks === 'true' ? 'true' : 'false'
 		} as IToggledMetrics
 
 		for (const chartLabel of props.defaultToggledCharts) {
@@ -184,6 +186,36 @@ export const ProtocolChart = memo(function ProtocolChart(props: IProtocolOvervie
 										)}
 									</button>
 								))}
+								{props.hacks && props.hacks.length > 0 ? (
+									<button
+										onClick={() => {
+											router
+												.push(
+													updateQueryParamInUrl(
+														router.asPath,
+														'hacks',
+														toggledMetrics.hacks === 'true' ? 'false' : 'true'
+													),
+													undefined,
+													{
+														shallow: true
+													}
+												)
+												.then(() => {
+													metricsDialogStore.toggle()
+												})
+										}}
+										data-active={toggledMetrics.hacks === 'true'}
+										className="flex items-center gap-1 rounded-full border border-(--old-blue) px-2 py-1 hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) data-[active=true]:bg-(--old-blue) data-[active=true]:text-white"
+									>
+										<span>Hacks</span>
+										{toggledMetrics.hacks === 'true' ? (
+											<Icon name="x" className="h-3.5 w-3.5" />
+										) : (
+											<Icon name="plus" className="h-3.5 w-3.5" />
+										)}
+									</button>
+								) : null}
 								{props.hallmarks?.length > 0 || props.rangeHallmarks?.length > 0 ? (
 									<button
 										onClick={() => {
@@ -253,6 +285,34 @@ export const ProtocolChart = memo(function ProtocolChart(props: IProtocolOvervie
 						</span>
 					</label>
 				))}
+				{toggledMetrics.hacks === 'true' && props.hacks && props.hacks.length > 0 ? (
+					<label className="relative flex cursor-pointer flex-nowrap items-center gap-1 text-sm last-of-type:mr-auto">
+						<input
+							type="checkbox"
+							value="hacks"
+							checked={true}
+							onChange={() => {
+								router.push(
+									updateQueryParamInUrl(router.asPath, 'hacks', toggledMetrics.hacks === 'true' ? 'false' : 'true'),
+									undefined,
+									{
+										shallow: true
+									}
+								)
+							}}
+							className="peer absolute h-[1em] w-[1em] opacity-[0.00001]"
+						/>
+						<span
+							className="flex items-center gap-1 rounded-full border-2 border-(--old-blue) px-2 py-1 text-xs"
+							style={{
+								borderColor: props.chartColors['Hacks'] || '#dc2626'
+							}}
+						>
+							<span>Hacks</span>
+							<Icon name="x" className="h-3.5 w-3.5" />
+						</span>
+					</label>
+				) : null}
 				{toggledMetrics.events === 'true' && (props.hallmarks?.length > 0 || props.rangeHallmarks?.length > 0) ? (
 					<label className="relative flex cursor-pointer flex-nowrap items-center gap-1 text-sm last-of-type:mr-auto">
 						<input
@@ -378,7 +438,8 @@ export const useFetchAndFormatChartData = ({
 	governanceApis,
 	tvlSettings,
 	feesSettings,
-	isCEX
+	isCEX,
+	hacks
 }: IProtocolOverviewPageData & {
 	toggledMetrics: IToggledMetrics
 	groupBy: 'daily' | 'weekly' | 'monthly' | 'cumulative'
@@ -1399,6 +1460,10 @@ export const useFetchAndFormatChartData = ({
 			})
 		}
 
+		if (toggledMetrics.hacks === 'true' && hacks && hacks.length > 0) {
+			charts['Hacks'] = hacks.map((hack) => [hack.date * 1000, hack.amount] as [number, number])
+		}
+
 		return { finalCharts: charts, valueSymbol, loadingCharts: '' }
 	}, [
 		toggledMetrics,
@@ -1460,7 +1525,8 @@ export const useFetchAndFormatChartData = ({
 		groupBy,
 		extraTvlCharts,
 		valueSymbol,
-		isCEX
+		isCEX,
+		hacks
 	])
 
 	return chartData

--- a/src/containers/ProtocolOverview/Chart/constants.tsx
+++ b/src/containers/ProtocolOverview/Chart/constants.tsx
@@ -37,7 +37,8 @@ export const protocolCharts = {
 	'Gas Used': 'gasUsed',
 	Tweets: 'tweets',
 	'NFT Volume': 'nftVolume',
-	'Bridge Volume': 'bridgeVolume'
+	'Bridge Volume': 'bridgeVolume',
+	Hacks: 'hacks'
 } as const
 
 export type ProtocolChartsLabels = keyof typeof protocolCharts
@@ -84,7 +85,8 @@ export const yAxisByChart: {
 	Treasury: 'Treasury',
 	Tweets: 'Tweets',
 	'NFT Volume': 'NFT Volume',
-	'Bridge Volume': 'DEX Volume'
+	'Bridge Volume': 'DEX Volume',
+	Hacks: 'Hacks'
 }
 
 export const BAR_CHARTS: ProtocolChartsLabels[] = [
@@ -112,5 +114,6 @@ export const BAR_CHARTS: ProtocolChartsLabels[] = [
 	'Options Notional Volume',
 	'Perp Aggregator Volume',
 	'Bridge Aggregator Volume',
-	'Bridge Volume'
+	'Bridge Volume',
+	'Hacks'
 ]

--- a/src/containers/ProtocolOverview/queries.tsx
+++ b/src/containers/ProtocolOverview/queries.tsx
@@ -21,7 +21,7 @@ import {
 	YIELD_POOLS_API
 } from '~/constants'
 import { chainCoingeckoIdsForGasNotMcap } from '~/constants/chainTokens'
-import { CHART_COLORS } from '~/constants/colors'
+import { CHART_COLORS, HACKS_COLOR } from '~/constants/colors'
 import { DEFI_SETTINGS_KEYS_SET } from '~/contexts/LocalStorage'
 import { definitions } from '~/public/definitions'
 import { capitalizeFirstLetter, firstDayOfMonth, firstDayOfQuarter, getProtocolTokenUrlOnExplorer, slug } from '~/utils'
@@ -820,12 +820,12 @@ export const getProtocolOverviewPageData = async ({
 	availableCharts.forEach((chart, index) => {
 		chartColors[chart] = CHART_COLORS[index]
 	})
+	if (hacks) {
+		chartColors['Hacks'] = HACKS_COLOR
+	}
 
 	const hallmarks = {}
 	const rangeHallmarks = []
-	for (const hack of hacks ?? []) {
-		hallmarks[hack.date] = `Hack: ${hack.classification ?? ''}`
-	}
 	for (const mark of protocolData.hallmarks ?? []) {
 		if (Array.isArray(mark[0])) {
 			rangeHallmarks.push(mark)

--- a/src/containers/ProtocolOverview/types.ts
+++ b/src/containers/ProtocolOverview/types.ts
@@ -336,5 +336,6 @@ export interface IDenominationPriceHistory {
 export interface IToggledMetrics
 	extends Record<(typeof protocolCharts)[keyof typeof protocolCharts], 'true' | 'false'> {
 	events: 'true' | 'false'
+	hacks: 'true' | 'false'
 	denomination: string | null
 }


### PR DESCRIPTION
### What
- Add hacks, and their values, as a chart series on protocol overview pages
- Render hacks as a bar chart with a dedicated axis and color
- Persist hacks visibility via query params like other metrics

### Why
- Makes it easy to visualise hack impact and correlate it with protocol metrics over time (see Balancer TVL impact below for example)

### Screenshots

<img width="1488" height="635" alt="Screenshot 2026-01-07 at 23 43 28" src="https://github.com/user-attachments/assets/774e841b-d3b8-40e4-9ecc-7c9a07ac47dc" />

<img width="609" height="331" alt="Screenshot 2026-01-07 at 23 49 42" src="https://github.com/user-attachments/assets/3f7a4063-02d6-45e2-b3b6-0e6c8755962d" />

<img width="1000" height="455" alt="Screenshot 2026-01-07 at 23 43 35" src="https://github.com/user-attachments/assets/e95a4530-7878-4165-a4fd-62101a8c3c6d" />

<img width="998" height="508" alt="Screenshot 2026-01-07 at 23 44 11" src="https://github.com/user-attachments/assets/38512db8-6a1c-4176-8bcf-462cdb2826c7" />

---

### Alternative Approach 🤔 

I think this works fairly well as an actual data point on the chart, as the hacks have a value we can represent on their own axis but I also explored having it as an annotation/hallmark instead as it's really an event rather than a stat. I'm pretty torn between the two so wanted to offer both. 

I have the code ready to go for this too so let me know what you think:

<img width="1001" height="637" alt="Screenshot 2026-01-07 at 22 48 02" src="https://github.com/user-attachments/assets/3aa60511-7900-4340-b30a-9885569f51f8" />

<img width="1489" height="673" alt="Screenshot 2026-01-07 at 22 47 52" src="https://github.com/user-attachments/assets/99b5cc8c-9abf-40d2-99e0-401b1895d07c" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Hacks" metric toggle to the protocol overview chart, allowing users to display or hide hacks data
  * Hacks data visualizes as a distinct dashed-line series with dedicated Y-axis styling and custom color
  * Enhanced chart layout customization with a new hideDataZoom option for flexible data zoom control
  * Added Hacks toggle button to metric selection UI alongside existing metric controls

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->