### PR TITLE
fix email preference not updating in UI

### DIFF
--- a/src/containers/Subscribtion/auth.tsx
+++ b/src/containers/Subscribtion/auth.tsx
@@ -548,7 +548,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 
 			return { value }
 		},
-		onSuccess: (data) => {
+		onSuccess: async (data) => {
 			queryClient.setQueryData(['currentUserAuthStatus'], (oldData: any) => {
 				if (!oldData) return oldData
 				return {
@@ -556,6 +556,11 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 					promotionalEmails: data.value
 				}
 			})
+			try {
+				await pb.collection('users').authRefresh()
+			} catch (error) {
+				console.log('Error refreshing auth after promotional emails update:', error)
+			}
 			toast.success('Email preferences updated successfully')
 		},
 		onError: (error: any) => {
@@ -583,7 +588,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 			expand: authStoreState.record.expand,
 			has_active_subscription: authStoreState.record.has_active_subscription,
 			flags: authStoreState.record.flags ?? {},
-			ethereum_email: authStoreState.record.ethereum_email
+			ethereum_email: authStoreState.record.ethereum_email,
+			promotionalEmails: authStoreState.record.promotionalEmails as PromotionalEmailsValue | undefined
 		} as AuthModel
 	}, [authStoreState])
 

--- a/src/utils/pocketbase.ts
+++ b/src/utils/pocketbase.ts
@@ -13,6 +13,7 @@ export interface AuthModel extends RecordModel {
 	updated: string
 	has_active_subscription: boolean
 	flags: Record<string, boolean>
+	promotionalEmails?: 'initial' | 'on' | 'off'
 }
 
 export default pb


### PR DESCRIPTION
### What
- Expose `promotionalEmails` in the AuthModel
- Refresh PocketBase auth after updating email preference

### Why
- Preference correctly updating in the DB but not the UI
- Always showing as false regardless of setting

### Demo
Before:

https://github.com/user-attachments/assets/1fd3a403-30ec-4b64-b8f6-5c52883a5d26



After: 


https://github.com/user-attachments/assets/c96d86f3-e853-4d16-bc21-7fa30b4f9376



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added promotional email preference management, allowing users to control whether they receive promotional content.

* **Improvements**
  * Enhanced reliability of preference updates with better error handling and data synchronization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->