### PR TITLE
fix: income statement tooltip labels

### DIFF
--- a/src/containers/ProtocolOverview/IncomeStatement.tsx
+++ b/src/containers/ProtocolOverview/IncomeStatement.tsx
@@ -741,6 +741,7 @@ const IncomeStatementByLabel = ({
 													}
 													groupBy={groupBy}
 													dataType={dataType}
+													label={breakdownlabel}
 												/>
 											}
 											className="justify-start underline decoration-black/60 decoration-dotted dark:decoration-white/60"
@@ -764,7 +765,8 @@ const PerformanceTooltipContent = ({
 	currentValue,
 	previousValue,
 	groupBy,
-	dataType
+	dataType,
+	label
 }: {
 	currentValue: number
 	previousValue: number
@@ -777,6 +779,7 @@ const PerformanceTooltipContent = ({
 		| 'earnings'
 		| 'token holder net income'
 		| 'others token holder flows'
+	label?: string
 }) => {
 	if (previousValue == null) return null
 	const valueChange = currentValue - previousValue
@@ -785,6 +788,7 @@ const PerformanceTooltipContent = ({
 		percentageChange > 0
 			? `+${percentageChange.toLocaleString(undefined, { maximumFractionDigits: 2 })}%`
 			: `${percentageChange.toLocaleString(undefined, { maximumFractionDigits: 2 })}%`
+	const displayLabel = label ? label.toLowerCase() : dataType
 	return (
 		<p className="text-xs">
 			<span className={`${percentageChange > 0 ? 'text-(--success)' : 'text-(--error)'}`}>
@@ -792,7 +796,7 @@ const PerformanceTooltipContent = ({
 			</span>{' '}
 			<span>
 				compared to previous {groupBy === 'Yearly' ? 'year' : groupBy === 'Quarterly' ? 'quarter' : 'month'} total{' '}
-				{dataType}
+				{displayLabel}
 			</span>
 		</p>
 	)


### PR DESCRIPTION
### What
- Pass the breakdown label through to the tooltip and use it where available over dataType
- Kept the text in the tooltip lowercase to match the existing dataType functionality

### Why
- When viewing breakdown rows, the tooltip currently refers to the overall data type. So if you're hovering over `Staking Rewards` under Total Cost of Revenue, it will say `+1.09% compared to previous month total cost of revenue` when actually it should be `+1.09% compared to previous month total staking rewards`

### Screenshots
Before (hovering over MEV Rewards):
<img width="557" height="121" alt="Screenshot 2026-01-19 at 22 20 04" src="https://github.com/user-attachments/assets/b5cb28c0-80ec-4e78-91bc-9d0c495383e3" />

After (hovering over MEV Rewards):
<img width="551" height="110" alt="Screenshot 2026-01-19 at 22 19 42" src="https://github.com/user-attachments/assets/e944f789-a28a-49ec-9e54-ef3ab3d242e6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip display to show breakdown labels in a more readable format (lowercased) instead of raw data types, providing clearer context for per-label comparisons in income statement tooltips.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->