### PR TITLE
add premium section separator to side nav

### DIFF
--- a/src/components/Nav/Desktop/index.tsx
+++ b/src/components/Nav/Desktop/index.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { Icon } from '~/components/Icon'
 import { BasicLink } from '~/components/Link'
 import { Account } from '../Account'
+import { PremiumHeader } from '../PremiumHeader'
 import { ThemeSwitch } from '../ThemeSwitch'
 import { TNavLink, TNavLinks, TOldNavLink } from '../types'
 import { LinkToPage } from './shared'
@@ -48,44 +49,21 @@ export const DesktopNav = React.memo(function DesktopNav({
 				</BasicLink>
 
 				<div className="flex flex-1 flex-col gap-1 overflow-y-auto">
-					{mainLinks.map(({ category, pages, showFreeTrial }) =>
-						category === 'Premium' ? (
-							<div key={`desktop-nav-${category}`} className="group flex flex-col">
-								<hr className="my-2 -ml-1.5 border-black/20 dark:border-white/20" />
-								<div className="mb-1 -ml-1.5 flex items-center gap-2">
-									<span className="text-xs font-medium tracking-wide opacity-65">PREMIUM</span>
-									<span
-										className={`relative inline-flex items-center rounded-full border border-[#C99A4A]/50 bg-gradient-to-r from-[#C99A4A]/15 via-[#C99A4A]/5 to-[#C99A4A]/15 px-2 py-0.5 text-[10px] font-bold tracking-wide text-[#996F1F] shadow-[0_0_8px_rgba(201,154,74,0.3)] dark:border-[#FDE0A9]/50 dark:from-[#FDE0A9]/20 dark:via-[#FDE0A9]/10 dark:to-[#FDE0A9]/20 dark:text-[#FDE0A9] dark:shadow-[0_0_8px_rgba(253,224,169,0.25)] ${showFreeTrial ? '' : 'invisible'}`}
-									>
-										Try free
-									</span>
-								</div>
-								{pages.map(({ name, route, icon, attention }) => (
-									<LinkToPage
-										key={`desktop-nav-${name}-${route}`}
-										route={route}
-										name={name}
-										icon={icon}
-										attention={attention}
-										asPath={asPath}
-									/>
-								))}
-							</div>
-						) : (
-							<div key={`desktop-nav-${category}`} className="group flex flex-col">
-								{pages.map(({ name, route, icon, attention }) => (
-									<LinkToPage
-										key={`desktop-nav-${name}-${route}`}
-										route={route}
-										name={name}
-										icon={icon}
-										attention={attention}
-										asPath={asPath}
-									/>
-								))}
-							</div>
-						)
-					)}
+					{mainLinks.map(({ category, pages }) => (
+						<div key={`desktop-nav-${category}`} className="group flex flex-col">
+							{category === 'Premium' ? <PremiumHeader /> : null}
+							{pages.map(({ name, route, icon, attention }) => (
+								<LinkToPage
+									key={`desktop-nav-${name}-${route}`}
+									route={route}
+									name={name}
+									icon={icon}
+									attention={attention}
+									asPath={asPath}
+								/>
+							))}
+						</div>
+					))}
 
 					<details className="group">
 						<summary className="-ml-1.5 flex items-center justify-between gap-3 rounded-md p-1.5 text-xs opacity-65 hover:bg-black/5 focus-visible:bg-black/5 dark:hover:bg-white/10 dark:focus-visible:bg-white/10">

--- a/src/components/Nav/Mobile/Menu.tsx
+++ b/src/components/Nav/Mobile/Menu.tsx
@@ -10,6 +10,7 @@ import { Icon } from '~/components/Icon'
 import { BasicLink } from '~/components/Link'
 import { Account } from '../Account'
 import { mutatePinnedMetrics } from '../pinnedUtils'
+import { PremiumHeader } from '../PremiumHeader'
 import { TNavLink, TNavLinks, TOldNavLink } from '../types'
 
 export const Menu = React.memo(function Menu({
@@ -43,48 +44,23 @@ export const Menu = React.memo(function Menu({
 						<Icon name="x" height={20} width={20} strokeWidth="4px" />
 					</Ariakit.DialogDismiss>
 
-					{mainLinks.map(({ category, pages, showFreeTrial }) =>
-						category === 'Premium' ? (
-							<div key={`mobile-nav-${category}`} className="group mb-3 flex flex-col first:mb-auto">
-								<div className="mb-1 flex items-center gap-2">
-									<span className="text-xs font-medium tracking-wide opacity-65">PREMIUM</span>
-									<span
-										className={`relative inline-flex items-center rounded-full border border-[#C99A4A]/50 bg-gradient-to-r from-[#C99A4A]/15 via-[#C99A4A]/5 to-[#C99A4A]/15 px-2 py-0.5 text-[10px] font-bold tracking-wide text-[#996F1F] shadow-[0_0_8px_rgba(201,154,74,0.3)] dark:border-[#FDE0A9]/50 dark:from-[#FDE0A9]/20 dark:via-[#FDE0A9]/10 dark:to-[#FDE0A9]/20 dark:text-[#FDE0A9] dark:shadow-[0_0_8px_rgba(253,224,169,0.25)] ${showFreeTrial ? '' : 'invisible'}`}
-									>
-										Try free
-									</span>
-								</div>
-								<hr className="border-black/20 dark:border-white/20" />
-								{pages.map(({ name, route, icon, attention }) => (
-									<LinkToPage
-										route={route}
-										name={name}
-										icon={icon}
-										attention={attention}
-										key={`mobile-nav-${name}-${route}`}
-										asPath={asPath}
-										setShow={setShow}
-									/>
-								))}
-							</div>
-						) : (
-							<div key={`mobile-nav-${category}`} className="group mb-3 flex flex-col first:mb-auto">
-								<p className="mb-1 text-xs opacity-65">{category}</p>
-								<hr className="border-black/20 dark:border-white/20" />
-								{pages.map(({ name, route, icon, attention }) => (
-									<LinkToPage
-										route={route}
-										name={name}
-										icon={icon}
-										attention={attention}
-										key={`mobile-nav-${name}-${route}`}
-										asPath={asPath}
-										setShow={setShow}
-									/>
-								))}
-							</div>
-						)
-					)}
+					{mainLinks.map(({ category, pages }) => (
+						<div key={`mobile-nav-${category}`} className="group mb-3 flex flex-col first:mb-auto">
+							{category === 'Premium' ? <PremiumHeader /> : <p className="mb-1 text-xs opacity-65">{category}</p>}
+							<hr className="border-black/20 dark:border-white/20" />
+							{pages.map(({ name, route, icon, attention }) => (
+								<LinkToPage
+									route={route}
+									name={name}
+									icon={icon}
+									attention={attention}
+									key={`mobile-nav-${name}-${route}`}
+									asPath={asPath}
+									setShow={setShow}
+								/>
+							))}
+						</div>
+					))}
 
 					<details className="group mb-3">
 						<summary className="-ml-1.5 flex items-center justify-between gap-3 rounded-md p-1.5 text-xs opacity-65 hover:bg-black/5 focus-visible:bg-black/5 dark:hover:bg-white/10 dark:focus-visible:bg-white/10">

--- a/src/components/Nav/PremiumHeader.tsx
+++ b/src/components/Nav/PremiumHeader.tsx
@@ -1,0 +1,20 @@
+import { useAuthContext } from '~/containers/Subscribtion/auth'
+
+export const PremiumHeader = () => {
+	const { hasActiveSubscription, isAuthenticated, loaders } = useAuthContext()
+	const showFreeTrial = !hasActiveSubscription && (!isAuthenticated || !loaders.userLoading)
+
+	return (
+		<>
+			<hr className="my-2 -ml-1.5 border-black/20 max-lg:hidden dark:border-white/20" />
+			<p className="mb-1 flex items-center gap-2">
+				<span className="text-xs font-medium tracking-wide opacity-65">PREMIUM</span>
+				<span
+					className={`relative inline-flex items-center rounded-full border border-[#C99A4A]/50 bg-gradient-to-r from-[#C99A4A]/15 via-[#C99A4A]/5 to-[#C99A4A]/15 px-2 py-0.5 text-[10px] font-bold tracking-wide text-[#996F1F] shadow-[0_0_8px_rgba(201,154,74,0.3)] dark:border-[#FDE0A9]/50 dark:from-[#FDE0A9]/20 dark:via-[#FDE0A9]/10 dark:to-[#FDE0A9]/20 dark:text-[#FDE0A9] dark:shadow-[0_0_8px_rgba(253,224,169,0.25)] ${showFreeTrial ? '' : 'invisible'}`}
+				>
+					Try free
+				</span>
+			</p>
+		</>
+	)
+}

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -1,4 +1,4 @@
-import { lazy, memo, Suspense, useEffect, useMemo, useState, useSyncExternalStore } from 'react'
+import { lazy, memo, Suspense, useMemo, useSyncExternalStore } from 'react'
 import { useGetLiteDashboards } from '~/containers/ProDashboard/hooks/useDashboardAPI'
 import { useAuthContext } from '~/containers/Subscribtion/auth'
 import { subscribeToPinnedMetrics } from '~/contexts/LocalStorage'
@@ -47,14 +47,9 @@ const oldMetricLinks: Array<TOldNavLink> = Object.values(
 function NavComponent({ metricFilters }: { metricFilters?: { name: string; key: string }[] }) {
 	const { data: liteDashboards } = useGetLiteDashboards()
 
-	const { hasActiveSubscription, isAuthenticated, loaders } = useAuthContext()
-
-	// Delay showing free trial badge until after hydration to prevent flash
-	const [mounted, setMounted] = useState(false)
-	useEffect(() => setMounted(true), [])
+	const { hasActiveSubscription } = useAuthContext()
 
 	const mainLinks = useMemo(() => {
-		const showFreeTrial = mounted && !hasActiveSubscription && (isAuthenticated ? !loaders.userLoading : true)
 		const otherMainPages = [
 			{ name: 'Chains', route: '/chains', icon: 'globe' },
 			{ name: 'Yields', route: '/yields', icon: 'percent' },
@@ -64,18 +59,16 @@ function NavComponent({ metricFilters }: { metricFilters?: { name: string; key: 
 		]
 		const premiumPages = [
 			{ name: hasActiveSubscription ? 'Manage Subscription' : 'Pricing', route: '/subscription', icon: 'user' },
-			...(hasActiveSubscription
-				? [{ name: 'LlamaAI', route: '/ai/chat', icon: '' }]
-				: [{ name: 'LlamaAI', route: '/ai', icon: '' }]),
+			{ name: 'LlamaAI', route: hasActiveSubscription ? '/ai/chat' : '/ai', icon: '' },
 			{ name: 'Custom Dashboards', route: '/pro', icon: 'blocks' },
 			{ name: 'Sheets', route: '/sheets', icon: 'sheets' },
 			{ name: 'LlamaFeed', route: 'https://llamafeed.io', icon: 'activity' }
 		]
 		return [
 			{ category: 'Main', pages: defillamaPages['Main'].concat(otherMainPages) },
-			{ category: 'Premium', pages: premiumPages, showFreeTrial }
+			{ category: 'Premium', pages: premiumPages }
 		]
-	}, [mounted, hasActiveSubscription, isAuthenticated, loaders.userLoading])
+	}, [hasActiveSubscription])
 
 	const userDashboards = useMemo(
 		() => liteDashboards?.map(({ id, name }) => ({ name, route: `/pro/${id}` })) ?? [],

--- a/src/components/Nav/types.ts
+++ b/src/components/Nav/types.ts
@@ -1,6 +1,6 @@
 export type TNavLink = { name: string; route: string; icon?: string; attention?: boolean; freeTrial?: boolean }
 
-export type TNavLinks = Array<{ category: string; pages: Array<TNavLink>; showFreeTrial?: boolean }>
+export type TNavLinks = Array<{ category: string; pages: Array<TNavLink> }>
 
 export type TOldNavLink = {
 	name: string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Support and API links to main navigation for easier access.
  * Introduced Premium section in navigation with distinct header styling.
  * Added "Try free" badge in Premium section for non-subscribers.
  * Added LlamaFeed to Premium features.

* **Improvements**
  * Reorganized navigation structure to better highlight Premium offerings.
  * Simplified Premium subscription management flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->