### PR TITLE
fix: exclude TVL from key metrics export if null

### DIFF
--- a/src/containers/ProtocolOverview/KeyMetricsPngExport.tsx
+++ b/src/containers/ProtocolOverview/KeyMetricsPngExport.tsx
@@ -10,6 +10,7 @@ interface KeyMetricsPngExportButtonProps {
 	primaryValue?: number
 	primaryLabel: string
 	formatPrice: (value: number | string | null) => string | number | null
+	hasTvlData?: boolean
 }
 
 interface MetricRow {
@@ -135,7 +136,8 @@ export function KeyMetricsPngExportButton({
 	protocolName,
 	primaryValue,
 	primaryLabel,
-	formatPrice
+	formatPrice,
+	hasTvlData = false
 }: KeyMetricsPngExportButtonProps) {
 	const [isLoading, setIsLoading] = useState(false)
 	const [isDark] = useDarkModeManager()
@@ -149,7 +151,7 @@ export function KeyMetricsPngExportButton({
 			const container = containerRef.current
 			const rows = extractRows(container)
 
-			const hasPrimaryValue = primaryValue != null
+			const hasPrimaryValue = hasTvlData && primaryValue != null
 			const formattedPrimaryValue = hasPrimaryValue ? String(formatPrice(primaryValue) ?? '') : ''
 
 			if (!hasPrimaryValue && rows.length === 0) {

--- a/src/containers/ProtocolOverview/index.tsx
+++ b/src/containers/ProtocolOverview/index.tsx
@@ -347,6 +347,12 @@ export const KeyMetrics = (props: IKeyMetricsProps) => {
 	const primaryValue = isOracleProtocol ? props.computedOracleTvs : props.tvl
 	const { title: primaryLabel } = getPrimaryValueLabelType(isOracleProtocol ? 'Oracle' : props.category)
 
+	const hasTvlData = isOracleProtocol
+		? props.oracleTvs != null
+		: props.metrics.tvl &&
+		  props.currentTvlByChain != null &&
+		  Object.keys(props.currentTvlByChain).length > 0
+
 	return (
 		<div className="flex flex-1 flex-col gap-2">
 			<div className="flex items-center justify-between">
@@ -366,6 +372,7 @@ export const KeyMetrics = (props: IKeyMetricsProps) => {
 					primaryValue={primaryValue}
 					primaryLabel={primaryLabel}
 					formatPrice={props.formatPrice}
+					hasTvlData={hasTvlData}
 				/>
 			</div>
 			<div className="flex flex-col" ref={containerRef}>


### PR DESCRIPTION
When exporting a png for key metrics, TVL was being set to 0 even if null and therefore included in the image.

This change checks whether it should actually be present or not, and excludes it if it shouldn't (which matches the UI behaviour).

### Screenshots

Before:
<img width="932" height="560" alt="bags-key-metrics (11)" src="https://github.com/user-attachments/assets/30f8aa68-36b4-46b8-9050-3004e0b61879" />

After:
<img width="932" height="416" alt="bags-key-metrics (10)" src="https://github.com/user-attachments/assets/62458c8e-1ab9-48a1-b60d-1859757fdfda" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the protocol overview display to better track and communicate TVL (Total Value Locked) data availability, ensuring key metrics display and export features appropriately adapt based on data presence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->