### PR TITLE
Refactor: Replace forEach with for loops

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,5 @@
 {
 	"$schema": "https://conductor.build/schema/conductor.json",
 	"name": "defillama",
-	"setup": {
-		"setup": "yarn; cp $CONDUCTOR_ROOT_PATH/.env.local .env.local"
-	}
+	"setup": "yarn; cp $CONDUCTOR_ROOT_PATH/.env.local .env.local"
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/api/categories/chains/multiChainClient.tsx
+++ b/src/api/categories/chains/multiChainClient.tsx
@@ -50,9 +50,10 @@ const finalizeAggregatedProtocol = (entry: Record<string | symbol, any>, options
 	const result = { ...entry }
 	const store = entry[WEIGHTED_ACC_SYMBOL] as WeightedStore | undefined
 	if (store) {
-		Object.entries(store).forEach(([key, accumulator]) => {
+		for (const key in store) {
+			const accumulator = store[key]
 			result[key] = accumulator.denominator > 0 ? accumulator.numerator / accumulator.denominator : undefined
-		})
+		}
 		delete result[WEIGHTED_ACC_SYMBOL]
 	}
 
@@ -102,7 +103,7 @@ export function useGetProtocolsListMultiChain(chains: string[]) {
 
 		const protocolsMap = new Map<string, any>()
 
-		chains.forEach((chain) => {
+		for (const chain of chains) {
 			const chainProtocols = formatProtocolsData({
 				chain,
 				protocols,
@@ -110,7 +111,7 @@ export function useGetProtocolsListMultiChain(chains: string[]) {
 				protocolProps: [...basicPropertiesToKeep, 'extraTvl', 'oracles', 'oraclesByChain']
 			})
 
-			chainProtocols.forEach((protocol) => {
+			for (const protocol of chainProtocols) {
 				const existing = protocolsMap.get(protocol.name)
 				if (existing) {
 					existing.tvl = (existing.tvl || 0) + (protocol.tvl || 0)
@@ -127,7 +128,7 @@ export function useGetProtocolsListMultiChain(chains: string[]) {
 					}
 					if (protocol.oraclesByChain) {
 						existing.oraclesByChain = existing.oraclesByChain || {}
-						for (const k of Object.keys(protocol.oraclesByChain)) {
+						for (const k in protocol.oraclesByChain) {
 							const cur = new Set([...(existing.oraclesByChain[k] || []), ...protocol.oraclesByChain[k]])
 							existing.oraclesByChain[k] = Array.from(cur)
 						}
@@ -135,8 +136,8 @@ export function useGetProtocolsListMultiChain(chains: string[]) {
 				} else {
 					protocolsMap.set(protocol.name, { ...protocol })
 				}
-			})
-		})
+			}
+		}
 
 		return {
 			fullProtocolsList: Array.from(protocolsMap.values()),
@@ -176,9 +177,9 @@ export function useGetProtocolsVolumeByMultiChain(chains: string[]) {
 
 		const protocolsMap = new Map<string, any>()
 
-		queryDatas.forEach((payload) => {
-			if (!payload?.protocols) return
-			payload.protocols.forEach((protocol: any) => {
+		for (const payload of queryDatas) {
+			if (!payload?.protocols) continue
+			for (const protocol of payload.protocols as any[]) {
 				const existing = protocolsMap.get(protocol.name)
 				const change7d = protocol.change_7d ?? protocol.change_7dover7d
 				const chainName = payload.chain
@@ -216,8 +217,8 @@ export function useGetProtocolsVolumeByMultiChain(chains: string[]) {
 					applyWeightedChange(newEntry, 'change_1m', protocol.total30d, protocol.change_1m)
 					protocolsMap.set(protocol.name, newEntry)
 				}
-			})
-		})
+			}
+		}
 
 		return Array.from(protocolsMap.values()).map((protocol) => finalizeAggregatedProtocol(protocol))
 	}, [shouldFetchAll, queryDatas])
@@ -247,9 +248,9 @@ export function useGetProtocolsFeesAndRevenueByMultiChain(chains: string[]) {
 
 		const protocolsMap = new Map<string, any>()
 
-		queryDatas.forEach((payload) => {
-			if (!payload?.protocols) return
-			payload.protocols.forEach((protocol: any) => {
+		for (const payload of queryDatas) {
+			if (!payload?.protocols) continue
+			for (const protocol of payload.protocols as any[]) {
 				const key = protocol.name
 				const existing = protocolsMap.get(key)
 				const chainName = payload.chain
@@ -310,8 +311,8 @@ export function useGetProtocolsFeesAndRevenueByMultiChain(chains: string[]) {
 					applyWeightedChange(newEntry, 'revenueChange_1m', protocol.revenue30d, protocol.revenueChange_1m)
 					protocolsMap.set(key, newEntry)
 				}
-			})
-		})
+			}
+		}
 
 		return Array.from(protocolsMap.values()).map((protocol) =>
 			finalizeAggregatedProtocol(protocol, { computeRatios: true })
@@ -346,9 +347,9 @@ export function useGetProtocolsPerpsVolumeByMultiChain(chains: string[]) {
 
 		const protocolsMap = new Map<string, any>()
 
-		queryDatas.forEach((payload) => {
-			if (!payload?.protocols) return
-			payload.protocols.forEach((protocol: any) => {
+		for (const payload of queryDatas) {
+			if (!payload?.protocols) continue
+			for (const protocol of payload.protocols as any[]) {
 				const existing = protocolsMap.get(protocol.name)
 				const chainName = payload.chain
 				const normalizedChainKey = typeof chainName === 'string' ? chainName.trim().toLowerCase() : ''
@@ -382,8 +383,8 @@ export function useGetProtocolsPerpsVolumeByMultiChain(chains: string[]) {
 					applyWeightedChange(newEntry, 'change_1m', protocol.total30d, protocol.change_1m)
 					protocolsMap.set(protocol.name, newEntry)
 				}
-			})
-		})
+			}
+		}
 
 		return Array.from(protocolsMap.values()).map((protocol) => finalizeAggregatedProtocol(protocol))
 	}, [shouldFetchAll, queryDatas])
@@ -413,9 +414,9 @@ export function useGetProtocolsOpenInterestByMultiChain(chains: string[]) {
 
 		const protocolsMap = new Map<string, any>()
 
-		queryDatas.forEach((payload) => {
-			if (!payload?.protocols) return
-			payload.protocols.forEach((protocol: any) => {
+		for (const payload of queryDatas) {
+			if (!payload?.protocols) continue
+			for (const protocol of payload.protocols as any[]) {
 				const existing = protocolsMap.get(protocol.name)
 				const chainName = payload.chain
 				const normalizedChainKey = typeof chainName === 'string' ? chainName.trim().toLowerCase() : ''
@@ -440,8 +441,8 @@ export function useGetProtocolsOpenInterestByMultiChain(chains: string[]) {
 					}
 					protocolsMap.set(protocol.name, entry)
 				}
-			})
-		})
+			}
+		}
 
 		return Array.from(protocolsMap.values())
 	}, [shouldFetchAll, queryDatas])

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -101,9 +101,9 @@ export async function fetchChainMcaps(chains: Array<[string, string]>) {
 
 	// Merge all results into a single object
 	const mergedMcaps = {}
-	batchResults.forEach((batchResult) => {
+	for (const batchResult of batchResults) {
 		Object.assign(mergedMcaps, batchResult)
-	})
+	}
 
 	return validChains.reduce((acc, [chain, geckoId]) => {
 		if (mergedMcaps[`coingecko:${geckoId}`]) {
@@ -142,9 +142,9 @@ export async function fetchCoinPrices(coins: Array<string>) {
 
 	// Merge all results into a single object
 	const mergedPrices = {}
-	batchResults.forEach((batchResult) => {
+	for (const batchResult of batchResults) {
 		Object.assign(mergedPrices, batchResult)
-	})
+	}
 
 	return coins.reduce(
 		(acc, coin) => {

--- a/src/components/Charts/BridgeVolumeChart.tsx
+++ b/src/components/Charts/BridgeVolumeChart.tsx
@@ -58,7 +58,7 @@ export function BridgeVolumeChart({ chain = 'all', height }: BridgeVolumeChartPr
 			}
 		>()
 
-		rawData.forEach((item) => {
+		for (const item of rawData) {
 			const date = dayjs.unix(item.timestamp)
 			const key = (timePeriod === 'Weekly' ? date.startOf('week') : date.startOf('month')).unix()
 
@@ -67,7 +67,7 @@ export function BridgeVolumeChart({ chain = 'all', height }: BridgeVolumeChartPr
 				deposits: existing.deposits + item.deposits,
 				withdrawals: existing.withdrawals + item.withdrawals
 			})
-		})
+		}
 
 		return Array.from(groupedData.entries())
 			.map(([date, values]) => ({

--- a/src/components/Charts/UpcomingUnlockVolumeChart.tsx
+++ b/src/components/Charts/UpcomingUnlockVolumeChart.tsx
@@ -47,31 +47,31 @@ export function UpcomingUnlockVolumeChart({ protocols, height }: UpcomingUnlockV
 		const endTimestamp = dayjs('2031-01-01').unix()
 		const now = Date.now() / 1000
 
-		protocols.forEach((protocol) => {
+		for (const protocol of protocols) {
 			if (!protocol.events || protocol.tPrice === null || protocol.tPrice === undefined || protocol.tPrice <= 0) {
-				return
+				continue
 			}
 
 			const futureEvents = protocol.events.filter((event) => {
 				return event.timestamp !== null && event.timestamp >= now && (isFullView || event.timestamp < endTimestamp)
 			})
 
-			futureEvents.forEach((event) => {
+			for (const event of futureEvents) {
 				if (event.timestamp === null || !event.noOfTokens || event.noOfTokens.length === 0) {
-					return
+					continue
 				}
 
 				const totalTokens = event.noOfTokens.reduce((sum, amount) => sum + (amount || 0), 0)
 				if (totalTokens === 0) {
-					return
+					continue
 				}
 
 				const valueUSD = totalTokens * protocol.tPrice
 				if (valueUSD > 0) {
 					upcomingUnlocks.push({ timestamp: event.timestamp, valueUSD, protocolName: protocol.name })
 				}
-			})
-		})
+			}
+		}
 
 		let processedChartData: Array<Record<string, number | string>> = []
 		let finalStacks = {}
@@ -81,13 +81,13 @@ export function UpcomingUnlockVolumeChart({ protocols, height }: UpcomingUnlockV
 		if (viewMode === 'Total View') {
 			const groupedData = new Map<number, number>()
 
-			upcomingUnlocks.forEach((unlock) => {
+			for (const unlock of upcomingUnlocks) {
 				const date = dayjs.unix(unlock.timestamp)
-				if (!date.isValid()) return
+				if (!date.isValid()) continue
 				const key = (timePeriod === 'Weekly' ? date.startOf('week') : date.startOf('month')).unix()
 				const existingValue = groupedData.get(key) || 0
 				groupedData.set(key, existingValue + unlock.valueUSD)
-			})
+			}
 
 			processedChartData = Array.from(groupedData.entries())
 				.map(([date, totalUpcomingUnlockValueUSD]) => ({
@@ -103,9 +103,9 @@ export function UpcomingUnlockVolumeChart({ protocols, height }: UpcomingUnlockV
 			const groupedData = new Map<number, Record<string, number>>()
 			const allProtocolNames = new Set<string>()
 
-			upcomingUnlocks.forEach((unlock) => {
+			for (const unlock of upcomingUnlocks) {
 				const date = dayjs.unix(unlock.timestamp)
-				if (!date.isValid()) return
+				if (!date.isValid()) continue
 				const key = (timePeriod === 'Weekly' ? date.startOf('week') : date.startOf('month')).unix()
 
 				const existingRecord = groupedData.get(key) || {}
@@ -114,7 +114,7 @@ export function UpcomingUnlockVolumeChart({ protocols, height }: UpcomingUnlockV
 
 				groupedData.set(key, existingRecord)
 				allProtocolNames.add(unlock.protocolName)
-			})
+			}
 
 			processedChartData = Array.from(groupedData.entries())
 				.map(([date, protocolValues]) => ({

--- a/src/components/ECharts/BarChart/NonTimeSeries.tsx
+++ b/src/components/ECharts/BarChart/NonTimeSeries.tsx
@@ -40,13 +40,13 @@ export default function NonTimeSeriesBarChart({
 		const series = []
 
 		const allStacks = new Set<string>()
-		chartData.forEach((item) => {
-			Object.keys(item).forEach((key) => {
+		for (const item of chartData) {
+			for (const key of Object.keys(item)) {
 				if (key !== 'date') {
 					allStacks.add(key)
 				}
-			})
-		})
+			}
+		}
 
 		for (const stack of allStacks) {
 			series.push({

--- a/src/components/ECharts/BarChart/index.tsx
+++ b/src/components/ECharts/BarChart/index.tsx
@@ -44,9 +44,9 @@ export default function BarChart({
 		const values = stacks || {}
 
 		if ((!values || Object.keys(values).length === 0) && customLegendOptions) {
-			customLegendOptions.forEach((name) => {
+			for (const name of customLegendOptions) {
 				values[name] = 'stackA'
-			})
+			}
 		}
 
 		const selectedStacks = Object.keys(values).filter((s) =>

--- a/src/components/ECharts/CandlestickChart/index.tsx
+++ b/src/components/ECharts/CandlestickChart/index.tsx
@@ -115,7 +115,8 @@ export default function CandleStickAndVolumeChart({ data, indicators = [] }: ICa
 			}
 		]
 
-		panels.forEach((panel, idx) => {
+		for (let idx = 0; idx < panels.length; idx++) {
+			const panel = panels[idx]
 			const gridIdx = idx + 2
 			const bottom = BASE_BOTTOM + (panelCount - idx - 1) * PANEL_HEIGHT
 
@@ -145,7 +146,7 @@ export default function CandleStickAndVolumeChart({ data, indicators = [] }: ICa
 				axisTick: { show: false },
 				splitLine: { lineStyle: { color: isThemeDark ? '#fff' : '#000', opacity: 0.05 } }
 			})
-		})
+		}
 
 		const allAxisIndices = Array.from({ length: grids.length }, (_, i) => i)
 
@@ -250,7 +251,8 @@ export default function CandleStickAndVolumeChart({ data, indicators = [] }: ICa
 			}
 		]
 
-		overlays.forEach((ind, idx) => {
+		for (let idx = 0; idx < overlays.length; idx++) {
+			const ind = overlays[idx]
 			const color = ind.color || INDICATOR_COLORS[idx % INDICATOR_COLORS.length]
 			if (ind.values && ind.name.toLowerCase().includes('bband')) {
 				result.push({
@@ -286,9 +288,10 @@ export default function CandleStickAndVolumeChart({ data, indicators = [] }: ICa
 					symbol: 'none'
 				})
 			}
-		})
+		}
 
-		panels.forEach((panel, idx) => {
+		for (let idx = 0; idx < panels.length; idx++) {
+			const panel = panels[idx]
 			const gridIdx = idx + 2
 			const color = panel.color || INDICATOR_COLORS[(overlays.length + idx) % INDICATOR_COLORS.length]
 
@@ -349,7 +352,7 @@ export default function CandleStickAndVolumeChart({ data, indicators = [] }: ICa
 					symbol: 'none'
 				})
 			}
-		})
+		}
 
 		return result
 	}, [isThemeDark, overlays, panels])

--- a/src/components/ECharts/LineAndBarChart/index.tsx
+++ b/src/components/ECharts/LineAndBarChart/index.tsx
@@ -203,7 +203,7 @@ export default function LineAndBarChart({
 			// Collect all unique yAxisIndex values from series and map them to colors
 			const yAxisIndexToColor = new Map<number, string | undefined>()
 
-			series.forEach((item) => {
+			for (const item of series) {
 				if (item.yAxisIndex != null) {
 					// Map each yAxisIndex to the color of the first series that uses it
 					if (!yAxisIndexToColor.has(item.yAxisIndex)) {
@@ -211,7 +211,7 @@ export default function LineAndBarChart({
 						yAxisIndexToColor.set(item.yAxisIndex, seriesColor)
 					}
 				}
-			})
+			}
 
 			// Create yAxis objects for each index from 0 to max
 			if (yAxisIndexToColor.size > 0) {

--- a/src/components/ECharts/MultiSeriesChart2/index.tsx
+++ b/src/components/ECharts/MultiSeriesChart2/index.tsx
@@ -188,7 +188,7 @@ export default function MultiSeriesChart2({
 			// Collect all unique yAxisIndex values from series and map them to colors
 			const yAxisIndexToColor = new Map<number, string | undefined>()
 
-			series.forEach((item) => {
+			for (const item of series) {
 				if (item.yAxisIndex != null) {
 					// Map each yAxisIndex to the color of the first series that uses it
 					if (!yAxisIndexToColor.has(item.yAxisIndex)) {
@@ -196,7 +196,7 @@ export default function MultiSeriesChart2({
 						yAxisIndexToColor.set(item.yAxisIndex, seriesColor)
 					}
 				}
-			})
+			}
 
 			// Create yAxis objects for each index from 0 to max
 			if (yAxisIndexToColor.size > 0) {

--- a/src/components/ECharts/SankeyChart/index.tsx
+++ b/src/components/ECharts/SankeyChart/index.tsx
@@ -39,7 +39,7 @@ export default function SankeyChart({
 		const descriptions: Record<string, string> = {}
 		const displayValues: Record<string, number | string> = {}
 		const percentageLabels: Record<string, string> = {}
-		nodes.forEach((node) => {
+		for (const node of nodes) {
 			if (node.description) {
 				descriptions[node.name] = node.description
 			}
@@ -49,7 +49,7 @@ export default function SankeyChart({
 			if (node.percentageLabel) {
 				percentageLabels[node.name] = node.percentageLabel
 			}
-		})
+		}
 		return { descriptions, displayValues, percentageLabels }
 	}, [nodes])
 

--- a/src/components/ECharts/UnlocksChart/index.tsx
+++ b/src/components/ECharts/UnlocksChart/index.tsx
@@ -143,9 +143,9 @@ export default function AreaChart({
 				})
 			}
 
-			chartData.forEach(([date, value]) => {
+			for (const [date, value] of chartData) {
 				series.data.push([+date * 1e3, value])
-			})
+			}
 
 			return series
 		} else {
@@ -251,7 +251,7 @@ export default function AreaChart({
 
 			for (const { date, ...item } of chartData) {
 				const sumOfTheDay = Object.values(item).reduce((acc: number, curr: number) => (acc += curr), 0) as number
-				chartsStack.forEach((stack) => {
+				for (const stack of chartsStack) {
 					if (legendOptions && customLegendName ? legendOptions.includes(stack) : true) {
 						const serie = series.find((t) => t.name === stack)
 						if (serie) {
@@ -269,7 +269,7 @@ export default function AreaChart({
 							}
 						}
 					}
-				})
+				}
 			}
 
 			return series

--- a/src/components/ECharts/UnlocksTreemapChart/index.tsx
+++ b/src/components/ECharts/UnlocksTreemapChart/index.tsx
@@ -57,18 +57,19 @@ export default function UnlocksTreemapChart({ unlocksData, height = '600px', fil
 		const treeData = []
 		const yearData: YearDataMap = {}
 
-		Object.entries(unlocksData).forEach(([dateStr, dailyData]) => {
+		for (const dateStr in unlocksData) {
+			const dailyData = unlocksData[dateStr]
 			const date = dayjs(dateStr)
 			const year = date.year()
 			const monthIndex = date.month()
 			const monthName = date.format('MMMM')
 
 			if (timeView === 'Month') {
-				if (monthIndex !== selectedDate.month() || year !== selectedDate.year()) return
+				if (monthIndex !== selectedDate.month() || year !== selectedDate.year()) continue
 			} else if (timeView === 'Current Year') {
-				if (year !== currentYear) return
+				if (year !== currentYear) continue
 			} else if (timeView === 'All Years') {
-				if (year < currentYear) return
+				if (year < currentYear) continue
 			}
 
 			if (!yearData[year]) {
@@ -85,7 +86,7 @@ export default function UnlocksTreemapChart({ unlocksData, height = '600px', fil
 				}
 			}
 
-			dailyData.events.forEach((event) => {
+			for (const event of dailyData.events) {
 				if (!yearData[year].children[monthName].protocols[event.protocol]) {
 					yearData[year].children[monthName].protocols[event.protocol] = 0
 				}
@@ -93,8 +94,8 @@ export default function UnlocksTreemapChart({ unlocksData, height = '600px', fil
 				yearData[year].children[monthName].protocols[event.protocol] += event.value
 				yearData[year].children[monthName].value += event.value
 				yearData[year].value += event.value
-			})
-		})
+			}
+		}
 
 		if (timeView === 'Month') {
 			const targetYear = selectedDate.year()
@@ -167,7 +168,8 @@ export default function UnlocksTreemapChart({ unlocksData, height = '600px', fil
 						}
 					}
 
-					Object.entries(monthInfo.protocols).forEach(([protocol, value]) => {
+					for (const protocol in monthInfo.protocols) {
+						const value = monthInfo.protocols[protocol]
 						const iconUrl = tokenIconUrl(protocol)
 						monthNode.children.push({
 							name: protocol,
@@ -208,7 +210,7 @@ export default function UnlocksTreemapChart({ unlocksData, height = '600px', fil
 								}
 							}
 						})
-					})
+					}
 
 					monthNode.children.sort((a, b) => b.value - a.value)
 					return monthNode
@@ -217,7 +219,8 @@ export default function UnlocksTreemapChart({ unlocksData, height = '600px', fil
 		}
 
 		if (timeView === 'All Years') {
-			Object.entries(yearData).forEach(([year, yearInfo]) => {
+			for (const year in yearData) {
+				const yearInfo = yearData[year]
 				const yearNode: any = {
 					name: year,
 					value: yearInfo.value,
@@ -231,7 +234,8 @@ export default function UnlocksTreemapChart({ unlocksData, height = '600px', fil
 					}
 				}
 
-				Object.entries(yearInfo.children).forEach(([month, monthInfo]) => {
+				for (const month in yearInfo.children) {
+					const monthInfo = yearInfo.children[month]
 					const monthNode: any = {
 						name: month,
 						value: monthInfo.value,
@@ -245,7 +249,8 @@ export default function UnlocksTreemapChart({ unlocksData, height = '600px', fil
 						}
 					}
 
-					Object.entries(monthInfo.protocols).forEach(([protocol, value]) => {
+					for (const protocol in monthInfo.protocols) {
+						const value = monthInfo.protocols[protocol]
 						const iconUrl = tokenIconUrl(protocol)
 						monthNode.children.push({
 							name: protocol,
@@ -286,15 +291,15 @@ export default function UnlocksTreemapChart({ unlocksData, height = '600px', fil
 								}
 							}
 						})
-					})
+					}
 
 					monthNode.children.sort((a, b) => b.value - a.value)
 					yearNode.children.push(monthNode)
-				})
+				}
 
 				yearNode.children.sort((a, b) => b.value - a.value)
 				treeData.push(yearNode)
-			})
+			}
 
 			treeData.sort((a, b) => Number(a.name) - Number(b.name))
 			return treeData

--- a/src/components/IconsRow.tsx
+++ b/src/components/IconsRow.tsx
@@ -88,11 +88,11 @@ export const IconsRow = ({
 		let remainingWidth = (mainWrapWidth > 280 ? 280 : mainWrapWidth) - CHAIN_ICON_WIDTH
 		let lastIndexOfFilters = 0
 
-		links.forEach(() => {
-			if (remainingWidth < 0) return
+		for (const _ of links) {
+			if (remainingWidth < 0) continue
 			remainingWidth -= CHAIN_ICON_WIDTH
 			lastIndexOfFilters += 1
-		})
+		}
 
 		setVisibileChainIndex(links.length > 2 ? lastIndexOfFilters : links.length)
 	}, [mainWrapWidth, links])

--- a/src/components/Unlocks/CalendarView.tsx
+++ b/src/components/Unlocks/CalendarView.tsx
@@ -38,7 +38,8 @@ export const CalendarView: React.FC<CalendarViewProps> = ({ initialUnlocksData, 
 
 		if (showOnlyWatchlist || showOnlyInsider) {
 			filteredData = {}
-			Object.entries(initialUnlocksData).forEach(([date, dailyData]) => {
+			for (const date in initialUnlocksData) {
+				const dailyData = initialUnlocksData[date]
 				let filteredEvents = dailyData.events
 
 				if (showOnlyWatchlist) {
@@ -56,7 +57,7 @@ export const CalendarView: React.FC<CalendarViewProps> = ({ initialUnlocksData, 
 						totalValue: filteredEvents.reduce((sum, event) => sum + event.value, 0)
 					}
 				}
-			})
+			}
 		}
 
 		return filteredData
@@ -88,14 +89,15 @@ export const CalendarView: React.FC<CalendarViewProps> = ({ initialUnlocksData, 
 		const endDate = startDate.add(listDurationDays, 'days')
 		const events: Array<{ date: Dayjs; event: any }> = []
 
-		Object.entries(unlocksData || {}).forEach(([dateStr, dailyData]) => {
+		for (const dateStr in unlocksData || {}) {
+			const dailyData = (unlocksData || {})[dateStr]
 			const date = dayjs(dateStr)
 			if (date.isBetween(startDate.subtract(1, 'day'), endDate)) {
-				dailyData.events.forEach((event) => {
+				for (const event of dailyData.events) {
 					events.push({ date, event })
-				})
+				}
 			}
-		})
+		}
 
 		events.sort((a, b) => a.date.valueOf() - b.date.valueOf())
 
@@ -121,7 +123,8 @@ export const CalendarView: React.FC<CalendarViewProps> = ({ initialUnlocksData, 
 		const startOfMonth = currentDate.startOf('month')
 		const endOfMonth = currentDate.endOf('month')
 		let max = 0
-		Object.entries(unlocksData || {}).forEach(([dateStr, dailyData]) => {
+		for (const dateStr in unlocksData || {}) {
+			const dailyData = (unlocksData || {})[dateStr]
 			const date = dayjs(dateStr)
 			if (
 				date.isSame(startOfMonth, 'day') ||
@@ -132,7 +135,7 @@ export const CalendarView: React.FC<CalendarViewProps> = ({ initialUnlocksData, 
 					max = dailyData.totalValue
 				}
 			}
-		})
+		}
 		return max
 	}, [currentDate, viewMode, unlocksData, precomputedData])
 
@@ -299,14 +302,14 @@ const chartOptions = {
 			if (validParams.length === 0) {
 				tooltipContent += 'No unlocks'
 			} else {
-				validParams.forEach((param) => {
+				for (const param of validParams) {
 					const value = param.value[1]
 					totalValue += value
 					tooltipContent += `<div style="display: flex; justify-content: space-between; align-items: center; gap: 8px;">
 					<span>${param.marker} ${param.seriesName}</span>
 					<span style="font-weight: 500;">${formattedNum(value, true)}</span>
 				</div>`
-				})
+				}
 				if (validParams.length > 1) {
 					tooltipContent += `<div style="border-top: 1px solid var(--divider); margin-top: 4px; padding-top: 4px; display: flex; justify-content: space-between; align-items: center; gap: 8px;">
 					<span><strong>Total</strong></span>

--- a/src/components/Unlocks/PastUnlockPriceImpact.tsx
+++ b/src/components/Unlocks/PastUnlockPriceImpact.tsx
@@ -45,15 +45,15 @@ export const PastUnlockPriceImpact: React.FC<PastUnlockPriceImpactProps> = ({ da
 			}
 		>()
 
-		data?.forEach((protocol) => {
+		for (const protocol of data ?? []) {
 			if (!protocol.historicalPrice?.length || protocol.historicalPrice.length < 8 || !protocol.lastEvent?.length)
-				return
+				continue
 
 			const now = Date.now() / 1000
 			const thirtyDaysAgo = now - 30 * 24 * 60 * 60
 
 			const lastEvents = protocol.lastEvent.filter((event) => event.timestamp >= thirtyDaysAgo)
-			if (!lastEvents.length) return
+			if (!lastEvents.length) continue
 
 			const eventsByTimestamp = lastEvents.reduce((acc, event) => {
 				const totalTokens = event.noOfTokens?.reduce((sum, amount) => sum + amount, 0) || 0
@@ -101,7 +101,7 @@ export const PastUnlockPriceImpact: React.FC<PastUnlockPriceImpactProps> = ({ da
 				mcap: protocol.mcap,
 				price: protocol.tPrice
 			})
-		})
+		}
 
 		return {
 			topImpacts: Array.from(protocolImpacts.values())

--- a/src/components/Unlocks/TopUnlocks.tsx
+++ b/src/components/Unlocks/TopUnlocks.tsx
@@ -25,30 +25,34 @@ export const TopUnlocks: React.FC<TopUnlocksProps> = ({ data, period, title, cla
 		const now = Date.now() / 1000
 		const startTime = now - period * 24 * 60 * 60
 
-		data?.forEach((protocol) => {
-			const timestampGroups = new Map<number, number>()
+		if (data) {
+			for (const protocol of data) {
+				const timestampGroups = new Map<number, number>()
 
-			protocol.events?.forEach((event) => {
-				if (event.timestamp >= startTime && event.timestamp <= now) {
-					const totalTokens = event.noOfTokens?.reduce((sum, amount) => sum + amount, 0) || 0
-					const existing = timestampGroups.get(event.timestamp) || 0
-					timestampGroups.set(event.timestamp, existing + totalTokens)
+				if (protocol.events) {
+					for (const event of protocol.events) {
+						if (event.timestamp >= startTime && event.timestamp <= now) {
+							const totalTokens = event.noOfTokens?.reduce((sum, amount) => sum + amount, 0) || 0
+							const existing = timestampGroups.get(event.timestamp) || 0
+							timestampGroups.set(event.timestamp, existing + totalTokens)
+						}
+					}
 				}
-			})
 
-			const totalUnlockValue = Array.from(timestampGroups.values()).reduce(
-				(sum, tokens) => sum + tokens * protocol.tPrice,
-				0
-			)
+				const totalUnlockValue = Array.from(timestampGroups.values()).reduce(
+					(sum, tokens) => sum + tokens * protocol.tPrice,
+					0
+				)
 
-			if (totalUnlockValue > 0) {
-				protocolUnlocks.set(protocol.name, {
-					name: protocol.name,
-					symbol: protocol.tSymbol,
-					value: totalUnlockValue
-				})
+				if (totalUnlockValue > 0) {
+					protocolUnlocks.set(protocol.name, {
+						name: protocol.name,
+						symbol: protocol.tSymbol,
+						value: totalUnlockValue
+					})
+				}
 			}
-		})
+		}
 
 		return {
 			topUnlocks: Array.from(protocolUnlocks.values())

--- a/src/components/Unlocks/components/UnlocksListView.tsx
+++ b/src/components/Unlocks/components/UnlocksListView.tsx
@@ -16,13 +16,13 @@ export const UnlocksListView: React.FC<UnlocksListViewProps> = ({ events }) => {
 	}
 
 	const groupedEvents: { [date: string]: Array<DailyUnlocks['events'][0]> } = {}
-	events.forEach(({ date, event }) => {
+	for (const { date, event } of events) {
 		const dateStr = date.format('YYYY-MM-DD')
 		if (!groupedEvents[dateStr]) {
 			groupedEvents[dateStr] = []
 		}
 		groupedEvents[dateStr].push(event)
-	})
+	}
 
 	return (
 		<div className="flex max-h-[70dvh] flex-col gap-2 overflow-y-auto rounded border border-(--divider) bg-(--bg-glass) p-1 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border-2 [&::-webkit-scrollbar-thumb]:border-solid [&::-webkit-scrollbar-thumb]:border-(--bg-glass) [&::-webkit-scrollbar-thumb]:bg-(--blue) [&::-webkit-scrollbar-track]:bg-transparent">

--- a/src/components/Unlocks/hooks/useUnlockChartData.ts
+++ b/src/components/Unlocks/hooks/useUnlockChartData.ts
@@ -47,42 +47,44 @@ export const useUnlockChartData = ({
 		const protocolTotals: { [key: string]: number } = {}
 		const protocolColorMap: { [key: string]: string } = {}
 
-		weekRange.dates.forEach((dateStr) => {
+		for (const dateStr of weekRange.dates) {
 			const dayData = unlocksData?.[dateStr]
 			if (dayData?.events) {
-				dayData.events.forEach((event) => {
+				for (const event of dayData.events) {
 					if (!protocolTotals[event.protocol]) {
 						protocolTotals[event.protocol] = 0
 					}
 					protocolTotals[event.protocol] += event.value
-				})
+				}
 			}
-		})
+		}
 
 		const sortedProtocols = Object.keys(protocolTotals).sort((a, b) => protocolTotals[b] - protocolTotals[a])
 
-		sortedProtocols.forEach((protocol, index) => {
-			protocolColorMap[protocol] = COLOR_PALETTE[index % COLOR_PALETTE.length]
-		})
+		for (let i = 0; i < sortedProtocols.length; i++) {
+			const protocol = sortedProtocols[i]
+			protocolColorMap[protocol] = COLOR_PALETTE[i % COLOR_PALETTE.length]
+		}
 
-		weekRange.dates.forEach((dateStr, i) => {
+		for (let i = 0; i < weekRange.dates.length; i++) {
+			const dateStr = weekRange.dates[i]
 			const day = weekRange.start.add(i, 'day')
 			const dayData = unlocksData?.[dateStr]
 			const dataPoint: { date: number; [key: string]: number } = { date: day.unix() }
 
-			sortedProtocols.forEach((protocol) => {
+			for (const protocol of sortedProtocols) {
 				dataPoint[protocol] = 0
-			})
+			}
 
 			if (dayData?.events) {
-				dayData.events.forEach((event) => {
+				for (const event of dayData.events) {
 					if (dataPoint.hasOwnProperty(event.protocol)) {
 						dataPoint[event.protocol] = event.value
 					}
-				})
+				}
 			}
 			weekData.push(dataPoint)
-		})
+		}
 
 		if (sortedProtocols.length === 0) {
 			return {
@@ -111,42 +113,44 @@ export const useUnlockChartData = ({
 		const protocolTotals: { [key: string]: number } = {}
 		const protocolColorMap: { [key: string]: string } = {}
 
-		monthRange.dates.forEach((dateStr) => {
+		for (const dateStr of monthRange.dates) {
 			const dayData = unlocksData?.[dateStr]
 			if (dayData?.events) {
-				dayData.events.forEach((event) => {
+				for (const event of dayData.events) {
 					if (!protocolTotals[event.protocol]) {
 						protocolTotals[event.protocol] = 0
 					}
 					protocolTotals[event.protocol] += event.value
-				})
+				}
 			}
-		})
+		}
 
 		const sortedProtocols = Object.keys(protocolTotals).sort((a, b) => protocolTotals[b] - protocolTotals[a])
 
-		sortedProtocols.forEach((protocol, index) => {
-			protocolColorMap[protocol] = COLOR_PALETTE[index % COLOR_PALETTE.length]
-		})
+		for (let i = 0; i < sortedProtocols.length; i++) {
+			const protocol = sortedProtocols[i]
+			protocolColorMap[protocol] = COLOR_PALETTE[i % COLOR_PALETTE.length]
+		}
 
-		monthRange.dates.forEach((dateStr, i) => {
+		for (let i = 0; i < monthRange.dates.length; i++) {
+			const dateStr = monthRange.dates[i]
 			const day = monthRange.start.date(i + 1)
 			const dayData = unlocksData[dateStr]
 			const dataPoint: { date: number; [key: string]: number } = { date: day.unix() }
 
-			sortedProtocols.forEach((protocol) => {
+			for (const protocol of sortedProtocols) {
 				dataPoint[protocol] = 0
-			})
+			}
 
 			if (dayData?.events) {
-				dayData.events.forEach((event) => {
+				for (const event of dayData.events) {
 					if (dataPoint.hasOwnProperty(event.protocol)) {
 						dataPoint[event.protocol] = event.value
 					}
-				})
+				}
 			}
 			monthData.push(dataPoint)
-		})
+		}
 
 		if (sortedProtocols.length === 0) {
 			return {

--- a/src/containers/Bridges/BridgesOverviewByChain.tsx
+++ b/src/containers/Bridges/BridgesOverviewByChain.tsx
@@ -73,30 +73,29 @@ export function BridgesOverviewByChain({
 		const fileName = 'bridge-and-messaging-volumes.csv'
 		const rows = [['Timestamp', 'Date', ...filteredBridgeNames, 'Total']]
 		let stackedDatasetObject = {} as any
-		filteredBridgeNames.map((bridgeName) => {
+		for (const bridgeName of filteredBridgeNames) {
 			const chartDataIndex = bridgeNameToChartDataIndex[bridgeName]
 			const charts = chartDataByBridge[chartDataIndex]
-			charts.map((chart) => {
+			for (const chart of charts) {
 				const date = chart.date
 				stackedDatasetObject[date] = stackedDatasetObject[date] || {}
 				stackedDatasetObject[date][bridgeName] = chart.volume
-			})
-		})
+			}
+		}
 		const stackedData = Object.entries(stackedDatasetObject).map((data: [string, object]) => {
 			return { date: parseInt(data[0]), ...data[1] }
 		})
-		stackedData
-			.sort((a, b) => a.date - b.date)
-			.forEach((day) => {
-				rows.push([
-					day.date,
-					toNiceCsvDate(day.date),
-					...filteredBridgeNames.map((chain) => day[chain] ?? ''),
-					filteredBridgeNames.reduce((acc, curr) => {
-						return (acc += day[curr] ?? 0)
-					}, 0)
-				])
-			})
+		const sortedStackedData = stackedData.sort((a, b) => a.date - b.date)
+		for (const day of sortedStackedData) {
+			rows.push([
+				day.date,
+				toNiceCsvDate(day.date),
+				...filteredBridgeNames.map((chain) => day[chain] ?? ''),
+				filteredBridgeNames.reduce((acc, curr) => {
+					return (acc += day[curr] ?? 0)
+				}, 0)
+			])
+		}
 
 		return { filename: fileName, rows }
 	}, [filteredBridges, messagingProtocols, bridgeNameToChartDataIndex, chartDataByBridge])
@@ -109,39 +108,39 @@ export function BridgesOverviewByChain({
 			fileName = 'bridge-volume-data.csv'
 			// For volume chart
 			rows = [['Timestamp', 'Date', 'Volume']]
-			chainVolumeData.forEach((entry) => {
+			for (const entry of chainVolumeData) {
 				rows.push([entry.date, toNiceCsvDate(entry.date), entry.volume])
-			})
+			}
 		} else if (chartType === 'Bridge Volume') {
 			fileName = `${selectedChain}-bridge-volume.csv`
 			rows = [['Timestamp', 'Date', 'Volume']]
-			chainVolumeData.forEach((entry) => {
+			for (const entry of chainVolumeData) {
 				rows.push([entry.date, toNiceCsvDate(entry.date), entry.volume])
-			})
+			}
 		} else if (chartType === 'Net Flow') {
 			fileName = `${selectedChain}-netflow.csv`
 			rows = [['Timestamp', 'Date', 'Net Flow']]
-			chainNetFlowData.forEach((entry) => {
+			for (const entry of chainNetFlowData) {
 				rows.push([entry.date, toNiceCsvDate(entry.date), entry['Net Flow']])
-			})
+			}
 		} else if (chartType === 'Net Flow (%)') {
 			fileName = `${selectedChain}-netflow-percentage.csv`
 			rows = [['Timestamp', 'Date', 'Inflows (%)', 'Outflows (%)']]
-			chainPercentageNet.forEach((entry) => {
+			for (const entry of chainPercentageNet) {
 				rows.push([entry.date, toNiceCsvDate(entry.date), entry.Inflows, entry.Outflows])
-			})
+			}
 		} else if (chartType === '24h Tokens Deposited') {
 			fileName = `${selectedChain}-tokens-deposited.csv`
 			rows = [['Token', 'Amount']]
-			tokenDeposits.forEach((entry) => {
+			for (const entry of tokenDeposits) {
 				rows.push([entry.name, entry.value])
-			})
+			}
 		} else if (chartType === '24h Tokens Withdrawn') {
 			fileName = `${selectedChain}-tokens-withdrawn.csv`
 			rows = [['Token', 'Amount']]
-			tokenWithdrawals.forEach((entry) => {
+			for (const entry of tokenWithdrawals) {
 				rows.push([entry.name, entry.value])
-			})
+			}
 		}
 
 		return { filename: fileName, rows }
@@ -163,11 +162,11 @@ export function BridgesOverviewByChain({
 		const bridgesToCalculate = activeTab === 'bridges' ? filteredBridges : messagingProtocols
 
 		if (bridgesToCalculate) {
-			bridgesToCalculate?.forEach((bridge) => {
+			for (const bridge of bridgesToCalculate ?? []) {
 				dayTotalVolume += Number(bridge?.lastDailyVolume) || 0
 				weekTotalVolume += Number(bridge?.weeklyVolume) || 0
 				monthTotalVolume += Number(bridge?.monthlyVolume) || 0
-			})
+			}
 		} else {
 			for (let i = 1; i < 31; i++) {
 				const dailyVolume = getPrevVolumeFromChart(chainVolumeData, i, false, selectedChain !== 'All')

--- a/src/containers/Bridges/DownloadButton.tsx
+++ b/src/containers/Bridges/DownloadButton.tsx
@@ -21,24 +21,23 @@ export const LargeTxDownloadButton = ({ data }: { data: any }) => {
 				'Hash'
 			]
 		]
-		data
-			.sort((a, b) => a.date - b.date)
-			.forEach((tx) => {
-				rows.push([
-					tx.date,
-					toNiceCsvDate(tx.date),
-					tx.bridge,
-					tx.chain,
-					tx.isDeposit ? 'withdrawal' : 'deposit',
-					tx.symbol.split('#')[0] ?? '',
-					tx.usdValue,
-					tx.token,
-					tx.amount,
-					tx.from,
-					tx.to,
-					tx.txHash.split(':')[1] ?? ''
-				])
-			})
+		const sortedData = data.sort((a, b) => a.date - b.date)
+		for (const tx of sortedData) {
+			rows.push([
+				tx.date,
+				toNiceCsvDate(tx.date),
+				tx.bridge,
+				tx.chain,
+				tx.isDeposit ? 'withdrawal' : 'deposit',
+				tx.symbol.split('#')[0] ?? '',
+				tx.usdValue,
+				tx.token,
+				tx.amount,
+				tx.from,
+				tx.to,
+				tx.txHash.split(':')[1] ?? ''
+			])
+		}
 
 		return { filename: 'bridge-transactions.csv', rows }
 	}, [data])

--- a/src/containers/Bridges/Transactions.tsx
+++ b/src/containers/Bridges/Transactions.tsx
@@ -24,7 +24,7 @@ const downloadCsv = (transactions: BridgeTransaction[]) => {
 	const rows = [
 		['Timestamp', 'Date', 'Bridge', 'Chain', 'Deposit/Withdrawal', 'Token', 'Amount', 'USD Value', 'From', 'To', 'Hash']
 	]
-	transactions.forEach((tx) => {
+	for (const tx of transactions) {
 		const timestamp = Math.floor(new Date(tx.ts).getTime() / 1000).toString()
 		rows.push([
 			timestamp,
@@ -39,7 +39,7 @@ const downloadCsv = (transactions: BridgeTransaction[]) => {
 			tx.tx_to,
 			tx.tx_hash
 		])
-	})
+	}
 	download(
 		`bridge-transactions.csv`,
 		rows

--- a/src/containers/Bridges/queries.server.tsx
+++ b/src/containers/Bridges/queries.server.tsx
@@ -192,15 +192,16 @@ export async function getBridgeChainsPageData() {
 
 	let chartData: Record<string, Record<string, number>> = {}
 
-	chains.forEach((chain, i) => {
+	for (let i = 0; i < chains.length; i++) {
+		const chain = chains[i]
 		const charts = chartDataByChain[i]
-		charts.forEach((chart) => {
+		for (const chart of charts) {
 			const date = chart.date
 			const netFlow = chart.depositUSD - chart.withdrawUSD
 			chartData[date] = chartData[date] || {}
 			chartData[date][chain.name] = netFlow
-		})
-	})
+		}
+	}
 
 	// order of chains will update every 24 hrs, can consider changing metric sorted by here
 	const chainList = await chains
@@ -351,10 +352,11 @@ export async function getBridgePageDatanew(bridge: string) {
 		}
 	} = {}
 
-	volume.forEach((chainVolume, index) => {
+	for (let index = 0; index < volume.length; index++) {
+		const chainVolume = volume[index]
 		const chartData = []
 
-		chainVolume.forEach((item) => {
+		for (const item of chainVolume) {
 			const date = Number(item.date)
 			chartData.push({ date, Deposited: item.depositUSD, Withdrawn: -item.withdrawUSD })
 
@@ -367,10 +369,10 @@ export async function getBridgePageDatanew(bridge: string) {
 				Deposited: volumeOnAllChains[date].Deposited + (item.depositUSD || 0),
 				Withdrawn: volumeOnAllChains[date].Withdrawn - (item.withdrawUSD || 0)
 			}
-		})
+		}
 
 		volumeDataByChain[chains[index]] = chartData
-	})
+	}
 
 	volumeDataByChain['All Chains'] =
 		destinationChain !== 'false' ? (volumeDataByChain?.[destinationChain] ?? []) : Object.values(volumeOnAllChains)
@@ -394,7 +396,8 @@ export async function getBridgePageDatanew(bridge: string) {
 
 	const prevDayDataByChain = {}
 
-	statsOnPrevDay.forEach((data, index) => {
+	for (let index = 0; index < statsOnPrevDay.length; index++) {
+		const data = statsOnPrevDay[index]
 		prevDayDataByChain['All Chains'] = {
 			date: Math.max(prevDayDataByChain['All Chains']?.date ?? 0, data.date),
 			totalTokensDeposited: {
@@ -416,7 +419,7 @@ export async function getBridgePageDatanew(bridge: string) {
 		}
 
 		prevDayDataByChain[chains[index]] = data
-	})
+	}
 
 	if (destinationChain !== 'false') {
 		prevDayDataByChain[destinationChain] = prevDayDataByChain['All Chains']
@@ -427,7 +430,7 @@ export async function getBridgePageDatanew(bridge: string) {
 	)
 
 	const tableDataByChain = {}
-	chainsList.forEach((currentChain) => {
+	for (const currentChain of chainsList) {
 		const prevDayData = prevDayDataByChain[currentChain]
 		let tokensTableData = [],
 			addressesTableData = [],
@@ -522,24 +525,22 @@ export async function getBridgePageDatanew(bridge: string) {
 			const totalAddressesDeposited = prevDayData.totalAddressDeposited
 			const totalAddressesWithdrawn = prevDayData.totalAddressWithdrawn
 			let addressesTableUnformatted = {}
-			Object.entries(totalAddressesDeposited).map(
-				([address, addressData]: [string, { txs: number; deposited: number; usdValue: number }]) => {
-					const txs = addressData.txs
-					const usdValue = addressData.usdValue
-					addressesTableUnformatted[address] = addressesTableUnformatted[address] || {}
-					addressesTableUnformatted[address].deposited = (addressesTableUnformatted[address].deposited ?? 0) + usdValue
-					addressesTableUnformatted[address].txs = (addressesTableUnformatted[address].txs ?? 0) + txs
-				}
-			)
-			Object.entries(totalAddressesWithdrawn).map(
-				([address, addressData]: [string, { txs: number; deposited: number; usdValue: number }]) => {
-					const txs = addressData.txs
-					const usdValue = addressData.usdValue
-					addressesTableUnformatted[address] = addressesTableUnformatted[address] || {}
-					addressesTableUnformatted[address].withdrawn = (addressesTableUnformatted[address].withdrawn ?? 0) + usdValue
-					addressesTableUnformatted[address].txs = (addressesTableUnformatted[address].txs ?? 0) + txs
-				}
-			)
+			for (const address in totalAddressesDeposited) {
+				const addressData = totalAddressesDeposited[address] as { txs: number; deposited: number; usdValue: number }
+				const txs = addressData.txs
+				const usdValue = addressData.usdValue
+				addressesTableUnformatted[address] = addressesTableUnformatted[address] || {}
+				addressesTableUnformatted[address].deposited = (addressesTableUnformatted[address].deposited ?? 0) + usdValue
+				addressesTableUnformatted[address].txs = (addressesTableUnformatted[address].txs ?? 0) + txs
+			}
+			for (const address in totalAddressesWithdrawn) {
+				const addressData = totalAddressesWithdrawn[address] as { txs: number; deposited: number; usdValue: number }
+				const txs = addressData.txs
+				const usdValue = addressData.usdValue
+				addressesTableUnformatted[address] = addressesTableUnformatted[address] || {}
+				addressesTableUnformatted[address].withdrawn = (addressesTableUnformatted[address].withdrawn ?? 0) + usdValue
+				addressesTableUnformatted[address].txs = (addressesTableUnformatted[address].txs ?? 0) + txs
+			}
 			addressesTableData = Object.entries(addressesTableUnformatted)
 				.filter(([, addressData]: [string, any]) => {
 					return addressData.txs !== 0
@@ -556,7 +557,7 @@ export async function getBridgePageDatanew(bridge: string) {
 			tokenWithdrawals,
 			tokenColor
 		}
-	})
+	}
 
 	return {
 		displayName,

--- a/src/containers/ChainOverview/Chart.tsx
+++ b/src/containers/ChainOverview/Chart.tsx
@@ -140,7 +140,7 @@ export default function ChainLineBarChart({
 
 		const noOffset = allYAxis.length < 3
 
-		allYAxis.forEach(([type, index]) => {
+		for (const [type, index] of allYAxis) {
 			const options = {
 				...yAxis,
 				name: '',
@@ -398,7 +398,7 @@ export default function ChainLineBarChart({
 					}
 				})
 			}
-		})
+		}
 
 		if (allYAxis.length === 0) {
 			finalYAxis.push(yAxis)

--- a/src/containers/ChainOverview/KeyMetricsPngExport.tsx
+++ b/src/containers/ChainOverview/KeyMetricsPngExport.tsx
@@ -234,7 +234,8 @@ export function KeyMetricsPngExportButton({
 
 			ctx.font = '14px system-ui, -apple-system, sans-serif'
 
-			rows.forEach((row, index) => {
+			for (let index = 0; index < rows.length; index++) {
+				const row = rows[index]
 				const rowY = rowsStartY + index * rowHeight
 
 				ctx.strokeStyle = borderColor
@@ -255,7 +256,7 @@ export function KeyMetricsPngExportButton({
 				ctx.fillText(row.value, canvasWidth - padding, rowY + rowHeight / 2)
 
 				ctx.font = '14px system-ui, -apple-system, sans-serif'
-			})
+			}
 
 			try {
 				const watermarkSrc = isDark ? '/assets/defillama-light-neutral.webp' : '/assets/defillama-dark-neutral.webp'

--- a/src/containers/ChainOverview/Table.tsx
+++ b/src/containers/ChainOverview/Table.tsx
@@ -145,13 +145,13 @@ export const ChainProtocolsTable = ({
 			try {
 				ops = JSON.parse(localStorage.getItem(tableColumnOptionsKey) ?? '{}')
 			} catch {}
-			allKeys.forEach((key) => {
+			for (const key of allKeys) {
 				if (key === newColumnKey) {
 					ops[key] = true
 				} else if (!(key in ops)) {
 					ops[key] = false
 				}
-			})
+			}
 			localStorage.setItem(tableColumnOptionsKey, JSON.stringify(ops))
 			window.dispatchEvent(new Event('storage'))
 			if (instance && instance.setColumnVisibility) {

--- a/src/containers/ChainOverview/constants.tsx
+++ b/src/containers/ChainOverview/constants.tsx
@@ -73,8 +73,12 @@ export const BAR_CHARTS: ChainChartLabels[] = [
 
 export const DISABLED_CUMULATIVE_CHARTS: ChainChartLabels[] = ['Core Developers', 'Devs Commits']
 
-export const chainOverviewChartColors = Object.fromEntries(
-	Object.keys(chainCharts).map((chart, index) => [chart as ChainChartLabels, CHART_COLORS[index]])
-) as {
+const chainOverviewChartColorsRecord: Record<string, string> = {}
+const chainChartKeys = Object.keys(chainCharts)
+for (let index = 0; index < chainChartKeys.length; index++) {
+	const chart = chainChartKeys[index]
+	chainOverviewChartColorsRecord[chart] = CHART_COLORS[index]
+}
+export const chainOverviewChartColors = chainOverviewChartColorsRecord as {
 	[K in keyof typeof chainCharts]: string
 }

--- a/src/containers/ChainOverview/customColumnsUtils.ts
+++ b/src/containers/ChainOverview/customColumnsUtils.ts
@@ -114,7 +114,8 @@ export const AVAILABLE_FIELDS = Object.keys(FIELD_ALIASES)
 
 export function replaceAliases(formula: string): string {
 	let result = formula
-	for (const [alias, path] of Object.entries(FIELD_ALIASES)) {
+	for (const alias in FIELD_ALIASES) {
+		const path = FIELD_ALIASES[alias as keyof typeof FIELD_ALIASES]
 		result = result.replace(new RegExp(`\\b${alias}\\b`, 'g'), path)
 	}
 	return result

--- a/src/containers/ChainOverview/utils.tsx
+++ b/src/containers/ChainOverview/utils.tsx
@@ -54,9 +54,10 @@ export function groupByTimeFrame(data, timeFrame) {
 				acc[timeFrameStart] = values.map(() => 0)
 			}
 
-			values.forEach((value, index) => {
+			for (let index = 0; index < values.length; index++) {
+				const value = values[index]
 				acc[timeFrameStart][index] += Number(value)
-			})
+			}
 
 			return acc
 		},

--- a/src/containers/ChainsByCategory/Table.tsx
+++ b/src/containers/ChainsByCategory/Table.tsx
@@ -122,19 +122,19 @@ export function ChainsByCategoryTable({
 	const [groupTvls, updater] = useLocalStorageSettingsManager('tvl_chains')
 
 	const clearAllAggrOptions = () => {
-		DEFI_CHAINS_SETTINGS.forEach((item) => {
+		for (const item of DEFI_CHAINS_SETTINGS) {
 			if (selectedAggregateTypes.includes(item.key)) {
 				updater(item.key)
 			}
-		})
+		}
 	}
 
 	const toggleAllAggrOptions = () => {
-		DEFI_CHAINS_SETTINGS.forEach((item) => {
+		for (const item of DEFI_CHAINS_SETTINGS) {
 			if (!selectedAggregateTypes.includes(item.key)) {
 				updater(item.key)
 			}
-		})
+		}
 	}
 
 	const addAggrOption = (selectedKeys) => {
@@ -152,7 +152,7 @@ export function ChainsByCategoryTable({
 	}
 
 	const addOnlyOneAggrOption = (newOption) => {
-		DEFI_CHAINS_SETTINGS.forEach((item) => {
+		for (const item of DEFI_CHAINS_SETTINGS) {
 			if (item.key === newOption) {
 				if (!selectedAggregateTypes.includes(item.key)) {
 					updater(item.key)
@@ -162,7 +162,7 @@ export function ChainsByCategoryTable({
 					updater(item.key)
 				}
 			}
-		})
+		}
 	}
 
 	const selectedAggregateTypes = React.useMemo(() => {

--- a/src/containers/CompareTokens/index.tsx
+++ b/src/containers/CompareTokens/index.tsx
@@ -36,7 +36,7 @@ export function CompareTokens({ coinsData, protocols }) {
 			coins.length == 2
 				? () =>
 						Promise.all([
-							fetchCoinPrices(coins.map((c) => 'coingecko:' + c)).then((coins) => ({ coins })),
+							fetchCoinPrices(coins.map((c) => `coingecko:${c}`)).then((coins) => ({ coins })),
 							fetchJson(`${CACHE_SERVER}/supply/${coins[0]}`),
 							fetchJson(`${CACHE_SERVER}/supply/${coins[1]}`)
 						])
@@ -49,7 +49,7 @@ export function CompareTokens({ coinsData, protocols }) {
 	let newPrice, increase
 
 	if (fdvData !== null) {
-		let coinPrices = coins.map((c) => fdvData[0].coins['coingecko:' + c].price)
+		let coinPrices = coins.map((c) => fdvData[0].coins[`coingecko:${c}`].price)
 
 		if (compareType.value === 'mcap') {
 			if (selectedCoins[0]['market_cap'] && selectedCoins[1]['market_cap']) {

--- a/src/containers/DeFiWatchlist/index.tsx
+++ b/src/containers/DeFiWatchlist/index.tsx
@@ -75,8 +75,8 @@ export function DefiWatchlistContainer({ protocols, chains }) {
 		const toAdd = selectedValues.filter((name) => !currentSet.has(name))
 		const toRemove = selectedProtocolNames.filter((name) => !newSet.has(name))
 
-		toAdd.forEach((name) => addProtocol(name))
-		toRemove.forEach((name) => removeProtocol(name))
+		for (const name of toAdd) addProtocol(name)
+		for (const name of toRemove) removeProtocol(name)
 	}
 
 	const { chainOptions, savedChainsList, selectedChainNames } = useMemo(() => {
@@ -94,8 +94,8 @@ export function DefiWatchlistContainer({ protocols, chains }) {
 		const newSet = new Set(selectedValues)
 		const toAdd = selectedValues.filter((name) => !currentSet.has(name))
 		const toRemove = selectedChainNames.filter((name) => !newSet.has(name))
-		toAdd.forEach((name) => addChain(name))
-		toRemove.forEach((name) => removeChain(name))
+		for (const name of toAdd) addChain(name)
+		for (const name of toRemove) removeChain(name)
 	}
 
 	if (isLoadingWatchlist) {
@@ -307,17 +307,17 @@ function PortfolioNotifications({
 
 			if (protocolMetrics?.length > 0 && filteredProtocols.length > 0) {
 				settings.protocols = {}
-				filteredProtocols.forEach((protocol) => {
+				for (const protocol of filteredProtocols) {
 					const identifier = protocol.slug
 					settings.protocols![identifier] = protocolMetrics.map(mapUIMetricToAPI)
-				})
+				}
 			}
 
 			if (chainMetrics?.length > 0 && filteredChains.length > 0) {
 				settings.chains = {}
-				filteredChains.forEach((chain) => {
+				for (const chain of filteredChains) {
 					settings.chains![chain.name] = chainMetrics.map(mapUIMetricToAPI)
-				})
+				}
 			}
 
 			if (!settings.protocols && !settings.chains) {
@@ -689,9 +689,9 @@ function TopMovers({ protocols }: TopMoversProps) {
 
 	const availableChains = useMemo(() => {
 		const chainSet = new Set<string>()
-		protocols.forEach((protocol) => {
-			protocol.chains?.forEach((chain) => chainSet.add(chain))
-		})
+		for (const protocol of protocols) {
+			if (protocol.chains) { for (const chain of protocol.chains) chainSet.add(chain) }
+		}
 		return Array.from(chainSet).sort()
 	}, [protocols])
 
@@ -699,7 +699,7 @@ function TopMovers({ protocols }: TopMoversProps) {
 		const periods = ['1d', '7d', '1m']
 		const movers: Record<string, Array<{ name: string; change: number; chains: string[] }>> = {}
 
-		periods.forEach((period) => {
+		for (const period of periods) {
 			const changeKey = `change${period}`
 			let candidates = protocols
 				.filter((p) => p.tvlChange?.[changeKey] != null && p.tvlChange[changeKey] != null)
@@ -723,7 +723,7 @@ function TopMovers({ protocols }: TopMoversProps) {
 
 			candidates.sort((a, b) => Math.abs(b.change) - Math.abs(a.change))
 			movers[period] = candidates.slice(0, 3)
-		})
+		}
 
 		return movers
 	}, [protocols, showPositiveMoves, showNegativeMoves, selectedChains])

--- a/src/containers/DimensionAdapters/ChainChart.tsx
+++ b/src/containers/DimensionAdapters/ChainChart.tsx
@@ -442,19 +442,19 @@ const getChartDataByChainAndInterval = ({
 				topItems.push([chain, chainsOnDate[chain]])
 			}
 		}
-		topItems
-			.sort((a: [string, number], b: [string, number]) => b[1] - a[1])
-			.forEach(([chain, value]: [string, number], index: number) => {
-				if (index < 10) {
-					topByDate[chain] = topByDate[chain] || {}
-					topByDate[chain][finalDate] = value ?? 0
-					uniqTopChains.add(chain)
-				} else {
-					topByDate[chain] = topByDate[chain] || {}
-					topByDate[chain][finalDate] = 0
-					others += value ?? 0
-				}
-			})
+		const sortedTopItems = topItems.sort((a: [string, number], b: [string, number]) => b[1] - a[1])
+		for (let index = 0; index < sortedTopItems.length; index++) {
+			const [chain, value] = sortedTopItems[index] as [string, number]
+			if (index < 10) {
+				topByDate[chain] = topByDate[chain] || {}
+				topByDate[chain][finalDate] = value ?? 0
+				uniqTopChains.add(chain)
+			} else {
+				topByDate[chain] = topByDate[chain] || {}
+				topByDate[chain][finalDate] = 0
+				others += value ?? 0
+			}
+		}
 
 		for (const chain of selectedChains) {
 			topByAllDates[chain] = topByAllDates[chain] || {}

--- a/src/containers/DimensionAdapters/ProtocolChart.tsx
+++ b/src/containers/DimensionAdapters/ProtocolChart.tsx
@@ -305,7 +305,10 @@ const ChartByType = ({
 
 		// Build chart config
 		const allColors = getNDistinctColors(breakdownNames.length + 1)
-		const stackColors = Object.fromEntries(breakdownNames.map((type, i) => [type, allColors[i]]))
+		const stackColors: Record<string, string> = {}
+		for (let i = 0; i < breakdownNames.length; i++) {
+			stackColors[breakdownNames[i]] = allColors[i]
+		}
 		stackColors['Others'] = allColors[allColors.length - 1]
 
 		const chartType2: 'line' | 'bar' = isCumulative ? 'line' : 'bar'

--- a/src/containers/DimensionAdapters/queries.tsx
+++ b/src/containers/DimensionAdapters/queries.tsx
@@ -475,11 +475,13 @@ function mergeBreakdowns(breakdowns: Record<string, Record<string, number>>[]) {
 	const merged = {}
 	for (const breakdown of breakdowns) {
 		if (!breakdown) continue
-		for (const [chainName, protocolData] of Object.entries(breakdown)) {
+		for (const chainName in breakdown) {
+			const protocolData = breakdown[chainName]
 			if (!merged[chainName]) {
 				merged[chainName] = {}
 			}
-			for (const [protocolName, value] of Object.entries(protocolData)) {
+			for (const protocolName in protocolData) {
+				const value = protocolData[protocolName]
 				merged[chainName][protocolName] = (merged[chainName][protocolName] || 0) + value
 			}
 		}
@@ -553,7 +555,7 @@ function processRevenueDataForMatching(protocols: any[]) {
 function matchRevenueToEarnings(revenueData: any[], earningsProtocols: any[]) {
 	const matchedData = {}
 
-	revenueData.forEach((revenueProtocol) => {
+	for (const revenueProtocol of revenueData) {
 		const matchingEarningsProtocol = earningsProtocols.find((earningsProto) => {
 			const earningsParentKey = earningsProto.parentProtocol || earningsProto.defillamaId
 
@@ -576,7 +578,7 @@ function matchRevenueToEarnings(revenueData: any[], earningsProtocols: any[]) {
 				totalAllTime: revenueProtocol.totalAllTime ?? null
 			}
 		}
-	})
+	}
 
 	return matchedData
 }

--- a/src/containers/Forks/queries.tsx
+++ b/src/containers/Forks/queries.tsx
@@ -27,24 +27,24 @@ export async function getForkPageData(fork = null) {
 
 		if (fork) {
 			let data = []
-			chartData.forEach(([date, tokens]) => {
+			for (const [date, tokens] of chartData) {
 				const value = tokens[fork]
 				if (value) {
 					data.push([date, value])
 				}
-			})
+			}
 			chartData = data
 			const protocol = protocolsData.find((p) => p.name.toLowerCase() === fork.toLowerCase())
 			if (protocol) {
 				parentTokens.push(protocol)
 			}
 		} else {
-			forksUnique.forEach((fork) => {
+			for (const fork of forksUnique) {
 				const protocol = protocolsData.find((p) => p.name.toLowerCase() === fork.toLowerCase())
 				if (protocol) {
 					parentTokens.push(protocol)
 				}
-			})
+			}
 		}
 
 		const forksProtocols = {}

--- a/src/containers/Hacks/queries.tsx
+++ b/src/containers/Hacks/queries.tsx
@@ -60,10 +60,10 @@ export async function getHacksPageData(): Promise<IHacksPageData> {
 
 	const monthlyHacks = {}
 
-	data.forEach((hack) => {
+	for (const hack of data) {
 		const monthlyDate = +firstDayOfMonth(hack.date * 1000) * 1e3
 		monthlyHacks[monthlyDate] = (monthlyHacks[monthlyDate] ?? 0) + hack.amount
-	})
+	}
 
 	const totalHacked = formattedNum(
 		data.map((hack) => hack.amount).reduce((acc, amount) => acc + amount, 0),

--- a/src/containers/Liquidations/LiquidableChanges24H.tsx
+++ b/src/containers/Liquidations/LiquidableChanges24H.tsx
@@ -31,45 +31,43 @@ const getLiquidableChangesRatio = (
 	let prev = 0
 	if (!selectedSeries) {
 		if (stackBy === 'chains') {
-			Object.keys(data.totalLiquidables.chains).forEach((chain) => {
+			for (const chain in data.totalLiquidables.chains) {
 				if (!prevData.totalLiquidables.chains[chain]) {
-					return
+					continue
 				}
 				current += data.totalLiquidables.chains[chain]
 				prev += prevData.totalLiquidables.chains[chain]
-			})
+			}
 		} else {
-			Object.keys(data.totalLiquidables.protocols).forEach((protocol) => {
+			for (const protocol in data.totalLiquidables.protocols) {
 				if (!prevData.totalLiquidables.protocols[protocol]) {
-					return
+					continue
 				}
 				current += data.totalLiquidables.protocols[protocol]
 				prev += prevData.totalLiquidables.protocols[protocol]
-			})
+			}
 		}
 	} else {
 		if (stackBy === 'chains') {
-			Object.keys(selectedSeries)
-				.filter((chain) => selectedSeries[chain])
-				.forEach((chain) => {
-					const _chain = PROTOCOL_NAMES_MAP_REVERSE[chain]
-					if (!prevData.totalLiquidables.chains[_chain]) {
-						return
-					}
-					current += data.totalLiquidables.chains[_chain]
-					prev += prevData.totalLiquidables.chains[_chain]
-				})
+			const filteredChains = Object.keys(selectedSeries).filter((chain) => selectedSeries[chain])
+			for (const chain of filteredChains) {
+				const _chain = PROTOCOL_NAMES_MAP_REVERSE[chain]
+				if (!prevData.totalLiquidables.chains[_chain]) {
+					continue
+				}
+				current += data.totalLiquidables.chains[_chain]
+				prev += prevData.totalLiquidables.chains[_chain]
+			}
 		} else {
-			Object.keys(selectedSeries)
-				.filter((protocol) => selectedSeries[protocol])
-				.forEach((protocol) => {
-					const _protocol = PROTOCOL_NAMES_MAP_REVERSE[protocol]
-					if (!prevData.totalLiquidables.protocols[_protocol]) {
-						return
-					}
-					current += data.totalLiquidables.protocols[_protocol]
-					prev += prevData.totalLiquidables.protocols[_protocol]
-				})
+			const filteredProtocols = Object.keys(selectedSeries).filter((protocol) => selectedSeries[protocol])
+			for (const protocol of filteredProtocols) {
+				const _protocol = PROTOCOL_NAMES_MAP_REVERSE[protocol]
+				if (!prevData.totalLiquidables.protocols[_protocol]) {
+					continue
+				}
+				current += data.totalLiquidables.protocols[_protocol]
+				prev += prevData.totalLiquidables.protocols[_protocol]
+			}
 		}
 	}
 

--- a/src/containers/Liquidations/LiquidationsContent.tsx
+++ b/src/containers/Liquidations/LiquidationsContent.tsx
@@ -150,25 +150,21 @@ const getDangerousPositionsAmount = (
 	if (!selectedSeries) {
 		dangerousPositionsAmount = data.dangerousPositionsAmount
 	} else if (stackBy === 'chains') {
-		Object.keys(selectedSeries)
-			.filter((chain) => selectedSeries[chain])
-			.forEach((chain) => {
-				const _chain = PROTOCOL_NAMES_MAP_REVERSE[chain]
-				const binSize = data.chartDataBins.chains[_chain]?.binSize ?? 0
-				dangerousPositionsAmount += Object.entries(data.chartDataBins.chains[_chain]?.bins ?? {})
-					.filter(([bin]) => binSize * parseInt(bin) >= priceThreshold)
-					.reduce((acc, [, value]) => acc + value['usd'], 0)
-			})
+		for (const chain of Object.keys(selectedSeries).filter((chain) => selectedSeries[chain])) {
+			const _chain = PROTOCOL_NAMES_MAP_REVERSE[chain]
+			const binSize = data.chartDataBins.chains[_chain]?.binSize ?? 0
+			dangerousPositionsAmount += Object.entries(data.chartDataBins.chains[_chain]?.bins ?? {})
+				.filter(([bin]) => binSize * parseInt(bin) >= priceThreshold)
+				.reduce((acc, [, value]) => acc + value['usd'], 0)
+		}
 	} else {
-		Object.keys(selectedSeries)
-			.filter((protocol) => selectedSeries[protocol])
-			.forEach((protocol) => {
-				const _protocol = PROTOCOL_NAMES_MAP_REVERSE[protocol]
-				const binSize = data.chartDataBins.protocols[_protocol]?.binSize ?? 0
-				dangerousPositionsAmount += Object.entries(data.chartDataBins.protocols[_protocol]?.bins ?? {})
-					.filter(([bin]) => binSize * parseInt(bin) >= priceThreshold)
-					.reduce((acc, [, value]) => acc + value['usd'], 0)
-			})
+		for (const protocol of Object.keys(selectedSeries).filter((protocol) => selectedSeries[protocol])) {
+			const _protocol = PROTOCOL_NAMES_MAP_REVERSE[protocol]
+			const binSize = data.chartDataBins.protocols[_protocol]?.binSize ?? 0
+			dangerousPositionsAmount += Object.entries(data.chartDataBins.protocols[_protocol]?.bins ?? {})
+				.filter(([bin]) => binSize * parseInt(bin) >= priceThreshold)
+				.reduce((acc, [, value]) => acc + value['usd'], 0)
+		}
 	}
 	return dangerousPositionsAmount
 }

--- a/src/containers/Liquidations/utils.ts
+++ b/src/containers/Liquidations/utils.ts
@@ -563,10 +563,15 @@ export const PROTOCOL_NAMES_MAP = {
 	strike: 'Strike'
 } as const
 
-export const PROTOCOL_NAMES_MAP_REVERSE: { [name: string]: string } = Object.entries(PROTOCOL_NAMES_MAP).reduce(
-	(acc, [key, value]) => ({ ...acc, [value]: key }),
-	{}
-)
+const buildProtocolNamesMapReverse = (): { [name: string]: string } => {
+	const result: { [name: string]: string } = {}
+	for (const key in PROTOCOL_NAMES_MAP) {
+		const value = PROTOCOL_NAMES_MAP[key as keyof typeof PROTOCOL_NAMES_MAP]
+		result[value] = key
+	}
+	return result
+}
+export const PROTOCOL_NAMES_MAP_REVERSE = buildProtocolNamesMapReverse()
 
 export const sortObject = <T>(
 	unordered: { [key: string]: T },
@@ -636,11 +641,11 @@ export const getOption = (
 		}))
 	}
 
-	series.forEach((seriesItem) => {
+	for (const seriesItem of series) {
 		if (seriesItem.data.length === 0) {
 			seriesItem.large = false
 		}
-	})
+	}
 
 	const option: ECBasicOption = {
 		graphic: {

--- a/src/containers/LlamaAI/components/ChatHistorySidebar.tsx
+++ b/src/containers/LlamaAI/components/ChatHistorySidebar.tsx
@@ -57,12 +57,13 @@ export function ChatHistorySidebar({
 
 	const virtualItems = useMemo(() => {
 		const items: VirtualItem[] = []
-		groupedSessions.forEach(([groupName, groupSessions], groupIndex) => {
+		for (let groupIndex = 0; groupIndex < groupedSessions.length; groupIndex++) {
+			const [groupName, groupSessions] = groupedSessions[groupIndex]
 			items.push({ type: 'header', groupName, isFirst: groupIndex === 0 })
-			groupSessions.forEach((session) => {
+			for (const session of groupSessions) {
 				items.push({ type: 'session', session, groupName })
-			})
-		})
+			}
+		}
 		return items
 	}, [groupedSessions])
 

--- a/src/containers/LlamaAI/components/MarkdownRenderer.tsx
+++ b/src/containers/LlamaAI/components/MarkdownRenderer.tsx
@@ -61,10 +61,10 @@ const TableWrapper = memo(function TableWrapper({
 		const rows: Array<Array<string>> = []
 		const tableRows = Array.from(table.querySelectorAll('tr'))
 
-		tableRows.forEach((row) => {
+		for (const row of tableRows) {
 			const cells = Array.from(row.querySelectorAll('th, td'))
 			rows.push(cells.map((cell) => cell.textContent || ''))
-		})
+		}
 
 		const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5)
 		return { filename: `table-${timestamp}.csv`, rows }
@@ -187,7 +187,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
 			return text.replace(/\[(\d+(?:(?:-\d+)|(?:,\s*\d+))*)\]/g, (_, nums) => {
 				const parts = nums.split(',').map((p: string) => p.trim())
 				const expandedNums: number[] = []
-				parts.forEach((part: string) => {
+				for (const part of parts) {
 					if (part.includes('-')) {
 						const [start, end] = part.split('-').map((n: string) => parseInt(n.trim()))
 						if (!isNaN(start) && !isNaN(end) && start <= end) {
@@ -197,7 +197,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
 						const num = parseInt(part.trim())
 						if (!isNaN(num)) expandedNums.push(num)
 					}
-				})
+				}
 				return expandedNums
 					.map((num) => {
 						const idx = num - 1

--- a/src/containers/LlamaAI/components/PromptInput.tsx
+++ b/src/containers/LlamaAI/components/PromptInput.tsx
@@ -90,7 +90,9 @@ export const PromptInput = memo(function PromptInput({
 					errorToast({ title: 'Image upload limit', description: 'You may upload only 4 images at a time' })
 				})
 				// Revoke URLs for images that won't be used
-				newImages.slice(4 - prev.length).forEach(({ url }) => URL.revokeObjectURL(url))
+				for (const { url } of newImages.slice(4 - prev.length)) {
+					URL.revokeObjectURL(url)
+				}
 			}
 			return [...prev, ...newImages].slice(0, 4)
 		})
@@ -238,7 +240,9 @@ export const PromptInput = memo(function PromptInput({
 		setValue('')
 		setIsTriggerOnly(false)
 		if (revokeImageUrls) {
-			selectedImages.forEach(({ url }) => URL.revokeObjectURL(url))
+			for (const { url } of selectedImages) {
+				URL.revokeObjectURL(url)
+			}
 		}
 		setSelectedImages([])
 		combobox.setValue('')

--- a/src/containers/LlamaAI/components/RecommendedPrompts.tsx
+++ b/src/containers/LlamaAI/components/RecommendedPrompts.tsx
@@ -68,7 +68,11 @@ const researchCategory = {
 
 async function getRecommendedPrompts() {
 	try {
-		return Object.fromEntries(promptCategories.map((category) => [category.name, category.prompts]))
+		const result: Record<string, readonly string[]> = {}
+		for (const category of promptCategories) {
+			result[category.name] = category.prompts
+		}
+		return result
 	} catch (error) {
 		console.log(error)
 		throw new Error(error instanceof Error ? error.message : 'Failed to fetch recommended prompts')

--- a/src/containers/LlamaAI/utils/chartAdapter.ts
+++ b/src/containers/LlamaAI/utils/chartAdapter.ts
@@ -177,9 +177,10 @@ function adaptPieChartData(config: ChartConfiguration, rawData: any[]): AdaptedC
 			.sort((a, b) => b.value - a.value)
 
 		const stackColors: Record<string, string> = {}
-		pieData.forEach((item, index) => {
+		for (let index = 0; index < pieData.length; index++) {
+			const item = pieData[index]
 			stackColors[item.name] = getChartColor(item.name, index, '#8884d8')
-		})
+		}
 
 		const pieProps: Partial<IPieChartProps> = {
 			title: config.title,
@@ -382,12 +383,12 @@ export function adaptChartData(config: ChartConfiguration, rawData: any[]): Adap
 
 						let content = `<div style="margin-bottom: 8px; font-weight: 600;">${date}</div>`
 
-						params.forEach((param: any) => {
+						for (const param of params as any[]) {
 							const value = param.value?.[1]
 							if (value !== null && value !== undefined) {
 								content += `<div>${param.marker} ${param.seriesName}: ${formatPrecisionPercentage(value)}</div>`
 							}
-						})
+						}
 
 						return content
 					}
@@ -428,10 +429,11 @@ export function adaptMultiSeriesData(config: ChartConfiguration, rawData: any[])
 
 		const yAxisIdToIndex = new Map<string, number>()
 		const yAxisIndexToSymbol = new Map<number, string>()
-		config.axes.yAxes?.forEach((axis, index) => {
+		for (let index = 0; index < (config.axes.yAxes?.length ?? 0); index++) {
+			const axis = config.axes.yAxes![index]
 			yAxisIdToIndex.set(axis.id, index)
 			yAxisIndexToSymbol.set(index, axis.valueSymbol ?? config.valueSymbol ?? '$')
-		})
+		}
 
 		const series: Array<{
 			data: Array<[number, number | null]>
@@ -527,7 +529,7 @@ export function adaptMultiSeriesData(config: ChartConfiguration, rawData: any[])
 						const header = config.axes.x.type === 'time' ? new Date(xValue).toLocaleDateString() : String(xValue)
 
 						let content = `<div style="margin-bottom: 8px; font-weight: 600;">${header}</div>`
-						params.forEach((param: any) => {
+						for (const param of params as any[]) {
 							const value = param.value?.[1]
 							if (value != null) {
 								const yAxisIndex = validSeries[param.seriesIndex]?.yAxisIndex ?? 0
@@ -536,7 +538,7 @@ export function adaptMultiSeriesData(config: ChartConfiguration, rawData: any[])
 									axisSymbol === '%' ? formatPrecisionPercentage(value) : formatTooltipValue(value, axisSymbol)
 								content += `<div>${param.marker} ${param.seriesName}: ${formattedValue}</div>`
 							}
-						})
+						}
 						return content
 					}
 				}
@@ -622,13 +624,13 @@ export function adaptCandlestickData(
 		}
 
 		const maFields = keys.filter((k) => /_(ma|sma|ema)\d*$/i.test(k) || /^(sma|ema)_\d+$/i.test(k))
-		maFields.forEach((field) => {
+		for (const field of maFields) {
 			indicators.push({
 				name: field.toUpperCase(),
 				category: 'overlay',
 				data: rawData.map((r: any) => [getTs(r), parseFloat(r[field]) || null])
 			})
-		})
+		}
 
 		const rsiField = keys.find((k) => /^rsi(_\d+)?$/i.test(k))
 		if (rsiField) {

--- a/src/containers/LlamaAI/utils/chartDataTransformer.ts
+++ b/src/containers/LlamaAI/utils/chartDataTransformer.ts
@@ -8,7 +8,7 @@ export class ChartDataTransformer {
 			const isFlowMetric = s.metricClass === 'flow'
 			const grouped = new Map<number, number[]>()
 
-			s.data.forEach(([timestamp, value]: [number, number]) => {
+			for (const [timestamp, value] of s.data as [number, number][]) {
 				const date = new Date(timestamp * 1000)
 				let key: number
 
@@ -28,7 +28,7 @@ export class ChartDataTransformer {
 
 				if (!grouped.has(key)) grouped.set(key, [])
 				grouped.get(key)!.push(value)
-			})
+			}
 
 			const aggregatedData: [number, number][] = Array.from(grouped.entries())
 				.map(([timestamp, values]): [number, number] => {
@@ -51,9 +51,11 @@ export class ChartDataTransformer {
 		chartType: 'line' | 'area' | 'bar' | 'combo' | 'pie' | 'scatter' | 'hbar' | 'candlestick'
 	): any[] {
 		const allTimestamps = new Set<number>()
-		series.forEach((s) => {
-			s.data.forEach(([timestamp]: [number, number]) => allTimestamps.add(timestamp))
-		})
+		for (const s of series) {
+			for (const [timestamp] of s.data as [number, number][]) {
+				allTimestamps.add(timestamp)
+			}
+		}
 
 		const sortedTimestamps = Array.from(allTimestamps).sort((a, b) => a - b)
 
@@ -79,23 +81,25 @@ export class ChartDataTransformer {
 
 	static toPercentage(series: any[], shouldStack: boolean = true): any[] {
 		const allTimestamps = new Set<number>()
-		series.forEach((s) => {
-			s.data.forEach(([timestamp]: [number, number]) => allTimestamps.add(timestamp))
-		})
+		for (const s of series) {
+			for (const [timestamp] of s.data as [number, number][]) {
+				allTimestamps.add(timestamp)
+			}
+		}
 
 		const sortedTimestamps = Array.from(allTimestamps).sort((a, b) => a - b)
 
 		const totals = new Map<number, number>()
-		sortedTimestamps.forEach((timestamp) => {
+		for (const timestamp of sortedTimestamps) {
 			let total = 0
-			series.forEach((s) => {
+			for (const s of series) {
 				const dataPoint = s.data.find(([t]: [number, number]) => t === timestamp)
 				if (dataPoint) {
 					total += dataPoint[1]
 				}
-			})
+			}
 			totals.set(timestamp, total)
-		})
+		}
 
 		const percentageColors = [
 			'#FF6B6B',

--- a/src/containers/NarrativeTracker/index.tsx
+++ b/src/containers/NarrativeTracker/index.tsx
@@ -23,10 +23,10 @@ function calculateDenominatedChange(data, denominatedCoin) {
 	const sortedData = data.sort((a, b) => a.date - b.date)
 	const denominatedReturns = []
 
-	sortedData.forEach((dayData) => {
+	for (const dayData of sortedData) {
 		const newDayData = { date: dayData.date }
 
-		Object.keys(dayData).forEach((category) => {
+		for (const category in dayData) {
 			if (category !== 'date' && category !== denominatedCoin) {
 				// calculate relative performance
 				const categoryPerformance = 1 + dayData[category] / 100
@@ -35,10 +35,10 @@ function calculateDenominatedChange(data, denominatedCoin) {
 
 				newDayData[category] = relativePerformance
 			}
-		})
+		}
 
 		denominatedReturns.push(newDayData)
-	})
+	}
 
 	return denominatedReturns
 }
@@ -49,12 +49,12 @@ function calculateDenominatedChange2(data, denominatedCoin, field) {
 
 	const denominatedCoinPerformance = 1 + data.find((i) => i.name === denominatedCoin)[field] / 100
 
-	data.forEach((i) => {
+	for (const i of data) {
 		const categoryPerformance = 1 + i[field] / 100
 		const relativePerformance = (categoryPerformance / denominatedCoinPerformance - 1) * 100
 
 		denominatedReturns.push({ ...i, [field]: relativePerformance })
-	})
+	}
 
 	return denominatedReturns
 }

--- a/src/containers/NarrativeTracker/queries.tsx
+++ b/src/containers/NarrativeTracker/queries.tsx
@@ -70,15 +70,15 @@ export async function getCoinPerformance(categoryId) {
 
 		// calculate cumulative percentage change for each id
 		const results = {}
-		Object.keys(groupedData).forEach((id) => {
+		for (const id of Object.keys(groupedData)) {
 			const prices = groupedData[id]
 			const initialPrice = prices[0].price
-			prices.forEach(({ timestamp, price }) => {
+			for (const { timestamp, price } of prices) {
 				if (!results[timestamp]) results[timestamp] = {}
 				const percentageChange = ((price - initialPrice) / initialPrice) * 100
 				results[timestamp][mapping[id]] = percentageChange
-			})
-		})
+			}
+		}
 
 		// format for chart
 		return Object.entries(results).map(([timestamp, changes]) => ({

--- a/src/containers/Nft/queries.tsx
+++ b/src/containers/Nft/queries.tsx
@@ -213,14 +213,14 @@ export const getNFTCollectionEarnings = async () => {
 			let totalMintEarnings = 0
 			let totalEarnings = 0
 
-			subCollectionEarnings.forEach((c) => {
+			for (const c of subCollectionEarnings) {
 				total24h += c.total24h ?? 0
 				total7d += c.total7d ?? 0
 				total30d += c.total30d ?? 0
 				totalRoyaltyEarnings += c.totalRoyaltyEarnings ?? 0
 				totalMintEarnings += c.totalMintEarnings ?? 0
 				totalEarnings += c.totalEarnings ?? 0
-			})
+			}
 
 			return {
 				defillamaId: subCollections.join('+'),

--- a/src/containers/Oracles/queries.tsx
+++ b/src/containers/Oracles/queries.tsx
@@ -95,12 +95,12 @@ export async function getOraclePageData(oracle = null, chain = null) {
 
 		if (oracle) {
 			let data = []
-			chartData.forEach(([date, tokens]) => {
+			for (const [date, tokens] of chartData) {
 				const value = tokens[oracle]
 				if (value) {
 					data.push([date, value])
 				}
-			})
+			}
 			chartData = data
 		}
 

--- a/src/containers/ProDashboard/AppMetadataContext.tsx
+++ b/src/containers/ProDashboard/AppMetadataContext.tsx
@@ -136,7 +136,9 @@ export function AppMetadataProvider({ children }: { children: React.ReactNode })
 				for (const k of Object.keys(item)) {
 					const v = (item as any)[k]
 					if (k === 'chains' && Array.isArray(v)) {
-						v.forEach((c: string) => tmp[slug].chains.add(c))
+						for (const c of v) {
+							tmp[slug].chains.add(c)
+						}
 					} else if (k === 'displayName' && v && !tmp[slug].displayName) {
 						tmp[slug].displayName = v
 					} else if (typeof v === 'boolean') {

--- a/src/containers/ProDashboard/ProDashboardAPIContext.tsx
+++ b/src/containers/ProDashboard/ProDashboardAPIContext.tsx
@@ -490,13 +490,13 @@ export function ProDashboardAPIProvider({
 		const olderSessions = unratedSessions.slice(1)
 
 		const updatedAiGenerated = { ...currentDashboard.aiGenerated }
-		olderSessions.forEach((session) => {
+		for (const session of olderSessions) {
 			updatedAiGenerated[session.sessionId] = {
 				...updatedAiGenerated[session.sessionId],
 				rated: false,
 				skipped: true
 			} as AISessionData
-		})
+		}
 
 		try {
 			await saveDashboard({ aiGenerated: updatedAiGenerated })
@@ -819,13 +819,13 @@ export function ProDashboardAPIProvider({
 	// Load dashboard
 	const allChartItems: ChartConfig[] = useMemo(() => {
 		const chartItems: ChartConfig[] = []
-		items.forEach((item) => {
+		for (const item of items) {
 			if (item.kind === 'chart') {
 				chartItems.push(item)
 			} else if (item.kind === 'multi') {
 				chartItems.push(...item.items)
 			}
-		})
+		}
 		return chartItems
 	}, [items])
 
@@ -833,11 +833,12 @@ export function ProDashboardAPIProvider({
 
 	const queryById = useMemo(() => {
 		const map = new Map<string, any>()
-		allChartItems.forEach((chartConfig, index) => {
+		for (let index = 0; index < allChartItems.length; index++) {
+			const chartConfig = allChartItems[index]
 			if (chartQueries[index]) {
 				map.set(chartConfig.id, chartQueries[index])
 			}
-		})
+		}
 		return map
 	}, [allChartItems, chartQueries])
 
@@ -936,17 +937,17 @@ export function ProDashboardAPIProvider({
 
 	const chainByName = useMemo(() => {
 		const map = new Map<string, Chain>()
-		chains.forEach((chain) => {
+		for (const chain of chains) {
 			map.set(chain.name, chain)
-		})
+		}
 		return map
 	}, [chains])
 
 	const protocolBySlug = useMemo(() => {
 		const map = new Map<string, Protocol>()
-		protocols.forEach((protocol: Protocol) => {
+		for (const protocol of protocols as Protocol[]) {
 			map.set(protocol.slug, protocol)
-		})
+		}
 		return map
 	}, [protocols])
 

--- a/src/containers/ProDashboard/borrowedChartConstants.ts
+++ b/src/containers/ProDashboard/borrowedChartConstants.ts
@@ -16,6 +16,7 @@ export const BORROWED_CHART_TYPES = [
 	{ value: 'tokenBorrowedRaw', label: 'Borrowed by Token (Raw Quantities)' }
 ] as const
 
-export const BORROWED_CHART_TYPE_LABELS: Record<string, string> = Object.fromEntries(
-	BORROWED_CHART_TYPES.map(({ value, label }) => [value, label])
-)
+export const BORROWED_CHART_TYPE_LABELS: Record<string, string> = {}
+for (const { value, label } of BORROWED_CHART_TYPES) {
+	BORROWED_CHART_TYPE_LABELS[value] = label
+}

--- a/src/containers/ProDashboard/components/AddChartModal/ChartBuilderTab.tsx
+++ b/src/containers/ProDashboard/components/AddChartModal/ChartBuilderTab.tsx
@@ -152,11 +152,11 @@ export const ChartBuilderTab = memo(function ChartBuilderTab({
 	const categoryOptions = useMemo(() => {
 		if (!protocols) return []
 		const categoriesSet = new Set<string>()
-		protocols.forEach((protocol: any) => {
+		for (const protocol of protocols as any[]) {
 			if (protocol.category) {
 				categoriesSet.add(protocol.category)
 			}
-		})
+		}
 		return Array.from(categoriesSet)
 			.sort()
 			.map((cat) => ({
@@ -853,7 +853,7 @@ export const ChartBuilderTab = memo(function ChartBuilderTab({
 													filteredSeries = filteredSeries.map((s) => {
 														const aggregatedData: Map<number, number> = new Map()
 
-														s.data.forEach(([timestamp, value]: [number, number]) => {
+														for (const [timestamp, value] of s.data as [number, number][]) {
 															const date = new Date(timestamp * 1000)
 															const weekDate = new Date(date)
 															const day = weekDate.getDay()
@@ -863,7 +863,7 @@ export const ChartBuilderTab = memo(function ChartBuilderTab({
 															const weekKey = Math.floor(weekDate.getTime() / 1000)
 
 															aggregatedData.set(weekKey, (aggregatedData.get(weekKey) || 0) + value)
-														})
+														}
 
 														return {
 															...s,
@@ -874,11 +874,11 @@ export const ChartBuilderTab = memo(function ChartBuilderTab({
 
 												if (chartBuilder.displayAs === 'percentage') {
 													const timestampTotals = new Map<number, number>()
-													filteredSeries.forEach((s) => {
-														s.data.forEach(([timestamp, value]) => {
+													for (const s of filteredSeries) {
+														for (const [timestamp, value] of s.data) {
 															timestampTotals.set(timestamp, (timestampTotals.get(timestamp) || 0) + value)
-														})
-													})
+														}
+													}
 
 													return filteredSeries.map((s) => ({
 														name: s.name,

--- a/src/containers/ProDashboard/components/AddChartModal/ChartTypePills.tsx
+++ b/src/containers/ProDashboard/components/AddChartModal/ChartTypePills.tsx
@@ -45,7 +45,9 @@ export const ChartTypePills = memo(function ChartTypePills({
 }: ChartTypePillsProps) {
 	const chartTypeMap = useMemo(() => {
 		const map = new Map<string, ChartTypeOption>()
-		chartTypes.forEach((ct) => map.set(ct.value, ct))
+		for (const ct of chartTypes) {
+			map.set(ct.value, ct)
+		}
 		return map
 	}, [chartTypes])
 
@@ -54,7 +56,8 @@ export const ChartTypePills = memo(function ChartTypePills({
 	const groupedOptions = useMemo(() => {
 		const result: Array<{ group: string; options: ChartTypeOption[] }> = []
 
-		for (const [groupName, typeIds] of Object.entries(groups)) {
+		for (const groupName in groups) {
+			const typeIds = groups[groupName]
 			const options: ChartTypeOption[] = []
 			for (const id of typeIds) {
 				const chartType = chartTypeMap.get(id)

--- a/src/containers/ProDashboard/components/AddChartModal/CombinedChartPreview.tsx
+++ b/src/containers/ProDashboard/components/AddChartModal/CombinedChartPreview.tsx
@@ -42,7 +42,7 @@ export function CombinedChartPreview({ composerItems }: CombinedChartPreviewProp
 		let hasNonMonetaryMetrics = false
 		let allPercentMetrics = true
 
-		composerItems.forEach((item) => {
+		for (const item of composerItems) {
 			if (item.data && Array.isArray(item.data) && item.data.length > 0) {
 				const meta = CHART_TYPES[item.type]
 				const displayName = item.protocol ? getProtocolInfo(item.protocol)?.name || item.protocol : item.chain || ''
@@ -81,7 +81,7 @@ export function CombinedChartPreview({ composerItems }: CombinedChartPreviewProp
 					colorIndex++
 				}
 			}
-		})
+		}
 
 		const symbol = result.length > 0 && allPercentMetrics ? '%' : hasNonMonetaryMetrics ? '' : '$'
 

--- a/src/containers/ProDashboard/components/AddChartModal/StablecoinsChartTab.tsx
+++ b/src/containers/ProDashboard/components/AddChartModal/StablecoinsChartTab.tsx
@@ -96,14 +96,14 @@ export function StablecoinsChartTab({
 
 	const chainOptions: VirtualizedSelectOption[] = useMemo(() => {
 		const options: VirtualizedSelectOption[] = [{ value: 'All', label: 'All Chains', icon: '🌐' }]
-		;(chainsList as StablecoinChainInfo[]).forEach((chain) => {
+		for (const chain of chainsList as StablecoinChainInfo[]) {
 			options.push({
 				value: chain.name,
 				label: chain.name,
 				logo: chainIconUrl(chain.name),
 				description: formattedNum(chain.tvl, true)
 			})
-		})
+		}
 		return options
 	}, [chainsList])
 
@@ -144,9 +144,9 @@ export function StablecoinsChartTab({
 
 	const assetChainColors = useMemo(() => {
 		const colors: Record<string, string> = {}
-		chainsUnique.forEach((chain) => {
+		for (const chain of chainsUnique) {
 			colors[chain] = colorManager.getItemColor(chain, 'chain')
-		})
+		}
 		return colors
 	}, [chainsUnique])
 

--- a/src/containers/ProDashboard/components/AddChartModal/UnifiedChartTab.tsx
+++ b/src/containers/ProDashboard/components/AddChartModal/UnifiedChartTab.tsx
@@ -227,7 +227,9 @@ export const UnifiedChartTab = memo(function UnifiedChartTab({
 	const handleClearSelection = useCallback(() => {
 		if (!selectedChartTypeSingle) return
 		const itemsToRemove = composerItems.filter((item) => item.type === selectedChartTypeSingle)
-		itemsToRemove.forEach((item) => onRemoveFromComposer(item.id))
+		for (const item of itemsToRemove) {
+			onRemoveFromComposer(item.id)
+		}
 	}, [selectedChartTypeSingle, composerItems, onRemoveFromComposer])
 
 	const _instantAvailableChartTypes = useMemo(() => {

--- a/src/containers/ProDashboard/components/AddChartModal/UnifiedTableTab/components/FilterBuilder/index.tsx
+++ b/src/containers/ProDashboard/components/AddChartModal/UnifiedTableTab/components/FilterBuilder/index.tsx
@@ -547,9 +547,9 @@ export function FilterBuilder({ filters, onFiltersChange }: FilterBuilderProps) 
 
 	const totalFiltersAvailable = useMemo(() => {
 		let total = 0
-		filtersByCategory.forEach((categoryFilters) => {
+		for (const categoryFilters of filtersByCategory.values()) {
 			total += categoryFilters.length
-		})
+		}
 		return total
 	}, [filtersByCategory])
 

--- a/src/containers/ProDashboard/components/AddChartModal/UnifiedTableTab/components/FiltersPanel.tsx
+++ b/src/containers/ProDashboard/components/AddChartModal/UnifiedTableTab/components/FiltersPanel.tsx
@@ -86,12 +86,14 @@ export function FiltersPanel({ chains, filters, availableChains, onChainsChange,
 		for (const protocol of protocols as any[]) {
 			const weight = Number(protocol?.tvl) || 0
 			if (Array.isArray(protocol?.oracles)) {
-				protocol.oracles.forEach((oracle: string) => add(oracle, weight))
+				for (const oracle of protocol.oracles) {
+					add(oracle, weight)
+				}
 			}
 			if (protocol?.oraclesByChain) {
-				Object.values(protocol.oraclesByChain as Record<string, string[]>)
-					.flat()
-					.forEach((oracle: string) => add(oracle, weight))
+				for (const oracle of Object.values(protocol.oraclesByChain as Record<string, string[]>).flat()) {
+					add(oracle, weight)
+				}
 			}
 		}
 

--- a/src/containers/ProDashboard/components/AddChartModal/UnifiedTableTab/hooks/usePresetRecommendations.ts
+++ b/src/containers/ProDashboard/components/AddChartModal/UnifiedTableTab/hooks/usePresetRecommendations.ts
@@ -96,19 +96,24 @@ export function usePresetRecommendations({ filters, chains }: UsePresetRecommend
 		addPreset('fees-protocols')
 		addPreset('revenue-protocols')
 
-		combinedCategories.forEach((categoryValue) => {
-			Object.entries(CATEGORY_PRESET_MAP).forEach(([matchKey, presets]) => {
+		for (const categoryValue of combinedCategories) {
+			for (const matchKey in CATEGORY_PRESET_MAP) {
+				const presets = CATEGORY_PRESET_MAP[matchKey]
 				if (categoryValue.includes(matchKey)) {
-					presets.forEach(addPreset)
+					for (const preset of presets) {
+						addPreset(preset)
+					}
 				}
-			})
-		})
-
-		PROTOCOL_KEYWORD_PRESETS.forEach(({ keywords, presets }) => {
-			if (keywords.some((keyword) => normalizedProtocols.some((protocol) => protocol.includes(keyword)))) {
-				presets.forEach(addPreset)
 			}
-		})
+		}
+
+		for (const { keywords, presets } of PROTOCOL_KEYWORD_PRESETS) {
+			if (keywords.some((keyword) => normalizedProtocols.some((protocol) => protocol.includes(keyword)))) {
+				for (const preset of presets) {
+					addPreset(preset)
+				}
+			}
+		}
 
 		if (normalizedCategorySet.has('dex aggregator')) {
 			addPreset('aggregators-protocols')

--- a/src/containers/ProDashboard/components/AddChartModal/UnifiedTableTab/hooks/useUnifiedTableWizard.ts
+++ b/src/containers/ProDashboard/components/AddChartModal/UnifiedTableTab/hooks/useUnifiedTableWizard.ts
@@ -139,9 +139,10 @@ const reducer = (state: WizardState, action: WizardAction): WizardState => {
 				customColumns: state.customColumns
 			})
 			const customColumnIds = getOrderedCustomColumnIds(state.columnOrder, state.customColumns)
-			const customColumnVisibility = Object.fromEntries(
-				customColumnIds.map((id) => [id, state.columnVisibility[id] ?? true])
-			)
+			const customColumnVisibility: Record<string, boolean> = {}
+			for (const id of customColumnIds) {
+				customColumnVisibility[id] = state.columnVisibility[id] ?? true
+			}
 			const nextOrderSet = new Set(sanitized.order)
 			return {
 				...state,

--- a/src/containers/ProDashboard/components/AddChartModal/UnifiedTableTab/index.tsx
+++ b/src/containers/ProDashboard/components/AddChartModal/UnifiedTableTab/index.tsx
@@ -444,15 +444,13 @@ const TabContent = memo(function TabContent({
 	const activeFilterPills: FilterPill[] = useMemo(() => {
 		const pills: FilterPill[] = []
 
-		chains
-			.filter((chain) => chain !== 'All')
-			.forEach((chain) => {
-				pills.push({
-					id: `chain-${chain}`,
-					label: chainLabelMap.get(chain) ?? chain,
-					onRemove: () => handleRemoveChainValue(chain)
-				})
+		for (const chain of chains.filter((chain) => chain !== 'All')) {
+			pills.push({
+				id: `chain-${chain}`,
+				label: chainLabelMap.get(chain) ?? chain,
+				onRemove: () => handleRemoveChainValue(chain)
 			})
+		}
 
 		for (const chip of activeFilterChips) {
 			pills.push({

--- a/src/containers/ProDashboard/components/AddChartModal/YieldsChartTab.tsx
+++ b/src/containers/ProDashboard/components/AddChartModal/YieldsChartTab.tsx
@@ -80,12 +80,12 @@ export function YieldsChartTab({
 
 	const chainOptions = useMemo(() => {
 		const chainTvlMap = new Map<string, number>()
-		yieldsData.forEach((p: any) => {
+		for (const p of yieldsData as any[]) {
 			const chain = p.chains[0]
-			if (!chain) return
+			if (!chain) continue
 			const currentTvl = chainTvlMap.get(chain) || 0
 			chainTvlMap.set(chain, currentTvl + (p.tvl || 0))
-		})
+		}
 		return Array.from(chainTvlMap.entries())
 			.sort((a, b) => b[1] - a[1])
 			.map(([chain]) => ({ value: chain, label: chain }))
@@ -93,12 +93,12 @@ export function YieldsChartTab({
 
 	const projectOptions = useMemo(() => {
 		const projectTvlMap = new Map<string, number>()
-		yieldsData.forEach((p: any) => {
+		for (const p of yieldsData as any[]) {
 			const project = p.project
-			if (!project) return
+			if (!project) continue
 			const currentTvl = projectTvlMap.get(project) || 0
 			projectTvlMap.set(project, currentTvl + (p.tvl || 0))
-		})
+		}
 		return Array.from(projectTvlMap.entries())
 			.sort((a, b) => b[1] - a[1])
 			.map(([project]) => ({ value: project, label: project }))
@@ -114,20 +114,20 @@ export function YieldsChartTab({
 
 	const tokenOptions = useMemo(() => {
 		const tokenTvlMap = new Map<string, number>()
-		yieldsData.forEach((p: any) => {
+		for (const p of yieldsData as any[]) {
 			const symbol = (p.pool || '') as string
 			const baseSymbol = symbol.split('(')[0]
-			baseSymbol
+			const tokens = baseSymbol
 				.split('-')
 				.map((token: string) => token.trim())
 				.filter(Boolean)
-				.forEach((token: string) => {
-					const normalized = token.toUpperCase()
-					if (!normalized) return
-					const current = tokenTvlMap.get(normalized) || 0
-					tokenTvlMap.set(normalized, current + (p.tvl || 0))
-				})
-		})
+			for (const token of tokens) {
+				const normalized = token.toUpperCase()
+				if (!normalized) continue
+				const current = tokenTvlMap.get(normalized) || 0
+				tokenTvlMap.set(normalized, current + (p.tvl || 0))
+			}
+		}
 
 		const baseOptions = [
 			{ value: 'ALL_BITCOINS', label: 'All Bitcoins' },

--- a/src/containers/ProDashboard/components/AddChartModal/useModalActions.ts
+++ b/src/containers/ProDashboard/components/AddChartModal/useModalActions.ts
@@ -621,26 +621,26 @@ export function useModalActions(
 					if (state.chartCreationMode === 'combined') {
 						handleAddMultiChart(state.composerItems, state.unifiedChartName.trim() || undefined)
 					} else {
-						state.composerItems.forEach((item) => {
+						for (const item of state.composerItems) {
 							if (item.chain) {
 								handleAddChart(item.chain, item.type, 'chain', item.geckoId, item.color)
 							} else if (item.protocol) {
 								handleAddChart(item.protocol, item.type, 'protocol', item.geckoId, item.color)
 							}
-						})
+						}
 					}
 				} else if (state.chartCreationMode === 'separate' && state.selectedChartTypes.length > 0) {
 					if (state.selectedChain) {
 						const chain = chains.find((c: Chain) => c.name === state.selectedChain)
-						state.selectedChartTypes.forEach((chartType) => {
+						for (const chartType of state.selectedChartTypes) {
 							const geckoId = ['chainMcap', 'chainPrice'].includes(chartType) ? chain?.gecko_id : undefined
 							handleAddChart(state.selectedChain, chartType, 'chain', geckoId)
-						})
+						}
 					} else if (state.selectedProtocol) {
 						const protocol = protocols.find((p: Protocol) => p.slug === state.selectedProtocol)
-						state.selectedChartTypes.forEach((chartType) => {
+						for (const chartType of state.selectedChartTypes) {
 							handleAddChart(state.selectedProtocol, chartType, 'protocol', protocol?.geckoId)
-						})
+						}
 					}
 				}
 			} else if (state.selectedMainTab === 'table') {

--- a/src/containers/ProDashboard/components/ChartBuilderCard.tsx
+++ b/src/containers/ProDashboard/components/ChartBuilderCard.tsx
@@ -232,7 +232,7 @@ export function ChartBuilderCard({ builder }: ChartBuilderCardProps) {
 			processedSeries = chartData.series.map((s: any) => {
 				const aggregatedData: Map<number, { value: number; lastTimestamp: number }> = new Map()
 
-				s.data.forEach(([timestamp, value]: [number, number]) => {
+				for (const [timestamp, value] of s.data as [number, number][]) {
 					const date = new Date(timestamp * 1000)
 					let groupKey: number
 
@@ -269,7 +269,7 @@ export function ChartBuilderCard({ builder }: ChartBuilderCardProps) {
 							lastTimestamp
 						})
 					}
-				})
+				}
 
 				return {
 					...s,
@@ -293,11 +293,11 @@ export function ChartBuilderCard({ builder }: ChartBuilderCardProps) {
 
 		if (config.displayAs === 'percentage') {
 			const timestampTotals = new Map<number, number>()
-			processedSeries.forEach((s: any) => {
-				s.data.forEach(([timestamp, value]: [number, number]) => {
+			for (const s of processedSeries) {
+				for (const [timestamp, value] of s.data as [number, number][]) {
 					timestampTotals.set(timestamp, (timestampTotals.get(timestamp) || 0) + value)
-				})
-			})
+				}
+			}
 
 			return processedSeries.map((s: any) => ({
 				name: s.name,
@@ -376,19 +376,21 @@ export function ChartBuilderCard({ builder }: ChartBuilderCardProps) {
 		if (!chartSeries || chartSeries.length === 0) return
 
 		const timestampSet = new Set<number>()
-		chartSeries.forEach((s: any) => {
-			s.data.forEach(([timestamp]: [number, number]) => timestampSet.add(timestamp))
-		})
+		for (const s of chartSeries) {
+			for (const [timestamp] of s.data as [number, number][]) {
+				timestampSet.add(timestamp)
+			}
+		}
 		const timestamps = Array.from(timestampSet).sort((a, b) => a - b)
 
 		const headers = ['Date', ...chartSeries.map((s: any) => s.name)]
 
 		const rows = timestamps.map((timestamp) => {
 			const row = [new Date(timestamp * 1000).toLocaleDateString()]
-			chartSeries.forEach((s: any) => {
+			for (const s of chartSeries) {
 				const dataPoint = s.data.find(([t]: [number, number]) => t === timestamp)
 				row.push(dataPoint ? dataPoint[1].toString() : '0')
-			})
+			}
 			return row
 		})
 

--- a/src/containers/ProDashboard/components/ComparisonWizard/steps/SelectItemsStep.tsx
+++ b/src/containers/ProDashboard/components/ComparisonWizard/steps/SelectItemsStep.tsx
@@ -74,7 +74,7 @@ export function SelectItemsStep() {
 		const parentsOrSolo: typeof protocols = []
 		const parentIdToSlug = new Map<string, string>()
 
-		protocols.forEach((protocol) => {
+		for (const protocol of protocols) {
 			if (protocol.parentProtocol) {
 				const existing = childrenByParentId.get(protocol.parentProtocol) || []
 				childrenByParentId.set(protocol.parentProtocol, [...existing, protocol])
@@ -82,7 +82,7 @@ export function SelectItemsStep() {
 				parentsOrSolo.push(protocol)
 				parentIdToSlug.set(protocol.id, protocol.slug)
 			}
-		})
+		}
 
 		parentsOrSolo.sort((a, b) => (b.tvl || 0) - (a.tvl || 0))
 
@@ -114,11 +114,11 @@ export function SelectItemsStep() {
 
 	const protocolCategoryOptions = useMemo(() => {
 		const categoriesSet = new Set<string>()
-		protocols.forEach((protocol) => {
+		for (const protocol of protocols) {
 			if (protocol.category) {
 				categoriesSet.add(protocol.category)
 			}
-		})
+		}
 		return Array.from(categoriesSet)
 			.sort()
 			.map((cat) => ({ value: cat, label: cat }))

--- a/src/containers/ProDashboard/components/DashboardCard.tsx
+++ b/src/containers/ProDashboard/components/DashboardCard.tsx
@@ -30,9 +30,9 @@ export function DashboardCard({ dashboard, onTagClick, onDelete, viewMode = 'gri
 
 	const itemTypes = useMemo(() => {
 		const counts: Record<string, number> = {}
-		dashboard.data.items?.forEach((item: DashboardItemConfig) => {
+		for (const item of dashboard.data.items ?? []) {
 			if (!item || typeof item !== 'object') {
-				return
+				continue
 			}
 
 			switch (item.kind) {
@@ -52,7 +52,7 @@ export function DashboardCard({ dashboard, onTagClick, onDelete, viewMode = 'gri
 					const otherItem = item as DashboardItemConfig
 					counts[otherItem.kind] = (counts[otherItem.kind] || 0) + 1
 			}
-		})
+		}
 
 		const sorted = Object.entries(counts)
 			.sort(([, a], [, b]) => b - a)

--- a/src/containers/ProDashboard/components/MultiChartCard.tsx
+++ b/src/containers/ProDashboard/components/MultiChartCard.tsx
@@ -93,21 +93,21 @@ const MultiChartCard = memo(function MultiChartCard({ multi }: MultiChartCardPro
 			}
 		}
 
-		for (const item in Object.fromEntries(color_uniqueItemIdsPerProtocol)) {
-			if (color_uniqueItemIdsPerProtocol.get(item)?.length > 1) {
-				;(color_uniqueItemIdsPerProtocol.get(item) || []).forEach((id) => {
+		for (const [item, ids] of color_uniqueItemIdsPerProtocol) {
+			if (ids.length > 1) {
+				for (const id of ids) {
 					color_uniqueItemIds.add(id)
-				})
+				}
 			} else {
 				color_uniqueItemIds.add(item)
 			}
 		}
 
-		for (const item in Object.fromEntries(color_uniqueItemIdsPerChain)) {
-			if (color_uniqueItemIdsPerChain.get(item)?.length > 1) {
-				;(color_uniqueItemIdsPerChain.get(item) || []).forEach((id) => {
+		for (const [item, ids] of color_uniqueItemIdsPerChain) {
+			if (ids.length > 1) {
+				for (const id of ids) {
 					color_uniqueItemIds.add(id)
-				})
+				}
 			} else {
 				color_uniqueItemIds.add(item)
 			}
@@ -217,9 +217,11 @@ const MultiChartCard = memo(function MultiChartCard({ multi }: MultiChartCardPro
 
 		if ((allBarType || allAreaType) && showStacked && !showCumulative && !showPercentage) {
 			const allTimestamps = new Set<number>()
-			processedSeries.forEach((serie) => {
-				serie.data.forEach(([timestamp]) => allTimestamps.add(timestamp))
-			})
+			for (const serie of processedSeries) {
+				for (const [timestamp] of serie.data) {
+					allTimestamps.add(timestamp)
+				}
+			}
 
 			const sortedTimestamps = Array.from(allTimestamps).sort((a, b) => a - b)
 
@@ -250,23 +252,25 @@ const MultiChartCard = memo(function MultiChartCard({ multi }: MultiChartCardPro
 		}
 
 		const allTimestamps = new Set<number>()
-		processedSeries.forEach((serie) => {
-			serie.data.forEach(([timestamp]) => allTimestamps.add(timestamp))
-		})
+		for (const serie of processedSeries) {
+			for (const [timestamp] of serie.data) {
+				allTimestamps.add(timestamp)
+			}
+		}
 
 		const sortedTimestamps = Array.from(allTimestamps).sort((a, b) => a - b)
 
 		const totals = new Map<number, number>()
-		sortedTimestamps.forEach((timestamp) => {
+		for (const timestamp of sortedTimestamps) {
 			let total = 0
-			processedSeries.forEach((serie) => {
+			for (const serie of processedSeries) {
 				const dataPoint = serie.data.find(([t]) => t === timestamp)
 				if (dataPoint) {
 					total += dataPoint[1]
 				}
-			})
+			}
 			totals.set(timestamp, total)
-		})
+		}
 
 		const percentageColors = [
 			'#FF6B6B',
@@ -322,19 +326,21 @@ const MultiChartCard = memo(function MultiChartCard({ multi }: MultiChartCardPro
 		if (!series || series.length === 0) return
 
 		const timestampSet = new Set<number>()
-		series.forEach((s) => {
-			s.data.forEach(([timestamp]) => timestampSet.add(timestamp))
-		})
+		for (const s of series) {
+			for (const [timestamp] of s.data) {
+				timestampSet.add(timestamp)
+			}
+		}
 		const timestamps = Array.from(timestampSet).sort((a, b) => a - b)
 
 		const headers = ['Date', ...series.map((s) => s.name)]
 
 		const rows = timestamps.map((timestamp) => {
 			const row = [new Date(timestamp * 1000).toLocaleDateString()]
-			series.forEach((s) => {
+			for (const s of series) {
 				const dataPoint = s.data.find(([t]) => t === timestamp)
 				row.push(dataPoint ? dataPoint[1].toString() : '0')
-			})
+			}
 			return row
 		})
 

--- a/src/containers/ProDashboard/components/ProTable/CustomColumnPanel.tsx
+++ b/src/containers/ProDashboard/components/ProTable/CustomColumnPanel.tsx
@@ -133,7 +133,7 @@ export function CustomColumnPanel({
 	// Sample data for live preview
 	const sampleData = React.useMemo(() => {
 		const sample: Record<string, number> = {}
-		availableVariables.forEach((variable) => {
+		for (const variable of availableVariables) {
 			// Create realistic sample data
 			switch (variable.key) {
 				case 'tvl':
@@ -180,7 +180,7 @@ export function CustomColumnPanel({
 						sample[variable.key] = Math.floor(Math.random() * 1000000) // Default up to 1M
 					}
 			}
-		})
+		}
 		return sample
 	}, [availableVariables])
 
@@ -195,9 +195,9 @@ export function CustomColumnPanel({
 
 			// Test with dummy data to catch variable issues
 			const testData: Record<string, number> = {}
-			availableVariables.forEach((variable) => {
+			for (const variable of availableVariables) {
 				testData[variable.key] = 100
-			})
+			}
 
 			expr.evaluate(testData)
 			return { isValid: true }

--- a/src/containers/ProDashboard/components/ProTable/ProtocolFilterModal.tsx
+++ b/src/containers/ProDashboard/components/ProTable/ProtocolFilterModal.tsx
@@ -138,18 +138,20 @@ export function ProtocolFilterModal({
 
 	const oracleOptions = React.useMemo(() => {
 		const tvsByOracle = new Map<string, number>()
-		;(protocols as any[]).forEach((p) => {
+		for (const p of protocols as any[]) {
 			const tvl = Number((p as any).tvl) || 0
 			const add = (o: string) => tvsByOracle.set(o, (tvsByOracle.get(o) || 0) + tvl)
 			if (Array.isArray((p as any).oracles)) {
-				;((p as any).oracles as string[]).forEach(add)
+				for (const o of (p as any).oracles as string[]) {
+					add(o)
+				}
 			}
 			if ((p as any).oraclesByChain) {
-				Object.values((p as any).oraclesByChain as Record<string, string[]>)
-					.flat()
-					.forEach(add)
+				for (const o of Object.values((p as any).oraclesByChain as Record<string, string[]>).flat()) {
+					add(o)
+				}
 			}
-		})
+		}
 		return Array.from(tvsByOracle.entries())
 			.sort((a, b) => b[1] - a[1])
 			.map(([o]) => ({ value: o, label: o }))
@@ -287,9 +289,13 @@ export function ProtocolFilterModal({
 										if (children && children.length > 0) {
 											const allSelected = children.every((c) => current.has(c))
 											if (allSelected) {
-												children.forEach((c) => current.delete(c))
+												for (const c of children) {
+													current.delete(c)
+												}
 											} else {
-												children.forEach((c) => current.add(c))
+												for (const c of children) {
+													current.add(c)
+												}
 											}
 										} else {
 											current.add(opt.value)

--- a/src/containers/ProDashboard/components/ProTable/useProTable.tsx
+++ b/src/containers/ProDashboard/components/ProTable/useProTable.tsx
@@ -80,7 +80,7 @@ function recalculateParentMetrics(parent: any, filteredSubRows: any[]) {
 	let totalPerpsVolumeWeight = 0
 
 	// Aggregate metrics from filtered children
-	filteredSubRows.forEach((child) => {
+	for (const child of filteredSubRows) {
 		if (child.tvl != null) tvl += child.tvl
 		if (child.tvlPrevDay != null) tvlPrevDay += child.tvlPrevDay
 		if (child.tvlPrevWeek != null) tvlPrevWeek += child.tvlPrevWeek
@@ -114,7 +114,7 @@ function recalculateParentMetrics(parent: any, filteredSubRows: any[]) {
 			totalPerpsVolumeWeight += child.perps_volume_7d
 		}
 		if (child.openInterest != null) openInterest += child.openInterest
-	})
+	}
 
 	const change_1d = getPercentChange(tvl, tvlPrevDay)
 	const change_7d = getPercentChange(tvl, tvlPrevWeek)
@@ -140,21 +140,23 @@ function recalculateParentMetrics(parent: any, filteredSubRows: any[]) {
 	const oraclesByChainAgg: Record<string, Set<string>> = {}
 	const addOracles = (obj: any) => {
 		if (Array.isArray(obj?.oracles)) {
-			obj.oracles.forEach((o: string) => oracleSet.add(o))
+			for (const o of obj.oracles as string[]) oracleSet.add(o)
 		}
 		if (obj?.oraclesByChain) {
 			for (const k of Object.keys(obj.oraclesByChain as Record<string, string[]>)) {
 				const set = (oraclesByChainAgg[k] = oraclesByChainAgg[k] || new Set<string>())
-				;(obj.oraclesByChain[k] || []).forEach((o: string) => set.add(o))
+				;for (const o of (obj.oraclesByChain[k] || []) as string[]) set.add(o)
 			}
 		}
 	}
 	addOracles(parent)
-	filteredSubRows.forEach(addOracles)
+	for (const subRow of filteredSubRows) addOracles(subRow)
 
-	const aggregatedOraclesByChain = Object.fromEntries(
-		Object.entries(oraclesByChainAgg).map(([k, v]) => [k, Array.from(v).sort((a, b) => a.localeCompare(b))])
-	)
+	const aggregatedOraclesByChain: Record<string, string[]> = {}
+	for (const k in oraclesByChainAgg) {
+		const v = oraclesByChainAgg[k]
+		aggregatedOraclesByChain[k] = Array.from(v).sort((a, b) => a.localeCompare(b))
+	}
 
 	return {
 		...parent,
@@ -422,7 +424,7 @@ export function useProTable(
 						try {
 							const context: Record<string, number> = {}
 
-							protocolsByChainTableColumns.forEach((tableCol) => {
+							for (const tableCol of protocolsByChainTableColumns) {
 								const value = row[tableCol.key as keyof IProtocolRow]
 								if (typeof value === 'number') {
 									context[tableCol.key] = value
@@ -432,7 +434,7 @@ export function useProTable(
 										context[tableCol.key] = numValue
 									}
 								}
-							})
+							}
 
 							const expr = parser.parse(customCol.expression)
 							const result = expr.evaluate(context)
@@ -585,18 +587,18 @@ export function useProTable(
 			'options_volume_30d'
 		]
 
-		usdMetrics.forEach((metric) => {
+		for (const metric of usdMetrics) {
 			sums[metric] = 0
-		})
+		}
 
-		finalProtocolsList.forEach((protocol) => {
-			usdMetrics.forEach((metric) => {
+		for (const protocol of finalProtocolsList) {
+			for (const metric of usdMetrics) {
 				const value = protocol[metric as keyof IProtocolRow]
 				if (typeof value === 'number' && value > 0) {
 					sums[metric] += value
 				}
-			})
-		})
+			}
+		}
 
 		return sums
 	}, [finalProtocolsList])
@@ -1250,11 +1252,11 @@ export function useProTable(
 	const categories = React.useMemo(() => {
 		if (!fullProtocolsList) return []
 		const uniqueCategories = new Set<string>()
-		fullProtocolsList.forEach((protocol: any) => {
+		for (const protocol of fullProtocolsList as any[]) {
 			if (protocol.category) {
 				uniqueCategories.add(protocol.category)
 			}
-		})
+		}
 		return Array.from(uniqueCategories).sort()
 	}, [fullProtocolsList])
 

--- a/src/containers/ProDashboard/components/StablecoinAssetChartCard.tsx
+++ b/src/containers/ProDashboard/components/StablecoinAssetChartCard.tsx
@@ -57,9 +57,9 @@ export function StablecoinAssetChartCard({ config }: StablecoinAssetChartCardPro
 
 	const chainColors = useMemo(() => {
 		const colors: Record<string, string> = {}
-		chainsUnique.forEach((chain) => {
+		for (const chain of chainsUnique) {
 			colors[chain] = colorManager.getItemColor(chain, 'chain')
-		})
+		}
 		return colors
 	}, [chainsUnique])
 

--- a/src/containers/ProDashboard/components/UnifiedTable/config/ColumnRegistry.tsx
+++ b/src/containers/ProDashboard/components/UnifiedTable/config/ColumnRegistry.tsx
@@ -644,10 +644,10 @@ export const getUnifiedTableColumns = (customColumns?: CustomColumnDefinition[])
 
 	const columnsByGroup = new Map<MetricGroup, ColumnDef<NormalizedRow>[]>()
 
-	allColumns.forEach((col) => {
+	for (const col of allColumns) {
 		const columnId = String(col.id)
 		const dictEntry = COLUMN_DICTIONARY_BY_ID.get(columnId)
-		if (!dictEntry || dictEntry.group === 'meta') return
+		if (!dictEntry || dictEntry.group === 'meta') continue
 
 		const group = dictEntry.group as MetricGroup
 
@@ -655,7 +655,7 @@ export const getUnifiedTableColumns = (customColumns?: CustomColumnDefinition[])
 			columnsByGroup.set(group, [])
 		}
 		columnsByGroup.get(group)!.push(col)
-	})
+	}
 
 	const groupedColumns: ColumnDef<NormalizedRow>[] = []
 

--- a/src/containers/ProDashboard/components/UnifiedTable/config/metricCapabilities.ts
+++ b/src/containers/ProDashboard/components/UnifiedTable/config/metricCapabilities.ts
@@ -40,7 +40,13 @@ export function pruneVisibility(
 	validCustomColumnIds?: Set<string>
 ): VisibilityState {
 	if (!visibility) return {}
-	return Object.fromEntries(Object.entries(visibility).filter(([key]) => isColumnSupported(key, validCustomColumnIds)))
+	const result: VisibilityState = {}
+	for (const key in visibility) {
+		if (isColumnSupported(key, validCustomColumnIds)) {
+			result[key] = visibility[key]
+		}
+	}
+	return result
 }
 
 export function sanitizeSorting(sorting: SortingState | undefined, validCustomColumnIds?: Set<string>): SortingState {

--- a/src/containers/ProDashboard/components/UnifiedTable/core/groupingUtils.ts
+++ b/src/containers/ProDashboard/components/UnifiedTable/core/groupingUtils.ts
@@ -117,7 +117,9 @@ const getAggregatedChains = (rows: NormalizedRow[]): string[] => {
 	const set = new Set<string>()
 	for (const row of rows) {
 		if (row.chains?.length) {
-			row.chains.forEach((chain) => set.add(chain))
+			for (const chain of row.chains) {
+				set.add(chain)
+			}
 		} else if (row.chain) {
 			set.add(row.chain)
 		}
@@ -129,7 +131,9 @@ const getAggregatedOracles = (rows: NormalizedRow[]): string[] => {
 	const set = new Set<string>()
 	for (const row of rows) {
 		if (row.oracles?.length) {
-			row.oracles.forEach((oracle) => set.add(oracle))
+			for (const oracle of row.oracles) {
+				set.add(oracle)
+			}
 		}
 	}
 	return Array.from(set)

--- a/src/containers/ProDashboard/components/UnifiedTable/core/useUnifiedTable.ts
+++ b/src/containers/ProDashboard/components/UnifiedTable/core/useUnifiedTable.ts
@@ -50,10 +50,14 @@ type UnifiedTableApiResponse = {
 const buildQueryString = (config: UnifiedTableConfig, rowHeaders: UnifiedRowHeaderType[]): string => {
 	const params = new URLSearchParams()
 
-	rowHeaders.forEach((header) => params.append('rowHeaders[]', header))
+	for (const header of rowHeaders) {
+		params.append('rowHeaders[]', header)
+	}
 
 	if (config.params?.chains) {
-		config.params.chains.forEach((chain) => params.append('chains[]', chain))
+		for (const chain of config.params.chains) {
+			params.append('chains[]', chain)
+		}
 	}
 
 	return params.toString()

--- a/src/containers/ProDashboard/components/UnifiedTable/index.tsx
+++ b/src/containers/ProDashboard/components/UnifiedTable/index.tsx
@@ -109,27 +109,38 @@ const rowHeadersMatch = (a: UnifiedRowHeaderType[], b: UnifiedRowHeaderType[]) =
 }
 
 const sanitizeFilters = (filters: TableFilters): TableFilters | undefined => {
-	const entries = Object.entries(filters).filter(([, value]) => {
+	const result: Record<string, unknown> = {}
+	for (const key in filters) {
+		const value = filters[key]
 		if (value === undefined || value === null) {
-			return false
+			continue
 		}
 		if (typeof value === 'boolean') {
-			return value === true
+			if (value === true) {
+				result[key] = value
+			}
+			continue
 		}
 		if (typeof value === 'string') {
-			return value.trim().length > 0
+			if (value.trim().length > 0) {
+				result[key] = value
+			}
+			continue
 		}
 		if (Array.isArray(value)) {
-			return value.length > 0
+			if (value.length > 0) {
+				result[key] = value
+			}
+			continue
 		}
-		return true
-	})
+		result[key] = value
+	}
 
-	if (!entries.length) {
+	if (!Object.keys(result).length) {
 		return undefined
 	}
 
-	return Object.fromEntries(entries) as TableFilters
+	return result as TableFilters
 }
 
 const metricFromColumn = (columnId: string) => columnId

--- a/src/containers/ProDashboard/components/UnifiedTable/utils/customColumns.tsx
+++ b/src/containers/ProDashboard/components/UnifiedTable/utils/customColumns.tsx
@@ -154,7 +154,8 @@ export function evaluateExpression(expression: string, metrics: NumericMetrics):
 		}
 
 		const context: Record<string, number> = {}
-		for (const [key, value] of Object.entries(metrics)) {
+		for (const key in metrics) {
+			const value = metrics[key as keyof NumericMetrics]
 			if (typeof value === 'number' && !Number.isNaN(value)) {
 				context[key] = value
 			}

--- a/src/containers/ProDashboard/components/UnifiedTable/utils/dataFilters.ts
+++ b/src/containers/ProDashboard/components/UnifiedTable/utils/dataFilters.ts
@@ -157,11 +157,11 @@ export function filterRowsByConfig(rows: NormalizedRow[], filters?: TableFilters
 		}
 	]
 
-	numericRangeFilters.forEach(({ minKey, maxKey, getValue }) => {
+	for (const { minKey, maxKey, getValue } of numericRangeFilters) {
 		const minValue = minKey ? (filters[minKey] as number | undefined) : undefined
 		const maxValue = maxKey ? (filters[maxKey] as number | undefined) : undefined
 		if (minValue === undefined && maxValue === undefined) {
-			return
+			continue
 		}
 		filtered = filtered.filter((row) => {
 			const value = getValue(row)
@@ -173,7 +173,7 @@ export function filterRowsByConfig(rows: NormalizedRow[], filters?: TableFilters
 			}
 			return true
 		})
-	})
+	}
 
 	if (filters.hasPerps) {
 		filtered = filtered.filter((row) => (row.metrics.perpsVolume24h ?? 0) > 0)

--- a/src/containers/ProDashboard/components/datasets/BridgeAggregatorsDataset/index.tsx
+++ b/src/containers/ProDashboard/components/datasets/BridgeAggregatorsDataset/index.tsx
@@ -64,11 +64,11 @@ export function BridgeAggregatorsDataset({ chains }: { chains?: string[] }) {
 
 	React.useEffect(() => {
 		const columnSizes = {}
-		bridgeAggregatorsDatasetColumns.forEach((column) => {
+		for (const column of bridgeAggregatorsDatasetColumns) {
 			if (column.size) {
 				columnSizes[column.id as string] = column.size
 			}
-		})
+		}
 		instance.setColumnSizing(columnSizes)
 	}, [instance])
 

--- a/src/containers/ProDashboard/components/datasets/ChainsDataset/ColumnManagementPanel.tsx
+++ b/src/containers/ProDashboard/components/datasets/ChainsDataset/ColumnManagementPanel.tsx
@@ -75,11 +75,11 @@ export function ColumnManagementPanel({
 				<div className="flex items-center gap-2">
 					<button
 						onClick={() => {
-							columns.forEach((col) => {
+							for (const col of columns) {
 								if (columnVisibility[col.id] === false) {
 									toggleColumnVisibility(col.id)
 								}
-							})
+							}
 						}}
 						className="pro-divider pro-hover-bg pro-text2 pro-bg2 rounded-md border px-2 py-1 text-xs transition-colors"
 					>
@@ -87,11 +87,11 @@ export function ColumnManagementPanel({
 					</button>
 					<button
 						onClick={() => {
-							columns.forEach((col) => {
+							for (const col of columns) {
 								if (col.id !== 'name' && columnVisibility[col.id] !== false) {
 									toggleColumnVisibility(col.id)
 								}
-							})
+							}
 						}}
 						className="pro-divider pro-hover-bg pro-text2 pro-bg2 rounded-md border px-2 py-1 text-xs transition-colors"
 					>

--- a/src/containers/ProDashboard/components/datasets/ChainsDataset/index.tsx
+++ b/src/containers/ProDashboard/components/datasets/ChainsDataset/index.tsx
@@ -58,19 +58,19 @@ export function ChainsDataset({
 		const sums: Record<string, number> = {}
 		const metrics = ['tvl', 'stablesMcap', 'totalVolume24h', 'totalFees24h', 'totalAppRevenue24h', 'nftVolume']
 
-		metrics.forEach((metric) => {
+		for (const metric of metrics) {
 			sums[metric] = 0
-		})
+		}
 
 		if (data && Array.isArray(data)) {
-			data.forEach((chain) => {
-				metrics.forEach((metric) => {
+			for (const chain of data) {
+				for (const metric of metrics) {
 					const value = chain[metric]
 					if (typeof value === 'number' && value > 0) {
 						sums[metric] += value
 					}
-				})
-			})
+				}
+			}
 		}
 
 		return sums
@@ -213,9 +213,9 @@ export function ChainsDataset({
 				const allColumns = instance.getAllColumns()
 				const newVisibility: Record<string, boolean> = {}
 
-				allColumns.forEach((column) => {
+				for (const column of allColumns) {
 					newVisibility[column.id] = presetColumns.includes(column.id)
-				})
+				}
 
 				instance.setColumnVisibility(newVisibility)
 				instance.setColumnOrder(presetColumns)
@@ -315,9 +315,9 @@ export function ChainsDataset({
 			if (presetColumns) {
 				const allColumns = instance.getAllColumns()
 				const newVisibility: Record<string, boolean> = {}
-				allColumns.forEach((column) => {
+				for (const column of allColumns) {
 					newVisibility[column.id] = presetColumns.includes(column.id)
-				})
+				}
 				setColumnVisibility(newVisibility)
 				setColumnOrder(presetColumns)
 				instance.setColumnVisibility(newVisibility)

--- a/src/containers/ProDashboard/components/datasets/EarningsDataset/index.tsx
+++ b/src/containers/ProDashboard/components/datasets/EarningsDataset/index.tsx
@@ -57,11 +57,11 @@ export function EarningsDataset({ chains, tableId, filters }: EarningsDatasetPro
 	const availableCategories = React.useMemo(() => {
 		if (!data || data.length === 0) return [] as string[]
 		const unique = new Set<string>()
-		data.forEach((row: any) => {
+		for (const row of data) {
 			if (row?.category) {
 				unique.add(row.category)
 			}
-		})
+		}
 		return Array.from(unique).sort((a, b) => a.localeCompare(b))
 	}, [data])
 

--- a/src/containers/ProDashboard/components/datasets/HoldersRevenueDataset/index.tsx
+++ b/src/containers/ProDashboard/components/datasets/HoldersRevenueDataset/index.tsx
@@ -56,11 +56,11 @@ export function HoldersRevenueDataset({ chains, tableId, filters }: HoldersReven
 	const availableCategories = React.useMemo(() => {
 		if (!data || data.length === 0) return [] as string[]
 		const unique = new Set<string>()
-		data.forEach((row: any) => {
+		for (const row of data) {
 			if (row?.category) {
 				unique.add(row.category)
 			}
-		})
+		}
 		return Array.from(unique).sort((a, b) => a.localeCompare(b))
 	}, [data])
 

--- a/src/containers/ProDashboard/components/datasets/RevenueDataset/index.tsx
+++ b/src/containers/ProDashboard/components/datasets/RevenueDataset/index.tsx
@@ -57,11 +57,11 @@ export function RevenueDataset({ chains, tableId, filters }: RevenueDatasetProps
 	const availableCategories = React.useMemo(() => {
 		if (!data || data.length === 0) return [] as string[]
 		const unique = new Set<string>()
-		data.forEach((row: any) => {
+		for (const row of data) {
 			if (row?.category) {
 				unique.add(row.category)
 			}
-		})
+		}
 		return Array.from(unique).sort((a, b) => a.localeCompare(b))
 	}, [data])
 

--- a/src/containers/ProDashboard/components/datasets/StablecoinAssetDataset/useStablecoinAssetChartData.ts
+++ b/src/containers/ProDashboard/components/datasets/StablecoinAssetDataset/useStablecoinAssetChartData.ts
@@ -101,20 +101,23 @@ export function useStablecoinAssetChartData(stablecoinSlug: string): UseStableco
 		if (stackedDataset.length === 0) return []
 
 		const daySum: Record<string, number> = {}
-		stackedDataset.forEach(([date, values]: [string, any]) => {
+		for (const entry of stackedDataset as [string, any][]) {
+			const date = entry[0]
+			const values = entry[1]
 			let totalDaySum = 0
-			Object.values(values).forEach((chainCirculating: any) => {
+			for (const chainCirculating of Object.values(values) as any[]) {
 				totalDaySum += chainCirculating?.circulating || 0
-			})
+			}
 			daySum[date] = totalDaySum
-		})
+		}
 
 		return stackedDataset.map(([date, values]: [string, any]) => {
 			const shares: Record<string, number> = {}
-			Object.entries(values).forEach(([name, chainCirculating]: [string, any]) => {
+			for (const name in values) {
+				const chainCirculating = values[name] as any
 				const circulating = chainCirculating?.circulating || 0
 				shares[name] = getDominancePercent(circulating, daySum[date]) || 0
-			})
+			}
 			return { date, ...shares }
 		})
 	}, [chartData.stackedDataset])

--- a/src/containers/ProDashboard/components/datasets/StablecoinsDataset/useStablecoinsChartData.ts
+++ b/src/containers/ProDashboard/components/datasets/StablecoinsDataset/useStablecoinsChartData.ts
@@ -63,9 +63,9 @@ export function useStablecoinsChartData(chain: string): UseStablecoinsChartDataR
 				return formattedCharts
 			})
 
-			chartDataByPeggedAsset.forEach((chart: any) => {
+			for (const chart of chartDataByPeggedAsset) {
 				const last = chart[chart.length - 1]
-				if (!last) return
+				if (!last) continue
 
 				let lastDate = Number(last.date)
 				while (lastDate < lastTimestamp) {
@@ -75,7 +75,7 @@ export function useStablecoinsChartData(chain: string): UseStablecoinsChartDataR
 						date: lastDate
 					})
 				}
-			})
+			}
 
 			const peggedAssetNames = peggedAssets.map((p: any) => p.name)
 
@@ -89,11 +89,12 @@ export function useStablecoinsChartData(chain: string): UseStablecoinsChartDataR
 			})
 
 			const doublecountedIds: number[] = []
-			peggedAssets.forEach((asset: any, idx: number) => {
+			for (let idx = 0; idx < peggedAssets.length; idx++) {
+				const asset = peggedAssets[idx]
 				if (asset.doublecounted) {
 					doublecountedIds.push(idx)
 				}
-			})
+			}
 
 			return {
 				chartDataByPeggedAsset,
@@ -142,20 +143,23 @@ export function useStablecoinsChartData(chain: string): UseStablecoinsChartDataR
 		if (stackedDataset.length === 0) return []
 
 		const daySum: Record<string, number> = {}
-		stackedDataset.forEach(([date, values]: [string, any]) => {
+		for (const entry of stackedDataset as [string, any][]) {
+			const date = entry[0]
+			const values = entry[1]
 			let totalDaySum = 0
-			Object.values(values).forEach((chainCirculating: any) => {
+			for (const chainCirculating of Object.values(values) as any[]) {
 				totalDaySum += chainCirculating?.circulating || 0
-			})
+			}
 			daySum[date] = totalDaySum
-		})
+		}
 
 		return stackedDataset.map(([date, values]: [string, any]) => {
 			const shares: Record<string, number> = {}
-			Object.entries(values).forEach(([name, chainCirculating]: [string, any]) => {
+			for (const name in values) {
+				const chainCirculating = values[name] as any
 				const circulating = chainCirculating?.circulating || 0
 				shares[name] = getDominancePercent(circulating, daySum[date]) || 0
-			})
+			}
 			return { date, ...shares }
 		})
 	}, [chartData.stackedDataset])

--- a/src/containers/ProDashboard/components/datasets/StablecoinsDataset/useStablecoinsData.ts
+++ b/src/containers/ProDashboard/components/datasets/StablecoinsDataset/useStablecoinsData.ts
@@ -45,9 +45,9 @@ export function useStablecoinsData(chain: string) {
 			})
 
 			// Normalize chart data to same end date
-			chartDataByPeggedAsset.forEach((chart: any) => {
+			for (const chart of chartDataByPeggedAsset) {
 				const last = chart[chart.length - 1]
-				if (!last) return
+				if (!last) continue
 
 				let lastDate = Number(last.date)
 				while (lastDate < lastTimestamp) {
@@ -57,7 +57,7 @@ export function useStablecoinsData(chain: string) {
 						date: lastDate
 					})
 				}
-			})
+			}
 
 			// Format the assets data
 			const filteredPeggedAssets = formatPeggedAssetsData({

--- a/src/containers/ProDashboard/components/datasets/TokenUsageDataset/columns.tsx
+++ b/src/containers/ProDashboard/components/datasets/TokenUsageDataset/columns.tsx
@@ -51,7 +51,7 @@ export const getColumns = (tokenSymbols: string[]): ColumnDef<TokenUsageRow>[] =
 	]
 
 	if (isMultiToken) {
-		tokenSymbols.forEach((symbol) => {
+		for (const symbol of tokenSymbols) {
 			baseColumns.push({
 				header: symbol.toUpperCase(),
 				accessorFn: (row) => row.tokens?.[symbol] || 0,
@@ -67,7 +67,7 @@ export const getColumns = (tokenSymbols: string[]): ColumnDef<TokenUsageRow>[] =
 					align: 'end'
 				}
 			})
-		})
+		}
 	}
 
 	baseColumns.push({

--- a/src/containers/ProDashboard/components/datasets/TokenUsageDataset/index.tsx
+++ b/src/containers/ProDashboard/components/datasets/TokenUsageDataset/index.tsx
@@ -144,20 +144,21 @@ export default function TokenUsageDataset({ config, onConfigChange }: TokenUsage
 		if (tokenSymbols.length <= 1) return null
 
 		const stats: Record<string, { total: number; protocols: number }> = {}
-		tokenSymbols.forEach((symbol) => {
+		for (const symbol of tokenSymbols) {
 			stats[symbol] = { total: 0, protocols: 0 }
-		})
+		}
 
-		rawData.forEach((item) => {
+		for (const item of rawData) {
 			if (item.tokens) {
-				Object.entries(item.tokens).forEach(([symbol, amount]) => {
+				for (const symbol in item.tokens) {
+					const amount = item.tokens[symbol]
 					if (stats[symbol]) {
 						stats[symbol].total += amount
 						stats[symbol].protocols++
 					}
-				})
+				}
 			}
-		})
+		}
 
 		return stats
 	}, [rawData, tokenSymbols])
@@ -193,11 +194,11 @@ export default function TokenUsageDataset({ config, onConfigChange }: TokenUsage
 			shared: 0
 		}
 
-		tokenSymbols.forEach((symbol) => {
+		for (const symbol of tokenSymbols) {
 			overlap[`${symbol}_only`] = 0
-		})
+		}
 
-		rawData.forEach((protocol) => {
+		for (const protocol of rawData) {
 			const usedTokens = tokenSymbols.filter((symbol) => protocol.tokens?.[symbol] && protocol.tokens[symbol] > 0)
 
 			if (usedTokens.length === 1) {
@@ -206,7 +207,7 @@ export default function TokenUsageDataset({ config, onConfigChange }: TokenUsage
 			} else if (usedTokens.length > 1) {
 				overlap.shared++
 			}
-		})
+		}
 
 		return overlap
 	}, [rawData, tokenSymbols])
@@ -216,20 +217,22 @@ export default function TokenUsageDataset({ config, onConfigChange }: TokenUsage
 		const headers = ['Protocol', 'Category']
 
 		if (isMultiToken) {
-			tokenSymbols.forEach((symbol) => headers.push(`${symbol.toUpperCase()} (USD)`))
+			for (const symbol of tokenSymbols) {
+				headers.push(`${symbol.toUpperCase()} (USD)`)
+			}
 		}
 		headers.push('Total Amount (USD)')
 
 		const csvData = table.getRowModel().rows.map((row) => {
-			const data: any = {
+			const data: Record<string, any> = {
 				Protocol: row.original.name,
 				Category: row.original.category || ''
 			}
 
 			if (isMultiToken) {
-				tokenSymbols.forEach((symbol) => {
+				for (const symbol of tokenSymbols) {
 					data[`${symbol.toUpperCase()} (USD)`] = row.original.tokens?.[symbol] || 0
-				})
+				}
 			}
 
 			data['Total Amount (USD)'] = row.original.amountUsd

--- a/src/containers/ProDashboard/components/datasets/TokenUsageDataset/useTokenUsageData.ts
+++ b/src/containers/ProDashboard/components/datasets/TokenUsageDataset/useTokenUsageData.ts
@@ -30,32 +30,34 @@ export function useTokenUsageData(tokenSymbols: string[], includeCex: boolean = 
 
 				const protocolMap = new Map<string, TokenUsageData>()
 
-				results.forEach(({ symbol, data }) => {
-					data?.forEach((p: any) => {
-						const key = p.name
+				for (const { symbol, data } of results) {
+					if (data) {
+						for (const p of data) {
+							const key = p.name
 
-						if (protocolMap.has(key)) {
-							const existing = protocolMap.get(key)!
-							existing.tokens = existing.tokens || {}
-							existing.tokens[symbol] = Object.values(p.amountUsd as Record<string, number>).reduce(
-								(s: number, a: number) => s + a,
-								0
-							)
-							existing.amountUsd += existing.tokens[symbol]
-						} else {
-							const tokenAmount = Object.values(p.amountUsd as Record<string, number>).reduce(
-								(s: number, a: number) => s + a,
-								0
-							)
-							protocolMap.set(key, {
-								...p,
-								amountUsdByChain: p.amountUsd,
-								amountUsd: tokenAmount,
-								tokens: { [symbol]: tokenAmount }
-							})
+							if (protocolMap.has(key)) {
+								const existing = protocolMap.get(key)!
+								existing.tokens = existing.tokens || {}
+								existing.tokens[symbol] = Object.values(p.amountUsd as Record<string, number>).reduce(
+									(s: number, a: number) => s + a,
+									0
+								)
+								existing.amountUsd += existing.tokens[symbol]
+							} else {
+								const tokenAmount = Object.values(p.amountUsd as Record<string, number>).reduce(
+									(s: number, a: number) => s + a,
+									0
+								)
+								protocolMap.set(key, {
+									...p,
+									amountUsdByChain: p.amountUsd,
+									amountUsd: tokenAmount,
+									tokens: { [symbol]: tokenAmount }
+								})
+							}
 						}
-					})
-				})
+					}
+				}
 
 				const processed = Array.from(protocolMap.values())
 

--- a/src/containers/ProDashboard/components/datasets/YieldsDataset/YieldsColumnManagementPanel.tsx
+++ b/src/containers/ProDashboard/components/datasets/YieldsDataset/YieldsColumnManagementPanel.tsx
@@ -165,9 +165,9 @@ export function YieldsColumnManagementPanel({
 				<div className="flex items-center gap-2">
 					<button
 						onClick={() => {
-							Object.keys(yieldsColumnMetadata).forEach((key) => {
+							for (const key in yieldsColumnMetadata) {
 								toggleColumnVisibility(key, true)
-							})
+							}
 						}}
 						className="pro-divider pro-hover-bg pro-text2 pro-bg2 rounded-md border px-2 py-1 text-xs transition-colors"
 					>
@@ -175,9 +175,9 @@ export function YieldsColumnManagementPanel({
 					</button>
 					<button
 						onClick={() => {
-							Object.keys(yieldsColumnMetadata).forEach((key) => {
+							for (const key in yieldsColumnMetadata) {
 								toggleColumnVisibility(key, ['pool', 'project', 'chains', 'tvl'].includes(key))
-							})
+							}
 						}}
 						className="pro-divider pro-hover-bg pro-text2 pro-bg2 rounded-md border px-2 py-1 text-xs transition-colors"
 					>

--- a/src/containers/ProDashboard/components/datasets/YieldsDataset/useYieldsTable.ts
+++ b/src/containers/ProDashboard/components/datasets/YieldsDataset/useYieldsTable.ts
@@ -254,9 +254,9 @@ export function useYieldsTable({
 					})
 					.filter(Boolean)
 
-				allColumnIds.forEach((colId) => {
+				for (const colId of allColumnIds) {
 					newVisibility[colId] = preset.includes(colId)
-				})
+				}
 
 				setColumnVisibility(newVisibility)
 				setColumnOrder(preset)
@@ -277,9 +277,9 @@ export function useYieldsTable({
 		if (!table) return {}
 		const allColumns = table.getAllLeafColumns()
 		const visibility = {}
-		allColumns.forEach((col) => {
+		for (const col of allColumns) {
 			visibility[col.id] = columnVisibility[col.id] !== false
-		})
+		}
 		return visibility
 	}, [table, columnVisibility])
 
@@ -394,9 +394,11 @@ export function useYieldsTable({
 	const availableChains = React.useMemo(() => {
 		if (!data) return []
 		const chainsSet = new Set<string>()
-		data.forEach((row) => {
-			row.chains?.forEach((chain: string) => chainsSet.add(chain))
-		})
+		for (const row of data) {
+			for (const chain of row.chains ?? []) {
+				chainsSet.add(chain)
+			}
+		}
 		return Array.from(chainsSet).sort()
 	}, [data])
 
@@ -404,19 +406,19 @@ export function useYieldsTable({
 		if (!data) return []
 		const tokenTvlMap = new Map<string, number>()
 
-		data.forEach((row) => {
+		for (const row of data) {
 			if (row.pool && row.tvl) {
 				const separators = /[-\s/,+]/
 				const tokens = row.pool.split(separators)
-				tokens.forEach((token: string) => {
+				for (const token of tokens) {
 					const cleaned = token.trim().toUpperCase()
 					if (cleaned && cleaned.length >= 2 && !['LP', 'V2', 'V3', 'POOL', 'VAULT', 'FARM'].includes(cleaned)) {
 						const currentTvl = tokenTvlMap.get(cleaned) || 0
 						tokenTvlMap.set(cleaned, currentTvl + row.tvl)
 					}
-				})
+				}
 			}
-		})
+		}
 
 		return Array.from(tokenTvlMap.entries())
 			.sort((a, b) => b[1] - a[1])
@@ -446,10 +448,10 @@ export function useYieldsTable({
 
 		const protocolMap = new Map<string, { value: string; label: string; tvl: number }>()
 
-		data.forEach((row) => {
+		for (const row of data) {
 			const slug = (row.projectslug || row.project || '').trim()
 			const name = (row.project || '').trim()
-			if (!slug && !name) return
+			if (!slug && !name) continue
 
 			const key = (slug || name).toLowerCase()
 			const existing = protocolMap.get(key)
@@ -470,7 +472,7 @@ export function useYieldsTable({
 					tvl
 				})
 			}
-		})
+		}
 
 		return Array.from(protocolMap.values())
 			.sort((a, b) => {

--- a/src/containers/ProDashboard/hooks/useDiscoveryCategories.ts
+++ b/src/containers/ProDashboard/hooks/useDiscoveryCategories.ts
@@ -46,13 +46,14 @@ export function useDiscoveryCategories() {
 	})
 
 	const categories: Record<string, CategoryData> = {}
-	CATEGORIES.forEach((category, index) => {
+	for (let index = 0; index < CATEGORIES.length; index++) {
+		const category = CATEGORIES[index]
 		categories[category.key] = {
 			dashboards: queries[index].data?.items || [],
 			isLoading: queries[index].isLoading,
 			error: queries[index].error as Error | null
 		}
-	})
+	}
 
 	return {
 		categories,

--- a/src/containers/ProDashboard/services/ChainCharts.ts
+++ b/src/containers/ProDashboard/services/ChainCharts.ts
@@ -65,9 +65,9 @@ export default class ChainCharts {
 				if (response.ok) {
 					const data = await response.json()
 					const extracted = extractData(data)
-					extracted.forEach(([timestamp, value]) => {
+					for (const [timestamp, value] of extracted) {
 						mergedMap.set(timestamp, value)
-					})
+					}
 				}
 			}
 

--- a/src/containers/ProDashboard/utils.ts
+++ b/src/containers/ProDashboard/utils.ts
@@ -36,7 +36,7 @@ export const normalizeHourlyToDaily = (
 
 	const dailyData: { [dayKey: string]: { values: number[]; lastTimestamp: number; lastValue: number } } = {}
 
-	sortedData.forEach(([timestamp, value]) => {
+	for (const [timestamp, value] of sortedData) {
 		const date = new Date(timestamp * 1000)
 		date.setUTCHours(0, 0, 0, 0)
 		const dayKey = (date.getTime() / 1000).toString()
@@ -50,7 +50,7 @@ export const normalizeHourlyToDaily = (
 			dailyData[dayKey].lastTimestamp = timestamp
 			dailyData[dayKey].lastValue = value
 		}
-	})
+	}
 
 	return Object.entries(dailyData)
 		.map(([dayTimestamp, { values, lastValue }]) => {
@@ -90,7 +90,7 @@ export const groupData = (
 
 	const groupedData: { [key: string]: number } = {}
 
-	data.forEach(([timestampStr, value]) => {
+	for (const [timestampStr, value] of data) {
 		const date = new Date(parseInt(timestampStr) * 1000)
 		let groupKeyDate: Date
 
@@ -112,7 +112,7 @@ export const groupData = (
 		} else {
 			groupedData[groupKey] = +value
 		}
-	})
+	}
 
 	return Object.entries(groupedData).sort((a, b) => parseInt(a[0]) - parseInt(b[0]))
 }

--- a/src/containers/ProDashboard/utils/buildProtocolOptions.ts
+++ b/src/containers/ProDashboard/utils/buildProtocolOptions.ts
@@ -23,7 +23,9 @@ export function buildProtocolOptions(
 ): BuiltProtocolOptions {
 	const childrenByParentId = new Map<string, AnyProtocol[]>()
 	const parentMetaById = new Map<string, ParentProto>()
-	parentProtocols.forEach((pp) => parentMetaById.set(pp.id, pp))
+	for (const pp of parentProtocols) {
+		parentMetaById.set(pp.id, pp)
+	}
 
 	const allChildren = new Set<string>()
 

--- a/src/containers/ProtocolOverview/Chart/Chart.tsx
+++ b/src/containers/ProtocolOverview/Chart/Chart.tsx
@@ -195,7 +195,7 @@ export default function ProtocolLineBarChart({
 
 		const chartsInSeries = new Set(series.map((s) => s.name))
 
-		allYAxis.forEach(([type, index]) => {
+		for (const [type, index] of allYAxis) {
 			const options = {
 				...yAxis,
 				name: '',
@@ -508,7 +508,7 @@ export default function ProtocolLineBarChart({
 					}
 				})
 			}
-		})
+		}
 
 		if (allYAxis.length === 0) {
 			finalYAxis.push(yAxis)

--- a/src/containers/ProtocolOverview/IncomeStatement.tsx
+++ b/src/containers/ProtocolOverview/IncomeStatement.tsx
@@ -227,7 +227,8 @@ export const IncomeStatement = (props: IProtocolOverviewPageData) => {
 				displayValue: grossProtocolRevenue, // Show actual gross protocol revenue value, not sum of flows
 				depth: 1
 			})
-			for (const [label, value] of Object.entries(grossProtocolRevenueByLabelData)) {
+			for (const label in grossProtocolRevenueByLabelData) {
+				const value = grossProtocolRevenueByLabelData[label]
 				if (value > 0) {
 					nodes.push({
 						name: label,
@@ -263,7 +264,8 @@ export const IncomeStatement = (props: IProtocolOverviewPageData) => {
 
 			// Only add cost breakdown if labels are available
 			if (Object.keys(costOfRevenueByLabelData).length > 0) {
-				for (const [label, value] of Object.entries(costOfRevenueByLabelData)) {
+				for (const label in costOfRevenueByLabelData) {
+					const value = costOfRevenueByLabelData[label]
 					if (value > 0) {
 						const costLabel = `${label} (Cost)`
 						nodes.push({

--- a/src/containers/ProtocolOverview/KeyMetricsPngExport.tsx
+++ b/src/containers/ProtocolOverview/KeyMetricsPngExport.tsx
@@ -230,7 +230,8 @@ export function KeyMetricsPngExportButton({
 
 			ctx.font = '14px system-ui, -apple-system, sans-serif'
 
-			rows.forEach((row, index) => {
+			for (let index = 0; index < rows.length; index++) {
+				const row = rows[index]
 				const rowY = rowsStartY + index * rowHeight
 
 				ctx.strokeStyle = borderColor
@@ -251,7 +252,7 @@ export function KeyMetricsPngExportButton({
 				ctx.fillText(row.value, canvasWidth - padding, rowY + rowHeight / 2)
 
 				ctx.font = '14px system-ui, -apple-system, sans-serif'
-			})
+			}
 
 			try {
 				const watermarkSrc = isDark ? '/assets/defillama-light-neutral.webp' : '/assets/defillama-dark-neutral.webp'

--- a/src/containers/ProtocolOverview/index.tsx
+++ b/src/containers/ProtocolOverview/index.tsx
@@ -1176,7 +1176,7 @@ function BridgeVolume(props: IKeyMetricsProps) {
 	let total30d = 0
 	let totalAllTime = 0
 
-	props.bridgeVolume.forEach((item) => {
+	for (const item of props.bridgeVolume) {
 		const volume = (item.depositUSD + item.withdrawUSD) / 2
 		const timestamp = new Date(+item.date * 1000).getTime()
 
@@ -1193,7 +1193,7 @@ function BridgeVolume(props: IKeyMetricsProps) {
 		if (timestamp >= oneDayAgo) {
 			total24h += volume
 		}
-	})
+	}
 
 	if (total30d > 0) {
 		metrics.push({

--- a/src/containers/ProtocolOverview/queries.tsx
+++ b/src/containers/ProtocolOverview/queries.tsx
@@ -613,11 +613,11 @@ export const getProtocolOverviewPageData = async ({
 					.map((p) => {
 						let commonChains = 0
 
-						protocolData?.chains?.forEach((chain) => {
+						for (const chain of protocolData?.chains ?? []) {
 							if (p.chains.includes(chain)) {
 								commonChains += 1
 							}
-						})
+						}
 
 						return { name: p.name, tvl: p.tvl, commonChains }
 					})
@@ -629,14 +629,16 @@ export const getProtocolOverviewPageData = async ({
 	const protocolsWithCommonChains = [...competitors].sort((a, b) => b.commonChains - a.commonChains).slice(0, 5)
 
 	// first 5 are the protocols that are on same chain + same category
-	protocolsWithCommonChains.forEach((p) => competitorsSet.add(p.name))
+	for (const p of protocolsWithCommonChains) {
+		competitorsSet.add(p.name)
+	}
 
 	// last 5 are the protocols in same category
-	competitors.forEach((p) => {
+	for (const p of competitors) {
 		if (competitorsSet.size < 10) {
 			competitorsSet.add(p.name)
 		}
-	})
+	}
 
 	const hacks =
 		(protocolData.id
@@ -821,9 +823,10 @@ export const getProtocolOverviewPageData = async ({
 	}
 
 	const chartColors = {}
-	availableCharts.forEach((chart, index) => {
-		chartColors[chart] = CHART_COLORS[index]
-	})
+	for (let i = 0; i < availableCharts.length; i++) {
+		const chart = availableCharts[i]
+		chartColors[chart] = CHART_COLORS[i]
+	}
 
 	const hallmarks = {}
 	const rangeHallmarks = []

--- a/src/containers/ProtocolsWithTokens/queries.tsx
+++ b/src/containers/ProtocolsWithTokens/queries.tsx
@@ -346,7 +346,9 @@ export async function getProtocolsAdjustedFDVsByChain({
 			categories.add(protocol.category)
 		}
 
-		protocol.chains.forEach((chain) => chainsWithEmissions.add(chain))
+		for (const chain of protocol.chains) {
+			chainsWithEmissions.add(chain)
+		}
 
 		const p = {
 			name: protocol.name,

--- a/src/containers/RWA/queries.tsx
+++ b/src/containers/RWA/queries.tsx
@@ -244,16 +244,16 @@ export async function getRWAAssetsOverview(selectedChain?: string): Promise<IRWA
 				totalOnChainDeFiActiveTvlAllAssets += effectiveDeFiActiveTvl
 
 				// Add to categories/issuers/assetClasses/rwaClassifications/accessModels for assets on this chain
-				asset.assetClass?.forEach((assetClass) => {
+				for (const assetClass of asset.assetClass ?? []) {
 					if (assetClass) {
 						assetClasses.set(assetClass, (assetClasses.get(assetClass) ?? 0) + effectiveOnChainMarketcap)
 					}
-				})
-				asset.category?.forEach((category) => {
+				}
+				for (const category of asset.category ?? []) {
 					if (category) {
 						categories.set(category, (categories.get(category) ?? 0) + effectiveOnChainMarketcap)
 					}
-				})
+				}
 				if (asset.rwaClassification) {
 					rwaClassifications.set(
 						asset.rwaClassification,
@@ -269,11 +269,11 @@ export async function getRWAAssetsOverview(selectedChain?: string): Promise<IRWA
 			}
 
 			// Chains list always uses total TVL (not filtered) so order stays consistent
-			asset.chain?.forEach((chain) => {
+			for (const chain of asset.chain ?? []) {
 				if (chain) {
 					chains.set(chain, (chains.get(chain) ?? 0) + totalOnChainMarketcapForAsset)
 				}
-			})
+			}
 		}
 
 		const formattedRwaClassifications = Array.from(rwaClassifications.entries())
@@ -341,11 +341,11 @@ export async function getRWAChainsList(): Promise<string[]> {
 	const chains = new Set<string>()
 
 	for (const rwaId in data) {
-		data[rwaId].chain?.forEach((chain) => {
+		for (const chain of data[rwaId].chain ?? []) {
 			if (chain) {
 				chains.add(slug(chain))
 			}
-		})
+		}
 	}
 
 	return Array.from(chains)
@@ -409,12 +409,12 @@ export async function getRWAAssetData(assetSlug: string): Promise<IRWAAssetData 
 				const accessModelDescription = definitions.accessModel.values?.[accessModel] ?? null
 				// Get asset class descriptions
 				const assetClassDescriptions: Record<string, string> = {}
-				item.assetClass?.forEach((ac) => {
+				for (const ac of item.assetClass ?? []) {
 					const description = ac ? definitions.assetClass.values?.[ac] : null
 					if (description) {
 						assetClassDescriptions[ac] = description
 					}
-				})
+				}
 				return {
 					slug: assetSlug,
 					ticker: typeof item.ticker === 'string' && item.ticker !== '-' ? item.ticker : null,

--- a/src/containers/Raises/download.ts
+++ b/src/containers/Raises/download.ts
@@ -19,24 +19,23 @@ export const prepareRaisesCsv = ({ raises }) => {
 		]
 	]
 
-	raises
-		.sort((a, b) => b.date - a.date)
-		.forEach((item) => {
-			rows.push([
-				item.name,
-				item.date,
-				toNiceCsvDate(item.date),
-				item.amount === null ? '' : item.amount * 1_000_000,
-				item.round ?? '',
-				item.sector ?? '',
-				item.leadInvestors?.join(' + ') ?? '',
-				item.category ?? '',
-				item.source ?? '',
-				item.valuation ?? '',
-				item.chains?.join(' + ') ?? '',
-				item.otherInvestors?.join(' + ') ?? ''
-			])
-		})
+	const sortedRaises = raises.sort((a, b) => b.date - a.date)
+	for (const item of sortedRaises) {
+		rows.push([
+			item.name,
+			item.date,
+			toNiceCsvDate(item.date),
+			item.amount === null ? '' : item.amount * 1_000_000,
+			item.round ?? '',
+			item.sector ?? '',
+			item.leadInvestors?.join(' + ') ?? '',
+			item.category ?? '',
+			item.source ?? '',
+			item.valuation ?? '',
+			item.chains?.join(' + ') ?? '',
+			item.otherInvestors?.join(' + ') ?? ''
+		])
+	}
 
 	return { filename: `raises.csv`, rows: rows as (string | number | boolean)[][] }
 }

--- a/src/containers/Raises/hooks.tsx
+++ b/src/containers/Raises/hooks.tsx
@@ -76,17 +76,17 @@ export function useRaisesData({ raises, investors, rounds, sectors, chains }) {
 
 				let isAnInvestor = false
 
-				raise.leadInvestors.forEach((lead) => {
+				for (const lead of raise.leadInvestors) {
 					if (selectedInvestorsSet.has(lead)) {
 						isAnInvestor = true
 					}
-				})
+				}
 
-				raise.otherInvestors.forEach((otherInv) => {
+				for (const otherInv of raise.otherInvestors) {
 					if (selectedInvestorsSet.has(otherInv)) {
 						isAnInvestor = true
 					}
-				})
+				}
 
 				// filter if investor is in either leadInvestors or otherInvestors
 				if (!isAnInvestor) {
@@ -101,11 +101,11 @@ export function useRaisesData({ raises, investors, rounds, sectors, chains }) {
 				} else {
 					let raiseIncludesChain = false
 
-					raise.chains.forEach((chain) => {
+					for (const chain of raise.chains) {
 						if (selectedChainsSet.has(chain)) {
 							raiseIncludesChain = true
 						}
-					})
+					}
 
 					if (!raiseIncludesChain) {
 						toFilter = false
@@ -152,7 +152,7 @@ export function useRaisesData({ raises, investors, rounds, sectors, chains }) {
 			return toFilter
 		})
 
-		filteredRaisesList.forEach((r) => {
+		for (const r of filteredRaisesList) {
 			// split EOS raised amount between 13 months
 			if (r.name === 'EOS') {
 				for (let month = 0; month < 13; month++) {
@@ -170,7 +170,7 @@ export function useRaisesData({ raises, investors, rounds, sectors, chains }) {
 			if (r.round) {
 				investmentByRounds[r.round] = (investmentByRounds[r.round] ?? 0) + 1
 			}
-		})
+		}
 
 		const finalMonthlyInvestment = []
 		const finalRaisesByCategory = []

--- a/src/containers/RecentProtocols/index.tsx
+++ b/src/containers/RecentProtocols/index.tsx
@@ -61,12 +61,12 @@ export function RecentProtocols({ protocols, chainList, forkedList, claimableAir
 				}
 
 				let includesChain = false
-				protocol.chains.forEach((chain) => {
+				for (const chain of protocol.chains) {
 					// filter if a protocol has at least of one selected chain
 					if (!includesChain) {
 						includesChain = _chainsToSelect.includes(chain.toLowerCase())
 					}
-				})
+				}
 
 				toFilter = toFilter && includesChain
 
@@ -79,10 +79,10 @@ export function RecentProtocols({ protocols, chainList, forkedList, claimableAir
 				let tvlPrevMonth = null
 				let extraTvl = {}
 
-				p.chains.forEach((chainName) => {
-					// return if chainsToSelect does not include chainName
+				for (const chainName of p.chains) {
+					// continue if chainsToSelect does not include chainName
 					if (!_chainsToSelect.includes(chainName.toLowerCase())) {
-						return
+						continue
 					}
 
 					for (const sectionName in p.chainTvls) {
@@ -114,7 +114,7 @@ export function RecentProtocols({ protocols, chainList, forkedList, claimableAir
 							}
 						}
 					}
-				})
+				}
 
 				return {
 					...p,

--- a/src/containers/Stablecoins/ChainsWithStablecoins.tsx
+++ b/src/containers/Stablecoins/ChainsWithStablecoins.tsx
@@ -58,18 +58,17 @@ export function ChainsWithStablecoins({
 
 	const prepareeCsv = React.useCallback(() => {
 		const rows = [['Timestamp', 'Date', ...chainList, 'Total']]
-		stackedData
-			.sort((a, b) => a.date - b.date)
-			.forEach((day) => {
-				rows.push([
-					day.date,
-					toNiceCsvDate(day.date),
-					...chainList.map((chain) => day[chain] ?? ''),
-					chainList.reduce((acc, curr) => {
-						return (acc += day[curr] ?? 0)
-					}, 0)
-				])
-			})
+		const sortedData = stackedData.sort((a, b) => a.date - b.date)
+		for (const day of sortedData) {
+			rows.push([
+				day.date,
+				toNiceCsvDate(day.date),
+				...chainList.map((chain) => day[chain] ?? ''),
+				chainList.reduce((acc, curr) => {
+					return (acc += day[curr] ?? 0)
+				}, 0)
+			])
+		}
 		return { filename: 'stablecoinsChainTotals.csv', rows: rows as (string | number | boolean)[][] }
 	}, [stackedData, chainList])
 

--- a/src/containers/Stablecoins/Filters/ResetAll.tsx
+++ b/src/containers/Stablecoins/Filters/ResetAll.tsx
@@ -13,7 +13,11 @@ export function ResetAllStablecoinFilters({ pathname }: { pathname: string; nest
 	return (
 		<button
 			onClick={() => {
-				updater(Object.fromEntries(Object.values(STABLECOINS_SETTINGS).map((s) => [s, false])))
+				const resetSettings: Record<string, boolean> = {}
+				for (const s of Object.values(STABLECOINS_SETTINGS)) {
+					resetSettings[s] = false
+				}
+				updater(resetSettings)
 				router.push(pathname, undefined, { shallow: true })
 			}}
 			disabled={!hasActiveFilters}

--- a/src/containers/Stablecoins/StablecoinOverview.tsx
+++ b/src/containers/Stablecoins/StablecoinOverview.tsx
@@ -127,18 +127,17 @@ export const PeggedAssetInfo = ({
 
 	const prepareCsv = React.useCallback(() => {
 		const rows = [['Timestamp', 'Date', ...chainsUnique, 'Total']]
-		stackedData
-			.sort((a, b) => a.date - b.date)
-			.forEach((day) => {
-				rows.push([
-					day.date,
-					toNiceCsvDate(day.date),
-					...chainsUnique.map((chain) => day[chain] ?? ''),
-					chainsUnique.reduce((acc, curr) => {
-						return (acc += day[curr] ?? 0)
-					}, 0)
-				])
-			})
+		const sortedData = stackedData.sort((a, b) => a.date - b.date)
+		for (const day of sortedData) {
+			rows.push([
+				day.date,
+				toNiceCsvDate(day.date),
+				...chainsUnique.map((chain) => day[chain] ?? ''),
+				chainsUnique.reduce((acc, curr) => {
+					return (acc += day[curr] ?? 0)
+				}, 0)
+			])
+		}
 		return { filename: 'stablecoinsChains.csv', rows: rows as (string | number | boolean)[][] }
 	}, [stackedData, chainsUnique])
 

--- a/src/containers/Stablecoins/StablecoinsByChain.tsx
+++ b/src/containers/Stablecoins/StablecoinsByChain.tsx
@@ -81,13 +81,13 @@ export function StablecoinsByChain({
 
 			// These together filter depegged. Need to refactor once any other attributes are added.
 			toFilter = Math.abs(curr.pegDeviation) < 10 || !(typeof curr.pegDeviation === 'number')
-			selectedAttributes.forEach((attribute) => {
+			for (const attribute of selectedAttributes) {
 				const attributeOption = attributeOptionsMap.get(attribute)
 
 				if (attributeOption) {
 					toFilter = attributeOption.filterFn(curr)
 				}
-			})
+			}
 
 			toFilter =
 				toFilter &&
@@ -159,18 +159,17 @@ export function StablecoinsByChain({
 	const prepareCsv = () => {
 		const filteredPeggedNames = peggedAssetNames.filter((name, i) => filteredIndexes.includes(i))
 		const rows = [['Timestamp', 'Date', ...filteredPeggedNames, 'Total']]
-		stackedData
-			.sort((a, b) => a.date - b.date)
-			.forEach((day) => {
-				rows.push([
-					day.date,
-					toNiceCsvDate(day.date),
-					...filteredPeggedNames.map((peggedAsset) => day[peggedAsset] ?? ''),
-					filteredPeggedNames.reduce((acc, curr) => {
-						return (acc += day[curr] ?? 0)
-					}, 0)
-				])
-			})
+		const sortedData = stackedData.sort((a, b) => a.date - b.date)
+		for (const day of sortedData) {
+			rows.push([
+				day.date,
+				toNiceCsvDate(day.date),
+				...filteredPeggedNames.map((peggedAsset) => day[peggedAsset] ?? ''),
+				filteredPeggedNames.reduce((acc, curr) => {
+					return (acc += day[curr] ?? 0)
+				}, 0)
+			])
+		}
 		return { filename: 'stablecoins.csv', rows: rows as (string | number | boolean)[][] }
 	}
 
@@ -468,7 +467,9 @@ function handleRouting(selectedChain, queryParams) {
 
 	let params = ''
 
-	Object.keys(filters).forEach((filter, index) => {
+	const filterKeys = Object.keys(filters)
+	for (let index = 0; index < filterKeys.length; index++) {
+		const filter = filterKeys[index]
 		// append '?' before all query params and '&' bertween diff params
 		if (index === 0) {
 			params += '?'
@@ -476,17 +477,18 @@ function handleRouting(selectedChain, queryParams) {
 
 		// query params of same query like pegType will return in array form - pegType=['USD','EUR'], expected output is pegType=USD&pegType=EUR
 		if (Array.isArray(filters[filter])) {
-			filters[filter].forEach((f, i) => {
+			for (let i = 0; i < filters[filter].length; i++) {
+				const f = filters[filter][i]
 				if (i > 0) {
 					params += '&'
 				}
 
 				params += `${filter}=${f}`
-			})
+			}
 		} else {
 			params += `${filter}=${filters[filter]}`
 		}
-	})
+	}
 
 	if (selectedChain === 'All') return `/stablecoins${params}`
 	return `/stablecoins/${slug(selectedChain)}${params}`

--- a/src/containers/Stablecoins/Table/index.tsx
+++ b/src/containers/Stablecoins/Table/index.tsx
@@ -252,19 +252,19 @@ export function PeggedChainsTable({ data }) {
 	const [groupTvls, updater] = useLocalStorageSettingsManager('tvl_chains')
 
 	const clearAllAggrOptions = () => {
-		DEFI_CHAINS_SETTINGS.forEach((item) => {
+		for (const item of DEFI_CHAINS_SETTINGS) {
 			if (selectedAggregateTypes.includes(item.key)) {
 				updater(item.key)
 			}
-		})
+		}
 	}
 
 	const toggleAllAggrOptions = () => {
-		DEFI_CHAINS_SETTINGS.forEach((item) => {
+		for (const item of DEFI_CHAINS_SETTINGS) {
 			if (!selectedAggregateTypes.includes(item.key)) {
 				updater(item.key)
 			}
-		})
+		}
 	}
 
 	const addAggrOption = (selectedKeys) => {
@@ -282,7 +282,7 @@ export function PeggedChainsTable({ data }) {
 	}
 
 	const addOnlyOneAggrOption = (newOption) => {
-		DEFI_CHAINS_SETTINGS.forEach((item) => {
+		for (const item of DEFI_CHAINS_SETTINGS) {
 			if (item.key === newOption) {
 				if (!selectedAggregateTypes.includes(item.key)) {
 					updater(item.key)
@@ -292,7 +292,7 @@ export function PeggedChainsTable({ data }) {
 					updater(item.key)
 				}
 			}
-		})
+		}
 	}
 
 	const selectedAggregateTypes = React.useMemo(() => {

--- a/src/containers/Stablecoins/queries.server.tsx
+++ b/src/containers/Stablecoins/queries.server.tsx
@@ -66,9 +66,9 @@ let globalData: any
 function fetchGlobalData({ peggedAssets, chains }: any) {
 	if (globalData) return globalData
 	const tvlMap: any = {}
-	chains.forEach((chain) => {
+	for (const chain of chains) {
 		tvlMap[chain.name] = chain.tvl
-	})
+	}
 	const chainList = chains
 		.sort((a, b) => {
 			const bTotalCirculatings = Object.values(b.totalCirculatingUSD) as any
@@ -80,15 +80,15 @@ function fetchGlobalData({ peggedAssets, chains }: any) {
 		.map((chain) => chain.name)
 	const chainsSet = new Set()
 	const _chainSet = new Set(chainList)
-	peggedAssets.forEach(({ chains }) => {
-		chains.forEach((chain) => {
+	for (const { chains } of peggedAssets) {
+		for (const chain of chains) {
 			if (!chain) {
 				chainsSet.add(chain)
 			} else {
 				if (_chainSet.has(chain)) chainsSet.add(chain)
 			}
-		})
-	})
+		}
+	}
 	globalData = {
 		chainList,
 		chainsSet,
@@ -142,10 +142,10 @@ export async function getPeggedOverviewPageData(chain) {
 			}
 			return formattedCharts
 		})
-		chartDataByPeggedAsset.forEach((chart) => {
+		for (const chart of chartDataByPeggedAsset) {
 			const last = chart[chart.length - 1]
 			if (!last) {
-				return
+				continue
 			}
 			let lastDate = Number(last.date)
 			while (lastDate < lastTimestamp) {
@@ -155,7 +155,7 @@ export async function getPeggedOverviewPageData(chain) {
 					date: lastDate
 				})
 			}
-		})
+		}
 
 		const filteredPeggedAssets = formatPeggedAssetsData({
 			peggedAssets,
@@ -188,7 +188,7 @@ export async function getPeggedChainsPageData() {
 		const { chainList, chainsTVLData } = fetchGlobalData({ peggedAssets, chains })
 
 		let chainsGroupbyParent: Record<string, Record<string, string[]>> = {}
-		chainList.forEach((chain) => {
+		for (const chain of chainList) {
 			const parent = chainCoingeckoIds[chain]?.parent
 			if (parent) {
 				if (!chainsGroupbyParent[parent.chain]) {
@@ -201,7 +201,7 @@ export async function getPeggedChainsPageData() {
 					chainsGroupbyParent[parent.chain][type].push(chain)
 				}
 			}
-		})
+		}
 
 		let peggedChartDataByChain = chainList.map((chain) => chainChartMap[chain] ?? null)
 

--- a/src/containers/TokenPnl/index.tsx
+++ b/src/containers/TokenPnl/index.tsx
@@ -206,7 +206,8 @@ const computeTokenPnl = async (params: {
 		dataPoints.push([start * 1000, firstPoint.price])
 	}
 
-	series.forEach((point, index) => {
+	for (let index = 0; index < series.length; index++) {
+		const point = series[index]
 		prices.push(point.price)
 
 		if (index === 0) {
@@ -220,7 +221,7 @@ const computeTokenPnl = async (params: {
 
 		// Prepare chart data
 		dataPoints.push([point.timestamp * 1000, point.price])
-	})
+	}
 
 	const lastPoint = series[series.length - 1]
 	if (lastPoint && lastPoint.timestamp !== end) {

--- a/src/containers/Unlocks/Table.tsx
+++ b/src/containers/Unlocks/Table.tsx
@@ -147,36 +147,48 @@ export const UnlocksTable = ({
 	)
 
 	const clearAllOptions = () => {
-		const ops = JSON.stringify(Object.fromEntries(columnOptions.map((option) => [option.key, false])))
+		const opsObj: Record<string, boolean> = {}
+		for (const option of columnOptions) {
+			opsObj[option.key] = false
+		}
+		const ops = JSON.stringify(opsObj)
 		window.localStorage.setItem(optionsKey, ops)
 		window.dispatchEvent(new Event('storage'))
 	}
 
 	const toggleAllOptions = () => {
-		const ops = JSON.stringify(Object.fromEntries(columnOptions.map((option) => [option.key, true])))
+		const opsObj: Record<string, boolean> = {}
+		for (const option of columnOptions) {
+			opsObj[option.key] = true
+		}
+		const ops = JSON.stringify(opsObj)
 		window.localStorage.setItem(optionsKey, ops)
 		window.dispatchEvent(new Event('storage'))
 	}
 
 	const addOption = (newOptions) => {
-		const ops = Object.fromEntries(columnOptions.map((col) => [col.key, newOptions.includes(col.key)]))
+		const ops: Record<string, boolean> = {}
+		for (const col of columnOptions) {
+			ops[col.key] = newOptions.includes(col.key)
+		}
 		window.localStorage.setItem(optionsKey, JSON.stringify(ops))
 		window.dispatchEvent(new Event('storage'))
 	}
 
 	const addOnlyOneOption = (newOption) => {
-		const ops = Object.fromEntries(columnOptions.map((col) => [col.key, col.key === newOption]))
+		const ops: Record<string, boolean> = {}
+		for (const col of columnOptions) {
+			ops[col.key] = col.key === newOption
+		}
 		window.localStorage.setItem(optionsKey, JSON.stringify(ops))
 		window.dispatchEvent(new Event('storage'))
 	}
 
 	const _setFilter = (key) => (newState) => {
-		const newOptions = Object.fromEntries(
-			columnOptions.map((column) => [
-				[column.key],
-				['name', 'category'].includes(column.key) ? true : column[key] === newState
-			])
-		)
+		const newOptions: Record<string, boolean> = {}
+		for (const column of columnOptions) {
+			newOptions[column.key] = ['name', 'category'].includes(column.key) ? true : column[key] === newState
+		}
 
 		if (columnsInStorage === JSON.stringify(newOptions)) {
 			toggleAllOptions()

--- a/src/containers/Yields/Filters/ColumnFilters.tsx
+++ b/src/containers/Yields/Filters/ColumnFilters.tsx
@@ -61,10 +61,14 @@ export function ColumnFilters({ nestedMenu, ...props }: IColumnFiltersProps) {
 	}, [router.query, props])
 
 	const addOption = (newOptions) => {
+		const optionsObj: Record<string, boolean> = {}
+		for (const op of newOptions) {
+			optionsObj[op] = true
+		}
 		router.push(
 			{
 				pathname: router.pathname,
-				query: { ...queries, ...Object.fromEntries(newOptions.map((op) => [op, true])) }
+				query: { ...queries, ...optionsObj }
 			},
 			undefined,
 			{
@@ -87,12 +91,16 @@ export function ColumnFilters({ nestedMenu, ...props }: IColumnFiltersProps) {
 	}
 
 	const toggleAll = () => {
+		const optionsObj: Record<string, boolean> = {}
+		for (const op of options) {
+			optionsObj[op.key] = true
+		}
 		router.push(
 			{
 				pathname: router.pathname,
 				query: {
 					...queries,
-					...Object.fromEntries(options.map((op) => [op.key, true]))
+					...optionsObj
 				}
 			},
 			undefined,

--- a/src/containers/Yields/queries/index.ts
+++ b/src/containers/Yields/queries/index.ts
@@ -267,7 +267,7 @@ export async function getLendBorrowData() {
 	const lendingProtocols = new Set()
 	const farmProtocols = new Set()
 
-	props.pools.forEach((pool) => {
+	for (const pool of props.pools) {
 		projectsList.add(pool.projectName)
 		// remove undercollateralised cause we cannot borrow on those
 		if (['Lending', 'CDP', 'NFT Lending'].includes(pool.category)) {
@@ -275,11 +275,13 @@ export async function getLendBorrowData() {
 		}
 		farmProtocols.add(pool.projectName)
 
-		pool.rewardTokensNames?.forEach((rewardName) => {
-			projectsList.add(rewardName)
-			farmProtocols.add(rewardName)
-		})
-	})
+		if (pool.rewardTokensNames) {
+			for (const rewardName of pool.rewardTokensNames) {
+				projectsList.add(rewardName)
+				farmProtocols.add(rewardName)
+			}
+		}
+	}
 
 	return {
 		props: {

--- a/src/containers/Yields/queries/utils.ts
+++ b/src/containers/Yields/queries/utils.ts
@@ -73,7 +73,7 @@ export function formatYieldsPageData(poolsAndConfig: any) {
 
 	const categoryList: Set<string> = new Set()
 
-	_pools.forEach((pool) => {
+	for (const pool of _pools) {
 		// remove potential undefined on projectName
 		if (pool.projectName) {
 			poolsList.push(pool)
@@ -81,7 +81,7 @@ export function formatYieldsPageData(poolsAndConfig: any) {
 			categoryList.add(pool.category)
 			projectList.add(pool.projectName)
 		}
-	})
+	}
 
 	let tokenNameMapping = {}
 	for (const key of Object.keys(_config)) {
@@ -96,7 +96,13 @@ export function formatYieldsPageData(poolsAndConfig: any) {
 	tokenNameMapping['USDC'] = 'USD Coin'
 	tokenNameMapping['VELO'] = 'Velodrome'
 	// remove any null keys (where no token)
-	tokenNameMapping = Object.fromEntries(Object.entries(tokenNameMapping).filter(([k, _]) => k !== 'null'))
+	const filteredTokenNameMapping: Record<string, string> = {}
+	for (const k in tokenNameMapping) {
+		if (k !== 'null') {
+			filteredTokenNameMapping[k] = tokenNameMapping[k]
+		}
+	}
+	tokenNameMapping = filteredTokenNameMapping
 
 	const symbols = [...new Set(_pools.map((p) => p.symbol.split(' ')[0].split('-')).flat())]
 
@@ -117,7 +123,7 @@ export function formatYieldsPageData(poolsAndConfig: any) {
 
 	const tokenSymbolsList = ['ALL_BITCOINS', 'ALL_USD_STABLES']
 
-	symbols.forEach((token: string) => {
+	for (const token of symbols as string[]) {
 		if (token) {
 			tokens.push({
 				name: token,
@@ -127,7 +133,7 @@ export function formatYieldsPageData(poolsAndConfig: any) {
 			})
 			tokenSymbolsList.push(token)
 		}
-	})
+	}
 
 	return {
 		pools: poolsList,

--- a/src/containers/Yields/utils.ts
+++ b/src/containers/Yields/utils.ts
@@ -45,7 +45,7 @@ export function toFilterPool({
 	let toFilter = true
 
 	// used in pages like /yields/stablecoins to filter some pools by default
-	attributeOptions.forEach((option) => {
+	for (const option of attributeOptions) {
 		// check if this page has default attribute filter function
 		if (option.defaultFilterFnOnPage[pathname]) {
 			// apply default attribute filter function
@@ -55,15 +55,15 @@ export function toFilterPool({
 		if (pathname === '/yields' && option.key === 'apy_zero' && !selectedAttributes.includes(option.key)) {
 			toFilter = toFilter && curr.apy > 0
 		}
-	})
+	}
 
-	selectedAttributes.forEach((attribute) => {
+	for (const attribute of selectedAttributes) {
 		const attributeOption = attributeOptionsMap.get(attribute)
 
 		if (attributeOption) {
 			toFilter = toFilter && attributeOption.filterFn(curr)
 		}
-	})
+	}
 
 	toFilter = toFilter && selectedProjectsSet.has(curr.projectName)
 
@@ -526,13 +526,13 @@ export const filterPool = ({
 		toFilter = toFilter && selectedFarmProtocolsSet.has(pool.farmProjectName)
 	}
 	if (selectedAttributes) {
-		selectedAttributes.forEach((attribute) => {
+		for (const attribute of selectedAttributes) {
 			const attributeOption = attributeOptionsMap.get(attribute)
 
 			if (attributeOption) {
 				toFilter = toFilter && attributeOption.filterFn(pool)
 			}
-		})
+		}
 	}
 
 	const isValidTvlRange = minTvl != null || maxTvl != null

--- a/src/contexts/LocalStorage.tsx
+++ b/src/contexts/LocalStorage.tsx
@@ -308,9 +308,10 @@ export function useLocalStorageSettingsManager(type: TSETTINGTYPE): [Record<stri
 				const urlParams = isClient ? new URLSearchParams(window.location.search) : null
 
 				const ps = JSON.parse(localStorage.getItem(DEFILLAMA) ?? '{}')
-				const obj = Object.fromEntries(
-					keys.map((s) => [s, (urlParams && urlParams.get(s) ? urlParams.get(s) === 'true' : null) ?? ps[s] ?? false])
-				)
+				const obj: Record<string, boolean> = {}
+				for (const s of keys) {
+					obj[s] = (urlParams && urlParams.get(s) ? urlParams.get(s) === 'true' : null) ?? ps[s] ?? false
+				}
 
 				return JSON.stringify(obj)
 			} catch {

--- a/src/hooks/data/defi.tsx
+++ b/src/hooks/data/defi.tsx
@@ -229,7 +229,12 @@ export function groupDataWithTvlsByDay({ chains, tvlTypes, extraTvlsEnabled }: I
 	let tvlKey = 'tvl'
 	if (tvlTypes !== null) {
 		tvlKey = tvlTypes[tvlKey]
-		extraTvls = Object.fromEntries(Object.entries(extraTvls).map(([toggle, val]) => [tvlTypes[toggle], val]))
+		const mappedExtraTvls: Record<string, boolean> = {}
+		for (const toggle in extraTvls) {
+			const val = extraTvls[toggle]
+			mappedExtraTvls[tvlTypes[toggle]] = val
+		}
+		extraTvls = mappedExtraTvls
 	}
 
 	const daySum = {}
@@ -238,7 +243,8 @@ export function groupDataWithTvlsByDay({ chains, tvlTypes, extraTvlsEnabled }: I
 		const tvls: IChainTvl = {}
 		let totalDaySum = 0
 
-		Object.entries(values).forEach(([name, chainTvls]: ChainTvlsByDay) => {
+		for (const name in values) {
+			const chainTvls = values[name] as IChainTvl
 			let sum = chainTvls[tvlKey]
 			totalDaySum += chainTvls[tvlKey] || 0
 
@@ -267,7 +273,7 @@ export function groupDataWithTvlsByDay({ chains, tvlTypes, extraTvlsEnabled }: I
 			}
 
 			tvls[name] = sum
-		})
+		}
 
 		daySum[date] = totalDaySum
 
@@ -325,8 +331,9 @@ export const formatProtocolsList = ({
 	): Record<string, ChainMetricSnapshot> | undefined => {
 		if (!incoming) return existing
 		const next: Record<string, ChainMetricSnapshot> = { ...(existing ?? {}) }
-		Object.entries(incoming).forEach(([key, rawValue]) => {
-			if (!rawValue) return
+		for (const key in incoming) {
+			const rawValue = incoming[key]
+			if (!rawValue) continue
 			const value = rawValue as ChainMetricSnapshot & { chain?: string }
 			const chainLabel = typeof value.chain === 'string' && value.chain.trim().length ? value.chain : key
 			const normalizedKey =
@@ -337,7 +344,7 @@ export const formatProtocolsList = ({
 				...value,
 				chain: chainLabel
 			}
-		})
+		}
 		return next
 	}
 
@@ -556,10 +563,10 @@ export const formatProtocolsList = ({
 	const mergeVolumeDataset = (
 		dataset: DimensionDatasetItem[] | undefined,
 		assign: (protocol: IFormattedProtocol, item: DimensionDatasetItem) => IFormattedProtocol
-	) =>
-		(dataset ?? []).forEach((item) => {
+	) => {
+		for (const item of dataset ?? []) {
 			const protocolName = item.name?.toLowerCase()
-			if (!protocolName) return
+			if (!protocolName) continue
 			if (!allProtocols[protocolName]) {
 				allProtocols[protocolName] = { name: item.displayName ?? item.name } as IFormattedProtocol
 			}
@@ -570,7 +577,8 @@ export const formatProtocolsList = ({
 				},
 				item
 			)
-		})
+		}
+	}
 
 	mergeVolumeDataset(aggregatorsData, (protocol, item) => ({
 		...protocol,

--- a/src/hooks/data/stablecoins.tsx
+++ b/src/hooks/data/stablecoins.tsx
@@ -117,7 +117,8 @@ export const useCalcGroupExtraPeggedByDay = (chains) => {
 		const data = chains.map(([date, values]) => {
 			const circulatings: IChainTvl = {}
 			let totalDaySum = 0
-			Object.entries(values).forEach(([name, chainCirculating]: ChainTvlsByDay) => {
+			for (const name in values) {
+				const chainCirculating = values[name] as IChainTvl
 				let sum = chainCirculating.circulating
 				totalDaySum += chainCirculating.circulating
 				if (extraPeggedEnabled['unreleased'] && chainCirculating.unreleased) {
@@ -126,7 +127,7 @@ export const useCalcGroupExtraPeggedByDay = (chains) => {
 				}
 
 				circulatings[name] = sum
-			})
+			}
 			daySum[date] = totalDaySum
 			return { date, ...circulatings }
 		})
@@ -218,11 +219,11 @@ export const useGroupChainsPegged = (chains, groupData: IGroupData): GroupChainP
 			}
 		}
 
-		chains.forEach((item) => {
+		for (const item of chains) {
 			if (!addedChains.includes(item.name)) {
 				finalData[item.name] = item
 			}
-		})
+		}
 		return (Object.values(finalData) as GroupChainPegged[]).sort((a, b) => b.mcap - a.mcap)
 	}, [chains, groupData, groupsEnabled])
 

--- a/src/hooks/data/utils.ts
+++ b/src/hooks/data/utils.ts
@@ -71,11 +71,11 @@ const groupData = (protocols: IFormattedProtocol[], parent: IParentProtocol, noS
 			}
 
 			if (curr?.extraTvl?.excludeParent) {
-				;['tvl', 'tvlPrevDay', 'tvlPrevWeek', 'tvlPrevMonth'].forEach((key) => {
+				for (const key of ['tvl', 'tvlPrevDay', 'tvlPrevWeek', 'tvlPrevMonth']) {
 					if (curr.extraTvl.excludeParent[key]) {
 						acc[key] -= curr.extraTvl.excludeParent[key]
 					}
-				})
+				}
 			}
 			// for protocols with null historical values, propagate null to parent
 			for (const key of ['tvlPrevDay', 'tvlPrevWeek', 'tvlPrevMonth'] as const) {
@@ -190,19 +190,29 @@ const groupData = (protocols: IFormattedProtocol[], parent: IParentProtocol, noS
 	const oracleSet = new Set<string>()
 	const oraclesByChainAgg: Record<string, Set<string>> = {}
 	const addOracles = (obj: any) => {
-		if (Array.isArray(obj?.oracles)) obj.oracles.forEach((o: string) => oracleSet.add(o))
+		if (Array.isArray(obj?.oracles)) {
+			for (const o of obj.oracles as string[]) {
+				oracleSet.add(o)
+			}
+		}
 		if (obj?.oraclesByChain) {
 			for (const k of Object.keys(obj.oraclesByChain as Record<string, string[]>)) {
 				const set = (oraclesByChainAgg[k] = oraclesByChainAgg[k] || new Set<string>())
-				;(obj.oraclesByChain[k] || []).forEach((o: string) => set.add(o))
+				for (const o of obj.oraclesByChain[k] || []) {
+					set.add(o)
+				}
 			}
 		}
 	}
 	addOracles(parent)
-	protocols.forEach(addOracles)
-	const aggregatedOraclesByChain = Object.fromEntries(
-		Object.entries(oraclesByChainAgg).map(([k, v]) => [k, Array.from(v).sort((a, b) => a.localeCompare(b))])
-	)
+	for (const protocol of protocols) {
+		addOracles(protocol)
+	}
+	const aggregatedOraclesByChain: Record<string, string[]> = {}
+	for (const k in oraclesByChainAgg) {
+		const v = oraclesByChainAgg[k]
+		aggregatedOraclesByChain[k] = Array.from(v).sort((a, b) => a.localeCompare(b))
+	}
 
 	return {
 		name: parent.name,
@@ -265,7 +275,7 @@ export const groupProtocols = (
 ) => {
 	let data = [...protocols]
 
-	parentProtocols.forEach((item) => {
+	for (const item of parentProtocols) {
 		const list = protocols.filter((p) => p.parentProtocol === item.id)
 
 		if (list.length >= 2) {
@@ -275,7 +285,7 @@ export const groupProtocols = (
 
 			data.push(groupData(list, item, noSubrows))
 		}
-	})
+	}
 
 	return data.sort((a, b) => b.tvl - a.tvl)
 }

--- a/src/hooks/useBookmarks.tsx
+++ b/src/hooks/useBookmarks.tsx
@@ -57,7 +57,7 @@ export function useBookmarks(type: 'defi' | 'yields' | 'chains') {
 
 			// Deep merge watchlists
 			const mergedWatchlist = { ...localWatchlistData }
-			Object.keys(serverWatchlist).forEach((portfolio) => {
+			for (const portfolio of Object.keys(serverWatchlist)) {
 				if (!mergedWatchlist[portfolio]) {
 					mergedWatchlist[portfolio] = {}
 				}
@@ -65,7 +65,7 @@ export function useBookmarks(type: 'defi' | 'yields' | 'chains') {
 					...mergedWatchlist[portfolio],
 					...serverWatchlist[portfolio]
 				}
-			})
+			}
 
 			// Update localStorage with merged data
 			const updatedData = {

--- a/src/pages/airdrops.tsx
+++ b/src/pages/airdrops.tsx
@@ -154,11 +154,11 @@ export const getStaticProps = withPerformanceLogging('airdrops', async () => {
 
 	const forkedList: { [name: string]: boolean } = {}
 
-	Object.values(forks).map((list: string[]) => {
-		list.map((f) => {
+	for (const list of Object.values(forks) as string[][]) {
+		for (const f of list) {
 			forkedList[f] = true
-		})
-	})
+		}
+	}
 
 	return {
 		props: {

--- a/src/pages/api/datasets/aggregators.ts
+++ b/src/pages/api/datasets/aggregators.ts
@@ -49,7 +49,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 					continue
 				}
 
-				data.protocols.forEach((protocol: any) => {
+				for (const protocol of data.protocols) {
 					const key = protocol.defillamaId || protocol.name
 					const normalizedChainKey = chainName.trim().toLowerCase()
 
@@ -78,7 +78,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 							slug: protocol.slug
 						})
 					}
-				})
+				}
 			}
 
 			const aggregatedProtocols = Array.from(allProtocolsMap.values())

--- a/src/pages/api/datasets/bridge-aggregators.ts
+++ b/src/pages/api/datasets/bridge-aggregators.ts
@@ -49,7 +49,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 					continue
 				}
 
-				data.protocols.forEach((protocol: any) => {
+				for (const protocol of data.protocols) {
 					const key = protocol.defillamaId || protocol.name
 					const normalizedChainKey = chainName.trim().toLowerCase()
 
@@ -78,7 +78,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 							slug: protocol.slug
 						})
 					}
-				})
+				}
 			}
 
 			const aggregatedProtocols = Array.from(allProtocolsMap.values())

--- a/src/pages/api/datasets/cex.ts
+++ b/src/pages/api/datasets/cex.ts
@@ -76,14 +76,14 @@ export async function getCexData(req: NextApiRequest, res: NextApiResponse) {
 				let cexTvl = 0
 				let ownToken = 0
 
-				Object.values(chainTvls as IChainTvl).forEach((item: any) => {
-					if (item.tvl) {
-						cexTvl += item.tvl[item.tvl.length - 1]?.totalLiquidityUSD ?? 0
+				for (const item of Object.values(chainTvls as IChainTvl)) {
+					if ((item as any).tvl) {
+						cexTvl += (item as any).tvl[(item as any).tvl.length - 1]?.totalLiquidityUSD ?? 0
 					}
-					if (item.tokensInUsd && c.coin) {
-						ownToken += item.tokensInUsd[item.tokensInUsd.length - 1]?.tokens[c.coin] ?? 0
+					if ((item as any).tokensInUsd && c.coin) {
+						ownToken += (item as any).tokensInUsd[(item as any).tokensInUsd.length - 1]?.tokens[c.coin] ?? 0
 					}
-				})
+				}
 
 				const cleanTvl = cexTvl - ownToken
 

--- a/src/pages/api/datasets/dexs.ts
+++ b/src/pages/api/datasets/dexs.ts
@@ -49,7 +49,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 					continue
 				}
 
-				data.protocols.forEach((protocol: any) => {
+				for (const protocol of data.protocols) {
 					const key = protocol.defillamaId || protocol.name
 					if (allProtocolsMap.has(key)) {
 						const existing = allProtocolsMap.get(key)
@@ -65,7 +65,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 							slug: protocol.slug
 						})
 					}
-				})
+				}
 			}
 
 			const aggregatedProtocols = Array.from(allProtocolsMap.values())

--- a/src/pages/api/datasets/earnings.ts
+++ b/src/pages/api/datasets/earnings.ts
@@ -56,7 +56,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 				}
 
 				// Aggregate protocols across chains
-				data.protocols.forEach((protocol: any) => {
+				for (const protocol of data.protocols) {
 					const key = protocol.defillamaId || protocol.name
 					const normalizedChainKey = chainName.trim().toLowerCase()
 
@@ -86,7 +86,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 							slug: protocol.slug
 						})
 					}
-				})
+				}
 			}
 
 			const aggregatedProtocols = Array.from(allProtocolsMap.values())

--- a/src/pages/api/datasets/fees.ts
+++ b/src/pages/api/datasets/fees.ts
@@ -51,7 +51,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 					continue
 				}
 
-				data.protocols.forEach((protocol: any) => {
+				for (const protocol of data.protocols) {
 					const key = protocol.defillamaId || protocol.name
 					if (allProtocolsMap.has(key)) {
 						const existing = allProtocolsMap.get(key)
@@ -68,7 +68,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 							slug: protocol.slug
 						})
 					}
-				})
+				}
 			}
 
 			const aggregatedProtocols = Array.from(allProtocolsMap.values())

--- a/src/pages/api/datasets/holders-revenue.ts
+++ b/src/pages/api/datasets/holders-revenue.ts
@@ -56,7 +56,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 				}
 
 				// Aggregate protocols across chains
-				data.protocols.forEach((protocol: any) => {
+				for (const protocol of data.protocols) {
 					const key = protocol.defillamaId || protocol.name
 					if (allProtocolsMap.has(key)) {
 						const existing = allProtocolsMap.get(key)
@@ -73,7 +73,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 							slug: protocol.slug
 						})
 					}
-				})
+				}
 			}
 
 			const aggregatedProtocols = Array.from(allProtocolsMap.values())

--- a/src/pages/api/datasets/options.ts
+++ b/src/pages/api/datasets/options.ts
@@ -49,7 +49,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 					continue
 				}
 
-				data.protocols.forEach((protocol: any) => {
+				for (const protocol of data.protocols) {
 					const key = protocol.defillamaId || protocol.name
 					const normalizedChainKey = chainName.trim().toLowerCase()
 
@@ -78,7 +78,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 							slug: protocol.slug
 						})
 					}
-				})
+				}
 			}
 
 			const aggregatedProtocols = Array.from(allProtocolsMap.values())

--- a/src/pages/api/datasets/perps.ts
+++ b/src/pages/api/datasets/perps.ts
@@ -50,7 +50,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 					continue
 				}
 
-				data.protocols.forEach((protocol: any) => {
+				for (const protocol of data.protocols) {
 					const key = protocol.defillamaId || protocol.name
 					if (allProtocolsMap.has(key)) {
 						const existing = allProtocolsMap.get(key)
@@ -65,7 +65,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 							slug: protocol.slug
 						})
 					}
-				})
+				}
 			}
 
 			const aggregatedProtocols = Array.from(allProtocolsMap.values())

--- a/src/pages/api/datasets/revenue.ts
+++ b/src/pages/api/datasets/revenue.ts
@@ -56,7 +56,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 				}
 
 				// Aggregate protocols across chains
-				data.protocols.forEach((protocol: any) => {
+				for (const protocol of data.protocols) {
 					const key = protocol.defillamaId || protocol.name
 					if (allProtocolsMap.has(key)) {
 						const existing = allProtocolsMap.get(key)
@@ -73,7 +73,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 							slug: protocol.slug
 						})
 					}
-				})
+				}
 			}
 
 			const aggregatedProtocols = Array.from(allProtocolsMap.values())

--- a/src/pages/borrow.tsx
+++ b/src/pages/borrow.tsx
@@ -29,18 +29,17 @@ export const getStaticProps = withPerformanceLogging('borrow', async () => {
 		}
 	}
 
-	data.symbols
-		.sort((a, b) => cgPositions[a] - cgPositions[b])
-		.forEach((sRaw) => {
-			const s = sRaw.replaceAll(/\(.*\)/g, '').trim()
+	const sortedSymbols = data.symbols.sort((a, b) => cgPositions[a] - cgPositions[b])
+	for (const sRaw of sortedSymbols) {
+		const s = sRaw.replaceAll(/\(.*\)/g, '').trim()
 
-			// const cgToken = cgTokens.find((x) => x.symbol === sRaw.toLowerCase() || x.symbol === s.toLowerCase())
+		// const cgToken = cgTokens.find((x) => x.symbol === sRaw.toLowerCase() || x.symbol === s.toLowerCase())
 
-			searchData[s] = {
-				name: s,
-				symbol: s
-			}
-		})
+		searchData[s] = {
+			name: s,
+			symbol: s
+		}
+	}
 
 	return {
 		props: {
@@ -359,11 +358,11 @@ const PoolsList = ({ pools }: { pools: Array<IPool> }) => {
 
 	const filteredPools2 = {}
 
-	filteredPools.forEach((pool) => {
+	for (const pool of filteredPools) {
 		if (!filteredPools2[pool.projectName + pool.chain]) {
 			filteredPools2[pool.projectName + pool.chain] = pool
 		}
-	})
+	}
 
 	const finalPools: Array<IPool> = Object.values(filteredPools2)
 

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -27,12 +27,12 @@ export const getStaticProps = withPerformanceLogging('calendar', async () => {
 
 	const emissions = res.map((protocol) => {
 		const unlocksByDate = {}
-		protocol.events?.forEach((e) => {
-			if (e.timestamp < Date.now() / 1000 || (e.noOfTokens.length === 1 && e.noOfTokens[0] === 0)) return
+		for (const e of protocol.events ?? []) {
+			if (e.timestamp < Date.now() / 1000 || (e.noOfTokens.length === 1 && e.noOfTokens[0] === 0)) continue
 			unlocksByDate[e.timestamp] =
 				(unlocksByDate[e.timestamp] ?? 0) +
 				(e.noOfTokens.length === 2 ? e.noOfTokens[1] - e.noOfTokens[0] : e.noOfTokens[0])
-		})
+		}
 		const unlocksList = Object.entries(unlocksByDate)
 		const maxUnlock = unlocksList.reduce((max, curr) => {
 			if (max[1] < curr[1]) {

--- a/src/pages/categories.tsx
+++ b/src/pages/categories.tsx
@@ -35,11 +35,11 @@ export const getStaticProps = withPerformanceLogging('categories', async () => {
 	const categories = {}
 	const tagsByCategory = {}
 	const revenueByProtocol = {}
-	revenueData.protocols.forEach((p) => {
+	for (const p of revenueData.protocols) {
 		revenueByProtocol[p.defillamaId] = p.total24h || 0
-	})
+	}
 
-	protocols.forEach((p) => {
+	for (const p of protocols) {
 		const cat = p.category
 
 		const tvl = p.tvl ?? 0
@@ -75,7 +75,7 @@ export const getStaticProps = withPerformanceLogging('categories', async () => {
 				tagsByCategory[cat] = []
 			}
 
-			p.tags.forEach((t) => {
+			for (const t of p.tags) {
 				if (!tagsByCategory[cat][t]) {
 					tagsByCategory[cat][t] = {
 						name: t,
@@ -103,7 +103,7 @@ export const getStaticProps = withPerformanceLogging('categories', async () => {
 					tagsByCategory[cat][t].extraTvls[extra].tvlPrevWeek += extraTvls[extra].tvlPrevWeek
 					tagsByCategory[cat][t].extraTvls[extra].tvlPrevMonth += extraTvls[extra].tvlPrevMonth
 				}
-			})
+			}
 		}
 
 		categories[cat].protocols++
@@ -119,7 +119,7 @@ export const getStaticProps = withPerformanceLogging('categories', async () => {
 			categories[cat].extraTvls[extra].tvlPrevWeek += extraTvls[extra].tvlPrevWeek
 			categories[cat].extraTvls[extra].tvlPrevMonth += extraTvls[extra].tvlPrevMonth
 		}
-	})
+	}
 
 	for (const cat in protocolsByCategory) {
 		if (!categories[cat]) {
@@ -152,9 +152,12 @@ export const getStaticProps = withPerformanceLogging('categories', async () => {
 
 	const chartData = {}
 	const extraTvlCharts = {}
-	const totalCategories = Object.keys(protocolsByCategory).length
-	const allColors = getNDistinctColors(totalCategories)
-	const categoryColors = Object.fromEntries(Object.keys(protocolsByCategory).map((_, i) => [_, allColors[i]]))
+	const categoryKeys = Object.keys(protocolsByCategory)
+	const allColors = getNDistinctColors(categoryKeys.length)
+	const categoryColors: Record<string, string> = {}
+	for (let i = 0; i < categoryKeys.length; i++) {
+		categoryColors[categoryKeys[i]] = allColors[i]
+	}
 
 	for (const date in chart) {
 		for (const cat in protocolsByCategory) {

--- a/src/pages/compare-tokens.tsx
+++ b/src/pages/compare-tokens.tsx
@@ -28,12 +28,10 @@ export const getStaticProps = withPerformanceLogging('compare-tokens', async () 
 			}
 		)
 	])
-	const parentProtocols = Object.fromEntries(
-		tvlProtocols.parentProtocols.map((protocol) => [
-			protocol.id,
-			{ name: protocol.name, geckoId: protocol.gecko_id ?? null, tvl: null, fees: null, revenue: null }
-		])
-	)
+	const parentProtocols: Record<string, { name: string; geckoId: string | null; tvl: number | null; fees: number | null; revenue: number | null }> = {}
+	for (const protocol of tvlProtocols.parentProtocols) {
+		parentProtocols[protocol.id] = { name: protocol.name, geckoId: protocol.gecko_id ?? null, tvl: null, fees: null, revenue: null }
+	}
 	const llamaProtocols = tvlProtocols.protocols.map((protocol) => {
 		const fees = feesProtocols.protocols.find((fp) => fp.defillamaId === protocol.defillamaId)?.total24h ?? null
 		const revenue = revenueProtocols.protocols.find((fp) => fp.defillamaId === protocol.defillamaId)?.total24h ?? null

--- a/src/pages/governance/[...project].tsx
+++ b/src/pages/governance/[...project].tsx
@@ -78,9 +78,9 @@ export const getStaticProps = withPerformanceLogging(
 		const recentMonth = Object.keys(data.stats.months).sort().pop()
 		const missingMonths = getDateRange(recentMonth)
 
-		missingMonths.forEach((month) => {
+		for (const month of missingMonths) {
 			data.stats.months[month] = { total: 0, successful: 0, proposals: [] }
-		})
+		}
 
 		const { proposals, activity, maxVotes } = formatGovernanceData(data as any)
 

--- a/src/pages/lst.tsx
+++ b/src/pages/lst.tsx
@@ -406,23 +406,24 @@ async function getChartData({ chartData, lsdRates, lsdApy, lsdColors }) {
 	const barChartStacks = {}
 
 	// calc daily inflow per LSD
-	tokens.forEach((protocol) => {
+	for (const protocol of tokens) {
 		// sort ascending
 		const X = historicData.filter((i) => i.name === protocol).sort((a, b) => a.date - b.date)
 
 		const current = X.slice(1)
 		const previous = X.slice(0, -1)
 
-		current.forEach((c, i) => {
+		for (let i = 0; i < current.length; i++) {
+			const c = current[i]
 			if (!inflowsChartData[c.date]) {
 				inflowsChartData[c.date] = {}
 			}
 
 			inflowsChartData[c.date][c.name] = c.value - previous[i].value
-		})
+		}
 
 		barChartStacks[protocol] = 'A'
-	})
+	}
 
 	return {
 		areaChartData,

--- a/src/pages/pitch.tsx
+++ b/src/pages/pitch.tsx
@@ -29,7 +29,7 @@ async function generateVCList(): Promise<VC[]> {
 		raises.reduce((acc, raise) => {
 			const defiCategory = protocolsCategoryById[raise.defillamaId]
 			const investors = raise.leadInvestors.concat(raise.otherInvestors)
-			investors.forEach((vc) => {
+			for (const vc of investors) {
 				if (!acc[vc]) {
 					acc[vc] = {
 						name: vc,
@@ -48,7 +48,7 @@ async function generateVCList(): Promise<VC[]> {
 					acc[vc].numInvestments += 1
 					acc[vc].defiCategories.add(defiCategory)
 				}
-			})
+			}
 			return acc
 		}, {})
 	)
@@ -144,7 +144,13 @@ const VCFilterPage = ({ categories, chains, defiCategories, roundTypes, lastRoun
 	}
 
 	const fetchInvestors = async (filters) => {
-		const body = Object.fromEntries(Object.entries(filters).filter(([_key, v]: any) => v && v.length !== 0))
+		const body: Record<string, any> = {}
+		for (const key in filters) {
+			const v = filters[key]
+			if (v && v.length !== 0) {
+				body[key] = v
+			}
+		}
 
 		const response = await fetch('https://vc-emails.llama.fi/vc-list', {
 			method: 'POST',
@@ -179,7 +185,13 @@ const VCFilterPage = ({ categories, chains, defiCategories, roundTypes, lastRoun
 		e.preventDefault()
 		setIsSubmitting(true)
 		try {
-			const filtersData = Object.fromEntries(Object.entries(filters).filter(([_key, v]: any) => v && v.length !== 0))
+			const filtersData: Record<string, any> = {}
+			for (const key in filters) {
+				const v = filters[key]
+				if (v && v.length !== 0) {
+					filtersData[key] = v
+				}
+			}
 			const response = await fetch('https://vc-emails.llama.fi/new-payment', {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },

--- a/src/pages/unlocks/calendar.tsx
+++ b/src/pages/unlocks/calendar.tsx
@@ -52,9 +52,9 @@ export const getStaticProps = withPerformanceLogging('unlocks-calendar', async (
 		listEvents: {} as { [startDateKey: string]: Array<{ date: string; event: any }> }
 	}
 
-	data?.forEach((protocol) => {
+	for (const protocol of data ?? []) {
 		if (!protocol.events || protocol.tPrice === null || protocol.tPrice === undefined) {
-			return
+			continue
 		}
 
 		const processedEvents: Array<{
@@ -69,10 +69,10 @@ export const getStaticProps = withPerformanceLogging('unlocks-calendar', async (
 			(event) => event.timestamp !== null && event.noOfTokens && event.noOfTokens.length > 0
 		)
 
-		validEvents.forEach((event) => {
+		for (const event of validEvents) {
 			const totalTokens = event.noOfTokens.reduce((sum, amount) => sum + amount, 0)
 			if (totalTokens === 0) {
-				return
+				continue
 			}
 
 			const valueUSD = totalTokens * protocol.tPrice
@@ -86,12 +86,12 @@ export const getStaticProps = withPerformanceLogging('unlocks-calendar', async (
 				unlockType: unlockType,
 				category: event.category || ''
 			})
-		})
+		}
 
 		const protocolUnlocksByDate: {
 			[date: string]: { value: number; details: string[]; unlockTypes: string[]; category?: string }
 		} = {}
-		processedEvents.forEach((processedEvent) => {
+		for (const processedEvent of processedEvents) {
 			if (!protocolUnlocksByDate[processedEvent.dateStr]) {
 				protocolUnlocksByDate[processedEvent.dateStr] = { value: 0, details: [], unlockTypes: [] }
 			}
@@ -99,9 +99,10 @@ export const getStaticProps = withPerformanceLogging('unlocks-calendar', async (
 			protocolUnlocksByDate[processedEvent.dateStr].details.push(processedEvent.details)
 			protocolUnlocksByDate[processedEvent.dateStr].unlockTypes.push(processedEvent.unlockType)
 			protocolUnlocksByDate[processedEvent.dateStr].category = processedEvent.category
-		})
+		}
 
-		Object.entries(protocolUnlocksByDate).forEach(([dateStr, dailyData]) => {
+		for (const dateStr in protocolUnlocksByDate) {
+			const dailyData = protocolUnlocksByDate[dateStr]
 			if (!unlocksData[dateStr]) {
 				unlocksData[dateStr] = {
 					totalValue: 0,
@@ -116,12 +117,12 @@ export const getStaticProps = withPerformanceLogging('unlocks-calendar', async (
 				unlockType: dailyData.unlockTypes.find((type) => type !== '') || '',
 				category: dailyData.category
 			})
-		})
-	})
+		}
+	}
 
-	Object.keys(unlocksData).forEach((date) => {
+	for (const date in unlocksData) {
 		unlocksData[date].events.sort((a, b) => b.value - a.value)
-	})
+	}
 
 	const currentYear = new Date().getFullYear()
 	for (let year = currentYear - 1; year <= currentYear + 2; year++) {
@@ -131,14 +132,15 @@ export const getStaticProps = withPerformanceLogging('unlocks-calendar', async (
 			const monthKey = `${year}-${month.toString().padStart(2, '0')}`
 
 			let maxValue = 0
-			Object.entries(unlocksData).forEach(([dateStr, dailyData]) => {
+			for (const dateStr in unlocksData) {
+				const dailyData = unlocksData[dateStr]
 				const date = dayjs(dateStr)
 				if (date.isBetween(startOfMonth.subtract(1, 'day'), endOfMonth.add(1, 'day'))) {
 					if (dailyData.totalValue > maxValue) {
 						maxValue = dailyData.totalValue
 					}
 				}
-			})
+			}
 			precomputedData.monthlyMaxValues[monthKey] = maxValue
 		}
 	}
@@ -150,14 +152,15 @@ export const getStaticProps = withPerformanceLogging('unlocks-calendar', async (
 		const startDateKey = startDate.format('YYYY-MM-DD')
 
 		const events: Array<{ date: string; event: any }> = []
-		Object.entries(unlocksData).forEach(([dateStr, dailyData]) => {
+		for (const dateStr in unlocksData) {
+			const dailyData = unlocksData[dateStr]
 			const date = dayjs(dateStr)
 			if (date.isBetween(startDate.subtract(1, 'day'), endDate)) {
-				dailyData.events.forEach((event) => {
+				for (const event of dailyData.events) {
 					events.push({ date: dateStr, event })
-				})
+				}
 			}
-		})
+		}
 
 		events.sort((a, b) => dayjs(a.date).valueOf() - dayjs(b.date).valueOf())
 		precomputedData.listEvents[startDateKey] = events

--- a/src/pages/unlocks/index.tsx
+++ b/src/pages/unlocks/index.tsx
@@ -22,30 +22,32 @@ const calculateUnlockStatistics = (data) => {
 	const thirtyDaysLater = now + 30 * 24 * 60 * 60
 	const sevenDaysLater = now + 7 * 24 * 60 * 60
 
-	data?.forEach((protocol) => {
-		if (!protocol.upcomingEvent || protocol.tPrice === null || protocol.tPrice === undefined) {
-			return
+	if (data) {
+		for (const protocol of data) {
+			if (!protocol.upcomingEvent || protocol.tPrice === null || protocol.tPrice === undefined) {
+				continue
+			}
+
+			for (const event of protocol.upcomingEvent) {
+				if (event.timestamp === null || !event.noOfTokens || event.noOfTokens.length === 0) {
+					continue
+				}
+
+				const totalTokens = event.noOfTokens.reduce((sum, amount) => sum + amount, 0)
+				if (totalTokens === 0) {
+					continue
+				}
+
+				const valueUSD = totalTokens * protocol.tPrice
+				if (event.timestamp >= now && event.timestamp <= thirtyDaysLater) {
+					upcomingUnlocks30dValue += valueUSD
+				}
+				if (event.timestamp >= now && event.timestamp <= sevenDaysLater) {
+					upcomingUnlocks7dValue += valueUSD
+				}
+			}
 		}
-
-		protocol.upcomingEvent.forEach((event) => {
-			if (event.timestamp === null || !event.noOfTokens || event.noOfTokens.length === 0) {
-				return
-			}
-
-			const totalTokens = event.noOfTokens.reduce((sum, amount) => sum + amount, 0)
-			if (totalTokens === 0) {
-				return
-			}
-
-			const valueUSD = totalTokens * protocol.tPrice
-			if (event.timestamp >= now && event.timestamp <= thirtyDaysLater) {
-				upcomingUnlocks30dValue += valueUSD
-			}
-			if (event.timestamp >= now && event.timestamp <= sevenDaysLater) {
-				upcomingUnlocks7dValue += valueUSD
-			}
-		})
-	})
+	}
 
 	return {
 		upcomingUnlocks7dValue,

--- a/src/pages/yields/loop.tsx
+++ b/src/pages/yields/loop.tsx
@@ -16,7 +16,7 @@ export const getStaticProps = withPerformanceLogging('yields/loop', async () => 
 
 	const tokens = []
 
-	cgTokens.forEach((token) => {
+	for (const token of cgTokens) {
 		if (token.symbol) {
 			tokens.push({
 				name: token.name,
@@ -25,7 +25,7 @@ export const getStaticProps = withPerformanceLogging('yields/loop', async () => 
 				fallbackLogo: token.image || null
 			})
 		}
-	})
+	}
 
 	return {
 		props: {

--- a/src/pages/yields/pool/[pool].tsx
+++ b/src/pages/yields/pool/[pool].tsx
@@ -115,9 +115,9 @@ const PageView = (_props) => {
 		if (!chart?.data || !query?.pool) return { filename: `yields.csv`, rows: [] }
 		const rows = [['APY', 'APY_BASE', 'APY_REWARD', 'TVL', 'DATE']]
 
-		chart?.data?.forEach((item) => {
+		for (const item of chart?.data ?? []) {
 			rows.push([item.apy, item.apyBase, item.apyReward, item.tvlUsd, item.timestamp])
-		})
+		}
 
 		return { filename: `${query.pool}.csv`, rows: rows as (string | number | boolean)[][] }
 	}, [chart?.data, query?.pool])

--- a/src/pages/yields/projects.tsx
+++ b/src/pages/yields/projects.tsx
@@ -23,14 +23,14 @@ export const getStaticProps = withPerformanceLogging('yields/projects', async ()
 	data.props.pools = data.props.pools.filter((p) => p.apy > 0)
 
 	const projects = {}
-	data.props.pools.forEach((p) => {
+	for (const p of data.props.pools) {
 		const proj = p.project
 		if (projects[proj] === undefined) {
 			projects[proj] = { protocols: 0, tvl: 0, name: p.projectName }
 		}
 		projects[proj].protocols++
 		projects[proj].tvl += p.tvlUsd
-	})
+	}
 
 	// add other fields
 	for (const project of Object.keys(projects)) {

--- a/src/pages/yields/strategy/[strat].js
+++ b/src/pages/yields/strategy/[strat].js
@@ -85,14 +85,14 @@ const PageView = () => {
 		]
 
 		let merged = []
-		uniqueDates.forEach((d) => {
+		for (const d of uniqueDates) {
 			merged.push({
 				timestamp: d,
 				lendData: lendDataMap.get(d),
 				borrowData: borrowDataMap.get(d),
 				farmData: farmDataMap.get(d)
 			})
-		})
+		}
 		merged = merged.filter((t) => !Object.values(t).includes(undefined))
 		// filter merged to length where all 3 components (lend/borrow/farm values) are not null
 		merged = merged.filter(

--- a/src/pages/yields/strategyLongShort.tsx
+++ b/src/pages/yields/strategyLongShort.tsx
@@ -34,7 +34,7 @@ export const getStaticProps = withPerformanceLogging('yields/strategyLongShort',
 	const tokens = []
 	const tokenSymbolsList = []
 
-	cgTokens.forEach((token) => {
+	for (const token of cgTokens) {
 		if (token.symbol) {
 			tokens.push({
 				name: token.name,
@@ -44,7 +44,7 @@ export const getStaticProps = withPerformanceLogging('yields/strategyLongShort',
 			})
 			tokenSymbolsList.push(token.symbol?.toUpperCase())
 		}
-	})
+	}
 
 	return {
 		props: {

--- a/src/server/protocolSplit/dimensionsSplit.ts
+++ b/src/server/protocolSplit/dimensionsSplit.ts
@@ -75,11 +75,13 @@ const fetchChainResults = async (chainsArray: string[], metric: string): Promise
 
 const toBreakdownMap = (breakdown: Array<[number, Record<string, number>]>): Map<number, Map<string, number>> => {
 	const map = new Map<number, Map<string, number>>()
-	breakdown.forEach(([ts, protocols]) => {
+	for (const [ts, protocols] of breakdown) {
 		const m = new Map<string, number>()
-		Object.entries(protocols || {}).forEach(([name, v]) => m.set(name, v as number))
+		for (const name in protocols || {}) {
+			m.set(name, protocols[name] as number)
+		}
 		map.set(ts, m)
-	})
+	}
 	return map
 }
 
@@ -140,9 +142,9 @@ const buildAggregatedBreakdown = async (
 			const { data } = result
 			if (!data.totalDataChartBreakdown || !Array.isArray(data.totalDataChartBreakdown)) continue
 
-			data.totalDataChartBreakdown.forEach((item: any) => {
+			for (const item of data.totalDataChartBreakdown as any[]) {
 				const [timestamp, protocols] = item
-				if (!protocols) return
+				if (!protocols) continue
 
 				if (!aggregatedBreakdown.has(timestamp)) {
 					aggregatedBreakdown.set(timestamp, new Map())
@@ -150,11 +152,12 @@ const buildAggregatedBreakdown = async (
 
 				const timestampData = aggregatedBreakdown.get(timestamp)!
 
-				Object.entries(protocols).forEach(([protocolName, value]) => {
+				for (const protocolName in protocols) {
+					const value = protocols[protocolName]
 					const currentValue = timestampData.get(protocolName) || 0
 					timestampData.set(protocolName, currentValue + (value as number))
-				})
-			})
+				}
+			}
 		}
 	}
 
@@ -227,7 +230,7 @@ export const getDimensionsSplitData = async ({
 		}
 	}
 
-	protocols.forEach((protocol: any) => {
+	for (const protocol of protocols as any[]) {
 		if (protocol.name) {
 			if (protocol.category) {
 				const cat = protocol.category.toLowerCase()
@@ -238,7 +241,7 @@ export const getDimensionsSplitData = async ({
 				protocolToParentId.set(protocol.name, protocol.parentProtocol)
 			}
 		}
-	})
+	}
 
 	const getCategory = (name: string): string => {
 		return protocolCategories.get(name) || protocolCategoriesBySlug.get(toSlug(name)) || ''
@@ -313,27 +316,28 @@ export const getDimensionsSplitData = async ({
 	}
 
 	const protocolData: Map<string, [number, number][]> = new Map()
-	topProtocols.forEach((protocol) => {
+	for (const protocol of topProtocols) {
 		protocolData.set(protocol, [])
-	})
+	}
 
 	const timestampTotals: Map<number, number> = new Map()
 	const timestampTopTotals: Map<number, number> = new Map()
 
-	data.totalDataChartBreakdown.forEach((item: any) => {
+	for (const item of data.totalDataChartBreakdown as any[]) {
 		const [timestamp, protocols] = item
-		if (!protocols) return
+		if (!protocols) continue
 
 		let dayTotal = 0
 		let topTotal = 0
 
-		Object.entries(protocols).forEach(([protocolName, value]) => {
+		for (const protocolName in protocols) {
+			const value = protocols[protocolName]
 			if (categoriesArray.length > 0 && (protocolCategories.size > 0 || protocolCategoriesBySlug.size > 0)) {
 				const cat = getCategory(protocolName)
 				if (categoryFilterMode === 'exclude') {
-					if (categoriesArray.includes(cat)) return
+					if (categoriesArray.includes(cat)) continue
 				} else {
-					if (!categoriesArray.includes(cat)) return
+					if (!categoriesArray.includes(cat)) continue
 				}
 			}
 
@@ -354,17 +358,18 @@ export const getDimensionsSplitData = async ({
 					}
 				}
 			}
-		})
+		}
 
 		timestampTotals.set(timestamp, dayTotal)
 		timestampTopTotals.set(timestamp, topTotal)
-	})
+	}
 
 	const allTimestamps = Array.from(timestampTotals.keys()).sort((a, b) => a - b)
 
 	const series: ChartSeries[] = []
 
-	topProtocols.forEach((protocol, index) => {
+	for (let i = 0; i < topProtocols.length; i++) {
+		const protocol = topProtocols[i]
 		const sortedData = (protocolData.get(protocol) || []).sort((a, b) => a[0] - b[0])
 		const protocolDataMap = new Map(sortedData)
 
@@ -375,9 +380,9 @@ export const getDimensionsSplitData = async ({
 		series.push({
 			name: protocol,
 			data: alignedData,
-			color: EXTENDED_COLOR_PALETTE[index % EXTENDED_COLOR_PALETTE.length]
+			color: EXTENDED_COLOR_PALETTE[i % EXTENDED_COLOR_PALETTE.length]
 		})
-	})
+	}
 
 	const othersData: [number, number][] = allTimestamps.map((timestamp) => {
 		const total = timestampTotals.get(timestamp) || 0

--- a/src/server/protocolSplit/tvlSplit.ts
+++ b/src/server/protocolSplit/tvlSplit.ts
@@ -399,8 +399,14 @@ export const getTvlSplitData = async (
 	}
 
 	const timestampSet = new Set<number>()
-	totalSeries.forEach(([t]) => timestampSet.add(t))
-	protocolSeries.forEach((s) => s.data.forEach(([t]) => timestampSet.add(t)))
+	for (const [t] of totalSeries) {
+		timestampSet.add(t)
+	}
+	for (const s of protocolSeries) {
+		for (const [t] of s.data) {
+			timestampSet.add(t)
+		}
+	}
 	const allTimestamps = Array.from(timestampSet).sort((a, b) => a - b)
 
 	const alignedProtocolSeries: ChartSeries[] = protocolSeries.map((s, idx) => ({

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -74,14 +74,15 @@ export const toNiceDayMonthYear = (date) => dayjs.utc(dayjs.unix(date)).format('
 export const timeFromNow = (date) => dayjs.utc(dayjs.unix(date)).fromNow()
 
 export function formatUnlocksEvent({ description, noOfTokens, timestamp, price, symbol }) {
-	noOfTokens.forEach((tokens, i) => {
+	for (let i = 0; i < noOfTokens.length; i++) {
+		const tokens = noOfTokens[i]
 		description = description.replace(
 			`{tokens[${i}]}`,
 			`${formattedNum(tokens || 0) + (symbol ? ` ${symbol}` : '')}${
 				price ? ` ($${formattedNum((tokens || 0) * price)})` : ''
 			}`
 		)
-	})
+	}
 	description = description?.replace('{timestamp}', `${toNiceDateYear(timestamp)} (${timeFromNow(timestamp)})`)
 	return description
 }
@@ -791,18 +792,14 @@ export const formatPercentage = (value) => {
 	let zeroes = 0
 	let stop = false
 
-	value
-		.toString()
-		.split('.')?.[1]
-		?.slice(0, 5)
-		?.split('')
-		?.forEach((x) => {
-			if (!stop && x == '0') {
-				zeroes += 1
-			} else {
-				stop = true
-			}
-		})
+	const decimals = value.toString().split('.')?.[1]?.slice(0, 5)?.split('') ?? []
+	for (const x of decimals) {
+		if (!stop && x == '0') {
+			zeroes += 1
+		} else {
+			stop = true
+		}
+	}
 
 	return value.toLocaleString(undefined, { maximumFractionDigits: zeroes + 1 })
 }
@@ -810,10 +807,11 @@ export const formatPercentage = (value) => {
 export function iterateAndRemoveUndefined(obj) {
 	if (typeof obj !== 'object') return obj
 	if (Array.isArray(obj)) return obj
-	Object.entries(obj).forEach((key, value) => {
+	for (const key in obj) {
+		const value = obj[key]
 		if (value === undefined) delete obj[key]
 		else iterateAndRemoveUndefined(value)
-	})
+	}
 	return obj
 }
 

--- a/src/utils/tvl.ts
+++ b/src/utils/tvl.ts
@@ -126,7 +126,8 @@ export const processAdjustedProtocolTvl = (
 	const hasInclude = includeSet.size > 0
 	const hasExclude = excludeSet.size > 0
 
-	for (const [key, val] of Object.entries(chainTvls || {})) {
+	for (const key in chainTvls || {}) {
+		const val = (chainTvls || {})[key]
 		if (!val || typeof val !== 'object') continue
 		if (isIgnoreKey(key)) continue
 
@@ -169,7 +170,11 @@ export const processAdjustedProtocolTvl = (
 	}
 
 	const tsSet = new Set<number>()
-	;[base, dc, ls, overlap].forEach((m) => m.forEach((_, ts) => tsSet.add(ts)))
+	for (const m of [base, dc, ls, overlap]) {
+		for (const [ts] of m) {
+			tsSet.add(ts)
+		}
+	}
 	const allTs = Array.from(tsSet).sort((a, b) => a - b)
 
 	const adjusted: [number, number][] = allTs.map((ts) => [


### PR DESCRIPTION
## Summary
- Replace Array.forEach with for..of loops for better performance
- Convert Object.entries/keys.forEach to for..in loops
- Replace side-effect-only Array.map() calls with for..of
- Convert Object.fromEntries patterns to direct object assignment
- Fixed conductor.json setup command structure

All conversions complete across 154 files. TypeScript compiles without errors.