### PR TITLE
Fix: Close metrics modal when clicking link to current page

### DIFF
--- a/src/components/Metrics.tsx
+++ b/src/components/Metrics.tsx
@@ -239,7 +239,7 @@ export function LinkToMetricOrToolPage({
 	const isCurrentPage = useRouter().pathname === page.route
 
 	const handleClick = (e: React.MouseEvent) => {
-		if (isCurrentPage && dialogStore) {
+		if (isCurrentPage && dialogStore && e.button === 0 && !e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey) {
 			e.preventDefault()
 			dialogStore.hide()
 		}


### PR DESCRIPTION
When user clicks a link in the metrics modal that points to the 
current page, the modal now closes instead of doing nothing.

Before: Clicking link to current path → nothing happens (confusing)
After: Clicking link to current path → modal closes (expected behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dialogs now close when a user clicks a link to the page they’re already on, preventing redundant navigation and keeping the interface consistent.
  * Existing behavior for external links remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->