### PR TITLE
Perf: Pre-compute TVL 24h change on server

### DIFF
--- a/src/containers/ChainOverview/Stats.tsx
+++ b/src/containers/ChainOverview/Stats.tsx
@@ -107,6 +107,7 @@ export const Stats = memo(function Stats(props: IStatsProps) {
 			denomination,
 			selectedChain: props.metadata.name,
 			tvlChart: props.tvlChart,
+			tvlChartSummary: props.tvlChartSummary,
 			extraTvlCharts: props.extraTvlCharts,
 			tvlSettings,
 			chainGeckoId,

--- a/src/containers/ChainOverview/types.ts
+++ b/src/containers/ChainOverview/types.ts
@@ -33,6 +33,13 @@ export interface IChainOverviewData {
 	metadata: IChainMetadata
 	protocols: Array<IProtocol>
 	tvlChart: Array<[number, number]>
+	/** Pre-computed TVL values to avoid client-side iteration */
+	tvlChartSummary: {
+		totalValueUSD: number | null
+		tvlPrevDay: number | null
+		valueChange24hUSD: number | null
+		change24h: number | null
+	}
 	extraTvlCharts: {
 		staking: Record<string, number>
 		borrowed: Record<string, number>

--- a/src/containers/ChainOverview/useFetchChainChartData.tsx
+++ b/src/containers/ChainOverview/useFetchChainChartData.tsx
@@ -61,6 +61,7 @@ export const useFetchChainChartData = ({
 	denomination,
 	selectedChain,
 	tvlChart,
+	tvlChartSummary,
 	extraTvlCharts,
 	tvlSettings,
 	chainGeckoId,
@@ -70,6 +71,12 @@ export const useFetchChainChartData = ({
 	denomination: string
 	selectedChain: string
 	tvlChart: Array<[number, number]>
+	tvlChartSummary: {
+		totalValueUSD: number | null
+		tvlPrevDay: number | null
+		valueChange24hUSD: number | null
+		change24h: number | null
+	}
 	extraTvlCharts: Record<string, Record<string, number>>
 	tvlSettings: Record<string, boolean>
 	chainGeckoId?: string
@@ -293,10 +300,13 @@ export const useFetchChainChartData = ({
 		const toggledTvlSettings = TVL_SETTINGS_KEYS.filter((key) => tvlSettings[key])
 
 		if (toggledTvlSettings.length === 0) {
-			const { totalValueUSD, tvlPrevDay } = getTvl24hChange(tvlChart)
-			const valueChange24hUSD = totalValueUSD != null && tvlPrevDay != null ? totalValueUSD - tvlPrevDay : null
-			const change24h = totalValueUSD != null && tvlPrevDay != null ? getPercentChange(totalValueUSD, tvlPrevDay) : null
-			return { finalTvlChart: tvlChart, totalValueUSD, valueChange24hUSD, change24h }
+			// Use pre-computed values from server to avoid client-side iteration
+			return {
+				finalTvlChart: tvlChart,
+				totalValueUSD: tvlChartSummary.totalValueUSD,
+				valueChange24hUSD: tvlChartSummary.valueChange24hUSD,
+				change24h: tvlChartSummary.change24h
+			}
 		}
 
 		const toggledTvlSettingsSet = new Set(toggledTvlSettings)
@@ -328,7 +338,7 @@ export const useFetchChainChartData = ({
 		const change24h = totalValueUSD != null && tvlPrevDay != null ? getPercentChange(totalValueUSD, tvlPrevDay) : null
 		const isGovTokensEnabled = !!tvlSettings?.govtokens
 		return { finalTvlChart, totalValueUSD, valueChange24hUSD, change24h, isGovTokensEnabled }
-	}, [tvlChart, extraTvlCharts, tvlSettings])
+	}, [tvlChart, tvlChartSummary, extraTvlCharts, tvlSettings])
 
 	const chartData = useMemo(() => {
 		const charts: { [key in ChainChartLabels]?: Array<[number, number]> } = {}

--- a/src/pages/chart/chain/[...chain].tsx
+++ b/src/pages/chart/chain/[...chain].tsx
@@ -113,6 +113,7 @@ export default function ChainChartPage(props) {
 		denomination,
 		selectedChain,
 		tvlChart: props.tvlChart,
+		tvlChartSummary: props.tvlChartSummary,
 		extraTvlCharts: props.extraTvlChart,
 		tvlSettings,
 		chainGeckoId,


### PR DESCRIPTION
Move the expensive tvlChart iteration (which finds the 24h-old entry) from the client useFetchChainChartData hook to the server-side getChainOverviewData function. This eliminates blocking CPU time during React hydration on the home page.

## Changes
- Add `computeTvlChartSummary()` helper on server to pre-compute TVL 24h change values
- Update `IChainOverviewData` type to include pre-computed `tvlChartSummary`
- Modify `useFetchChainChartData` to use pre-computed values when no TVL settings are toggled
- Update call sites in Stats and chart pages to pass the summary

## Impact
This reduces client-side blocking time by eliminating unnecessary iteration through thousands of tvlChart entries during initial hydration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized TVL (Total Value Locked) metrics computation by moving calculations from client-side to server-side, reducing client-side processing overhead.
  * Pre-computed TVL summary data now includes total value, previous day value, 24-hour value change, and percentage change for improved performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->