### PR TITLE
Optimize localStorage usage with React Compiler

### DIFF
--- a/src/components/Metrics.tsx
+++ b/src/components/Metrics.tsx
@@ -229,7 +229,7 @@ export function LinkToMetricOrToolPage({
 		() => '[]'
 	)
 
-	const pinnedPages = JSON.parse(pinnedMetrics)
+	const pinnedPages = useMemo(() => JSON.parse(pinnedMetrics), [pinnedMetrics])
 	const isPinned = pinnedPages.includes(page.route)
 
 	const isExternalLink = page.route.startsWith('http')

--- a/src/containers/ChainOverview/Table.tsx
+++ b/src/containers/ChainOverview/Table.tsx
@@ -184,10 +184,11 @@ export const ChainProtocolsTable = ({
 		}
 	}
 
+	const columnVisibility = useMemo(() => JSON.parse(columnsInStorage), [columnsInStorage])
+
 	const selectedColumns = useMemo(() => {
-		const storage = JSON.parse(columnsInStorage)
-		return mergedColumns.filter((c) => !!storage[c.key]).map((c) => c.key)
-	}, [columnsInStorage, mergedColumns])
+		return mergedColumns.filter((c) => !!columnVisibility[c.key]).map((c) => c.key)
+	}, [columnVisibility, mergedColumns])
 
 	const [sorting, setSorting] = useState<SortingState>([
 		{ desc: true, id: MAIN_COLUMN_BY_CATEGORY[filterState] ?? 'tvl' }
@@ -301,7 +302,7 @@ export const ChainProtocolsTable = ({
 			sorting,
 			expanded,
 			columnSizing,
-			columnVisibility: JSON.parse(columnsInStorage)
+			columnVisibility
 		},
 		defaultColumn: {
 			sortUndefined: 'last'

--- a/src/containers/DimensionAdapters/AdapterByChain.tsx
+++ b/src/containers/DimensionAdapters/AdapterByChain.tsx
@@ -26,6 +26,7 @@ import type { ColumnOrdersByBreakpoint, ColumnSizesByBreakpoint } from '~/compon
 import { TokenLogo } from '~/components/TokenLogo'
 import { Tooltip } from '~/components/Tooltip'
 import { useLocalStorageSettingsManager } from '~/contexts/LocalStorage'
+import { setStorageItem } from '~/contexts/localStorageStore'
 import { definitions } from '~/public/definitions'
 import { chainIconUrl, formattedNum, slug } from '~/utils'
 import { chainCharts } from '../ChainOverview/constants'
@@ -354,24 +355,24 @@ export function AdapterByChain(props: IProps) {
 	const columnsKey = `columns-${props.type}`
 
 	const clearAllColumns = () => {
-		window.localStorage.setItem(columnsKey, '{}')
+		setStorageItem(columnsKey, '{}')
 		instance.getToggleAllColumnsVisibilityHandler()({ checked: false } as any)
 	}
 	const toggleAllColumns = () => {
 		const ops = JSON.stringify(Object.fromEntries(columnsOptions.map((option) => [option.key, true])))
-		window.localStorage.setItem(columnsKey, ops)
+		setStorageItem(columnsKey, ops)
 		instance.getToggleAllColumnsVisibilityHandler()({ checked: true } as any)
 	}
 
 	const addColumn = (newOptions) => {
 		const ops = Object.fromEntries(instance.getAllLeafColumns().map((col) => [col.id, newOptions.includes(col.id)]))
-		window.localStorage.setItem(columnsKey, JSON.stringify(ops))
+		setStorageItem(columnsKey, JSON.stringify(ops))
 		instance.setColumnVisibility(ops)
 	}
 
 	const addOnlyOneColumn = (newOption) => {
 		const ops = Object.fromEntries(instance.getAllLeafColumns().map((col) => [col.id, col.id === newOption]))
-		window.localStorage.setItem(columnsKey, JSON.stringify(ops))
+		setStorageItem(columnsKey, JSON.stringify(ops))
 		instance.setColumnVisibility(ops)
 	}
 

--- a/src/contexts/LocalStorage.tsx
+++ b/src/contexts/LocalStorage.tsx
@@ -395,7 +395,7 @@ export function useManageAppSettings(): [SettingsStore, (keys: Partial<Record<Se
 		() => getStorageItem(DEFILLAMA, '{}') ?? '{}',
 		() => '{}'
 	)
-	const toggledSettings = JSON.parse(store) as SettingsStore
+	const toggledSettings = useMemo(() => JSON.parse(store) as SettingsStore, [store])
 
 	return [toggledSettings, updateAllSettings]
 }
@@ -408,14 +408,14 @@ export function useYieldFilters() {
 		() => '{}'
 	)
 
-	const parsedStore = JSON.parse(store) as AppStorage
+	const parsedStore = useMemo(() => JSON.parse(store) as AppStorage, [store])
 	const savedFilters: YieldSavedFilters = parsedStore?.[YIELDS_SAVED_FILTERS] ?? {}
 
 	return {
 		savedFilters,
 		saveFilter: (name: string, filters: YieldSavedFilter) => {
 			writeAppStorage({
-				...parsedStore,
+				...readAppStorage(),
 				[YIELDS_SAVED_FILTERS]: { ...savedFilters, [name]: filters }
 			})
 		},
@@ -423,7 +423,7 @@ export function useYieldFilters() {
 			const newFilters = { ...savedFilters }
 			delete newFilters[name]
 			writeAppStorage({
-				...parsedStore,
+				...readAppStorage(),
 				[YIELDS_SAVED_FILTERS]: newFilters
 			})
 		}
@@ -436,7 +436,7 @@ export function useWatchlistManager(type: 'defi' | 'yields' | 'chains') {
 		() => getStorageItem(DEFILLAMA, '{}') ?? '{}',
 		() => '{}'
 	)
-	const parsedStore = JSON.parse(store) as AppStorage
+	const parsedStore = useMemo(() => JSON.parse(store) as AppStorage, [store])
 
 	return useMemo(() => {
 		const watchlistKey = type === 'defi' ? DEFI_WATCHLIST : type === 'yields' ? YIELDS_WATCHLIST : CHAINS_WATCHLIST
@@ -594,11 +594,11 @@ export function useLlamaAIWelcome(): [boolean, () => void] {
 		() => '{}'
 	)
 
-	const parsedStore = JSON.parse(store) as AppStorage
+	const parsedStore = useMemo(() => JSON.parse(store) as AppStorage, [store])
 	const shown = parsedStore?.[LLAMA_AI_WELCOME_SHOWN] ?? false
 
 	const setShown = () => {
-		writeAppStorage({ ...parsedStore, [LLAMA_AI_WELCOME_SHOWN]: true })
+		writeAppStorage({ ...readAppStorage(), [LLAMA_AI_WELCOME_SHOWN]: true })
 	}
 
 	return [shown, setShown]


### PR DESCRIPTION
Wrap JSON.parse calls in useMemo to prevent unnecessary re-renders with React Compiler enabled. Replace direct localStorage.setItem with setStorageItem helper to ensure storage subscriptions are properly notified. Update LocalStorage hooks to use readAppStorage() for mutations to get latest state.

This ensures better compatibility with React Compiler and prevents cascading re-renders from object references changing on each render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized metrics and column visibility calculations to reduce unnecessary re-renders
  * Improved state management consistency for better application performance
  * Enhanced storage operation abstraction for more reliable data persistence

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->