### PR TITLE
fix: base missing from pie chart despite being ranked #5 by TVL on /chains page

### DIFF
--- a/src/containers/ChainsByCategory/index.tsx
+++ b/src/containers/ChainsByCategory/index.tsx
@@ -120,6 +120,7 @@ const useFormatChartData = ({
 
 		for (const chain in tvlChartsByChain['tvl']) {
 			const data = []
+			let lastValue: number | undefined
 			for (const date in totalTvlByDate['tvl']) {
 				let total = totalTvlByDate['tvl'][date]
 				let value = tvlChartsByChain['tvl']?.[chain]?.[date]
@@ -129,9 +130,10 @@ const useFormatChartData = ({
 					}
 					total += totalTvlByDate?.[key]?.[date] ?? 0
 				}
-				recentTvlByChain[chain] = value
+				lastValue = value
 				data.push([+date, value != null ? (value / total) * 100 : null])
 			}
+			recentTvlByChain[chain] = lastValue ?? 0
 			charts[chain] = {
 				name: chain,
 				stack: chain,


### PR DESCRIPTION
The pie chart on /chains was not displaying Base despite it being the 5th largest chain by TVL. 

The issue was in the ```useFormatChartData``` hook where ```recentTvlByChain``` values were being overwritten on each date iteration instead of capturing only the most recent value. Moved the ```recentTvlByChain``` assignment outside the date loop to ensure each chain's TVL is set once with its latest data point. 

Fixes: https://github.com/DefiLlama/DefiLlama-Adapters/issues/17692

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TVL data collection for chain categories to accurately capture the most recent values for chart calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->