### PR TITLE
show retry when network error

### DIFF
--- a/src/containers/LlamaAI/index.tsx
+++ b/src/containers/LlamaAI/index.tsx
@@ -263,6 +263,7 @@ export function LlamaAI({ initialSessionId, sharedSession, readOnly = false, sho
 			})
 				.then((result) => {
 					setIsStreaming(false)
+					setLastFailedRequest(null)
 					if (result?.response) {
 						setMessages((prev) => [
 							...prev,
@@ -629,7 +630,8 @@ export function LlamaAI({ initialSessionId, sharedSession, readOnly = false, sho
 		const handleVisibilityChange = () => {
 			if (document.visibilityState !== 'visible') return
 			const currentSessionId = sessionIdRef.current
-			if (error && currentSessionId && !isStreaming && !isPending) {
+			const isUserAbort = error?.message === 'Request aborted'
+			if (error && !isUserAbort && currentSessionId && !isStreaming && !isPending) {
 				resetPrompt()
 				reconnectToStream(currentSessionId, streamingResponse)
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clear previous failure state after a successful reconnect so retries start clean.
  * Preserve request context on non-aborted errors to enable more accurate retry attempts.
  * Broaden reconnection triggers to be more robust (including session metadata changes).
  * Auto-attempt reconnection when returning to the app/tab if a session exists and streaming is idle.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->