### PR TITLE
add option to exclude own token in cex asset breakdown page

### DIFF
--- a/src/containers/ProtocolOverview/utils.tsx
+++ b/src/containers/ProtocolOverview/utils.tsx
@@ -712,20 +712,23 @@ export const useFetchProtocolAddlChartsData = (
 	const { data: addlProtocolData, isLoading } = useFetchProtocol(protocolName)
 	const [extraTvlsEnabled] = useLocalStorageSettingsManager('tvl_fees')
 
+	// Normalize to null for consistent caching
+	const normalizedTokenToExclude = tokenToExclude || null
+
 	const data = useQuery({
 		queryKey: [
 			'protocols-addl-chart-data',
 			protocolName,
 			addlProtocolData ? true : false,
 			isBorrowed ? 'borrowed' : JSON.stringify(extraTvlsEnabled),
-			tokenToExclude ?? null
+			normalizedTokenToExclude
 		],
 		queryFn: () =>
 			buildProtocolAddlChartsData({
 				protocolData: addlProtocolData as any,
 				extraTvlsEnabled: isBorrowed ? {} : extraTvlsEnabled,
 				isBorrowed,
-				tokenToExclude
+				tokenToExclude: normalizedTokenToExclude
 			}),
 		staleTime: 60 * 60 * 1000,
 		refetchInterval: 10 * 60 * 1000,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle on CEX asset pages to include/exclude an exchange’s own token, updating charts and URL state.
  * Charts updated to show token breakdown, token pie, and token inflows derived from token-level data with exclusion support.
  * Data fetching and chart remounting now respect the include/exclude setting so visualizations update reliably.
  * Page props now include exchange ownToken so pages can default and hydrate correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->