### PR TITLE
Refactor Select components: consolidate props and use includeQueryKey

### DIFF
--- a/src/components/ECharts/AreaChart/index.tsx
+++ b/src/components/ECharts/AreaChart/index.tsx
@@ -448,12 +448,7 @@ export default function AreaChart({
 							allValues={customLegendOptions}
 							selectedValues={legendOptions}
 							setSelectedValues={setLegendOptions}
-							selectOnlyOne={(newOption) => {
-								setLegendOptions([newOption])
-							}}
 							label={legendTitle}
-							clearAll={() => setLegendOptions([])}
-							toggleAll={() => setLegendOptions(customLegendOptions)}
 							labelType="smol"
 							triggerProps={{
 								className:

--- a/src/components/ECharts/BarChart/index.tsx
+++ b/src/components/ECharts/BarChart/index.tsx
@@ -289,12 +289,7 @@ export default function BarChart({
 							allValues={customLegendOptions}
 							selectedValues={legendOptions}
 							setSelectedValues={setLegendOptions}
-							selectOnlyOne={(newOption) => {
-								setLegendOptions([newOption])
-							}}
 							label={customLegendName}
-							clearAll={() => setLegendOptions([])}
-							toggleAll={() => setLegendOptions(customLegendOptions)}
 							labelType="smol"
 							triggerProps={{
 								className:

--- a/src/components/ECharts/UnlocksChart/index.tsx
+++ b/src/components/ECharts/UnlocksChart/index.tsx
@@ -382,12 +382,7 @@ export default function AreaChart({
 							allValues={customLegendOptions}
 							selectedValues={legendOptions}
 							setSelectedValues={setLegendOptions}
-							selectOnlyOne={(newOption) => {
-								setLegendOptions([newOption])
-							}}
 							label={legendTitle}
-							clearAll={() => setLegendOptions([])}
-							toggleAll={() => setLegendOptions(customLegendOptions)}
 							labelType="smol"
 							triggerProps={{
 								className:

--- a/src/components/Table/Defi/Protocols/index.tsx
+++ b/src/components/Table/Defi/Protocols/index.tsx
@@ -440,24 +440,13 @@ export const defaultColumns = JSON.stringify({
 
 const optionsKey = 'protocolsTableColumns'
 
-const clearAllOptions = () => {
-	const ops = JSON.stringify(Object.fromEntries(protocolsByChainTableColumns.map((option) => [option.key, false])))
-	setStorageItem(optionsKey, ops)
-}
-
-const toggleAllOptions = () => {
-	const ops = JSON.stringify(Object.fromEntries(protocolsByChainTableColumns.map((option) => [option.key, true])))
-	setStorageItem(optionsKey, ops)
-}
-
-const addOption = (newOptions) => {
+const setColumnOptions = (newOptions: string[]) => {
 	const ops = Object.fromEntries(protocolsByChainTableColumns.map((col) => [col.key, newOptions.includes(col.key)]))
 	setStorageItem(optionsKey, JSON.stringify(ops))
 }
 
-const addOnlyOneOption = (newOption) => {
-	const ops = Object.fromEntries(protocolsByChainTableColumns.map((col) => [col.key, col.key === newOption]))
-	setStorageItem(optionsKey, JSON.stringify(ops))
+const toggleAllOptions = () => {
+	setColumnOptions(protocolsByChainTableColumns.map((col) => col.key))
 }
 
 const ProtocolsTable = ({
@@ -565,10 +554,7 @@ export function ProtocolsByChainTable({
 				<SelectWithCombobox
 					allValues={protocolsByChainTableColumns}
 					selectedValues={selectedOptions}
-					setSelectedValues={addOption}
-					selectOnlyOne={addOnlyOneOption}
-					toggleAll={toggleAllOptions}
-					clearAll={clearAllOptions}
+					setSelectedValues={setColumnOptions}
 					nestedMenu={false}
 					label={'Columns'}
 					labelType="smol"

--- a/src/containers/ChainOverview/Table.tsx
+++ b/src/containers/ChainOverview/Table.tsx
@@ -71,34 +71,6 @@ export const ChainProtocolsTable = ({
 		() => null
 	)
 
-	const clearAllColumns = () => {
-		const ops = JSON.stringify(
-			Object.fromEntries(
-				[...columnOptions, ...customColumns.map((col, idx) => ({ key: `custom_formula_${idx}` }))].map((option) => [
-					option.key,
-					false
-				])
-			)
-		)
-		setStorageItem(tableColumnOptionsKey, ops)
-		if (instance && instance.setColumnVisibility) {
-			instance.setColumnVisibility(JSON.parse(ops))
-		}
-	}
-	const toggleAllColumns = () => {
-		const ops = JSON.stringify(
-			Object.fromEntries(
-				[...columnOptions, ...customColumns.map((col, idx) => ({ key: `custom_formula_${idx}` }))].map((option) => [
-					option.key,
-					true
-				])
-			)
-		)
-		setStorageItem(tableColumnOptionsKey, ops)
-		if (instance && instance.setColumnVisibility) {
-			instance.setColumnVisibility(JSON.parse(ops))
-		}
-	}
 
 	const [customColumnModalEditIndex, setCustomColumnModalEditIndex] = useState<number | null>(null)
 	const [customColumnModalInitialValues, setCustomColumnModalInitialValues] = useState<
@@ -166,7 +138,7 @@ export const ChainProtocolsTable = ({
 		]
 	}, [customColumns])
 
-	const addColumn = (newColumns) => {
+	const setColumnOptions = (newColumns: string[]) => {
 		const allKeys = mergedColumns.map((col) => col.key)
 		const ops = Object.fromEntries(allKeys.map((key) => [key, newColumns.includes(key)]))
 		setStorageItem(tableColumnOptionsKey, JSON.stringify(ops))
@@ -176,12 +148,8 @@ export const ChainProtocolsTable = ({
 		}
 	}
 
-	const addOnlyOneColumn = (newOption) => {
-		const ops = Object.fromEntries(instance.getAllLeafColumns().map((col) => [col.id, col.id === newOption]))
-		setStorageItem(tableColumnOptionsKey, JSON.stringify(ops))
-		if (instance && instance.setColumnVisibility) {
-			instance.setColumnVisibility(ops)
-		}
+	const toggleAllColumns = () => {
+		setColumnOptions(mergedColumns.map((col) => col.key))
 	}
 
 	const columnVisibility = useMemo(() => JSON.parse(columnsInStorage), [columnsInStorage])
@@ -424,10 +392,7 @@ export const ChainProtocolsTable = ({
 				<SelectWithCombobox
 					allValues={mergedColumns}
 					selectedValues={selectedColumns}
-					setSelectedValues={addColumn}
-					selectOnlyOne={addOnlyOneColumn}
-					toggleAll={toggleAllColumns}
-					clearAll={clearAllColumns}
+					setSelectedValues={setColumnOptions}
 					nestedMenu={false}
 					label={'Columns'}
 					labelType="smol"

--- a/src/containers/ChainsByCategory/Table.tsx
+++ b/src/containers/ChainsByCategory/Table.tsx
@@ -33,17 +33,7 @@ import { chainIconUrl, formattedNum, formattedPercent, slug } from '~/utils'
 
 const optionsKey = 'chains-overview-table-columns'
 
-const clearAllColumns = () => {
-	const ops = JSON.stringify(Object.fromEntries(columnOptions.map((option) => [option.key, false])))
-	setStorageItem(optionsKey, ops)
-}
-
-const toggleAllColumns = () => {
-	const ops = JSON.stringify(Object.fromEntries(columnOptions.map((option) => [option.key, true])))
-	setStorageItem(optionsKey, ops)
-}
-
-const addColumn = (newOptions) => {
+const setColumnOptions = (newOptions: string[]) => {
 	const ops = Object.fromEntries(columnOptions.map((col) => [col.key, newOptions.includes(col.key)]))
 	setStorageItem(optionsKey, JSON.stringify(ops))
 }
@@ -97,11 +87,6 @@ export function ChainsByCategoryTable({
 		columnOrders: chainsTableColumnOrders
 	})
 
-	const addOnlyOneColumn = (newOption) => {
-		const ops = Object.fromEntries(instance.getAllLeafColumns().map((col) => [col.id, col.id === newOption]))
-		setStorageItem(optionsKey, JSON.stringify(ops))
-	}
-
 	const selectedColumns = instance
 		.getAllLeafColumns()
 		.filter((col) => col.getIsVisible())
@@ -109,39 +94,11 @@ export function ChainsByCategoryTable({
 
 	const [groupTvls, updater] = useLocalStorageSettingsManager('tvl_chains')
 
-	const clearAllAggrOptions = () => {
-		const selectedAggregateTypesSet = new Set(selectedAggregateTypes)
-		for (const item of CHAINS_CATEGORY_GROUP_SETTINGS) {
-			if (selectedAggregateTypesSet.has(item.key)) {
-				updater(item.key)
-			}
-		}
-	}
-
-	const toggleAllAggrOptions = () => {
-		const selectedAggregateTypesSet = new Set(selectedAggregateTypes)
-		for (const item of CHAINS_CATEGORY_GROUP_SETTINGS) {
-			if (!selectedAggregateTypesSet.has(item.key)) {
-				updater(item.key)
-			}
-		}
-	}
-
-	const addAggrOption: React.Dispatch<React.SetStateAction<Array<string>>> = (selectedKeys) => {
+	const setAggrOptions: React.Dispatch<React.SetStateAction<Array<string>>> = (selectedKeys) => {
 		const nextSelectedKeys = typeof selectedKeys === 'function' ? selectedKeys(selectedAggregateTypes) : selectedKeys
 		const selectedKeysSet = new Set(nextSelectedKeys)
 		for (const item of CHAINS_CATEGORY_GROUP_SETTINGS) {
 			const shouldEnable = selectedKeysSet.has(item.key)
-			if (groupTvls[item.key] !== shouldEnable) {
-				updater(item.key)
-			}
-		}
-	}
-
-	const addOnlyOneAggrOption = (newOption: string) => {
-		if (!isChainsCategoryGroupKey(newOption)) return
-		for (const item of CHAINS_CATEGORY_GROUP_SETTINGS) {
-			const shouldEnable = item.key === newOption
 			if (groupTvls[item.key] !== shouldEnable) {
 				updater(item.key)
 			}
@@ -203,10 +160,7 @@ export function ChainsByCategoryTable({
 							<SelectWithCombobox
 								allValues={CHAINS_CATEGORY_GROUP_SETTINGS}
 								selectedValues={selectedAggregateTypes}
-								setSelectedValues={addAggrOption}
-								selectOnlyOne={addOnlyOneAggrOption}
-								toggleAll={toggleAllAggrOptions}
-								clearAll={clearAllAggrOptions}
+								setSelectedValues={setAggrOptions}
 								nestedMenu={false}
 								label={'Group Chains'}
 								labelType="smol"
@@ -219,10 +173,7 @@ export function ChainsByCategoryTable({
 						<SelectWithCombobox
 							allValues={columnOptions}
 							selectedValues={selectedColumns}
-							setSelectedValues={addColumn}
-							selectOnlyOne={addOnlyOneColumn}
-							toggleAll={toggleAllColumns}
-							clearAll={clearAllColumns}
+							setSelectedValues={setColumnOptions}
 							nestedMenu={false}
 							label={'Columns'}
 							labelType="smol"

--- a/src/containers/CompareChains/index.tsx
+++ b/src/containers/CompareChains/index.tsx
@@ -151,9 +151,6 @@ const ChartFilters = () => {
 			allValues={supportedCharts}
 			selectedValues={selectedValues}
 			setSelectedValues={setSelectedValues}
-			selectOnlyOne={(newOption) => {
-				setSelectedValues([newOption])
-			}}
 			labelType="none"
 			label={
 				<>

--- a/src/containers/DimensionAdapters/AdapterByChain.tsx
+++ b/src/containers/DimensionAdapters/AdapterByChain.tsx
@@ -295,58 +295,6 @@ export function AdapterByChain(props: IProps) {
 		return { filename: `${props.type}-${props.chain}-protocols.csv`, rows: [header, ...csvdata] }
 	}
 
-	const { category: _category, chain, ...queries } = router.query
-
-	const addCategory = (newCategory) => {
-		router.push(
-			{
-				pathname: router.basePath,
-				query: {
-					...queries,
-					...(!router.basePath.includes('/chain/') && chain ? { chain } : {}),
-					category: newCategory
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
-	const toggleAllCategories = () => {
-		router.push(
-			{
-				pathname: router.basePath,
-				query: {
-					...queries,
-					...(!router.basePath.includes('/chain/') && chain ? { chain } : {}),
-					category: props.categories
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
-	const clearAllCategories = () => {
-		const newQuery: any = {
-			...queries,
-			...(!router.basePath.includes('/chain/') && chain ? { chain } : {})
-		}
-
-		if (props.categories.length > 0) {
-			newQuery.category = ''
-		}
-
-		router.push(
-			{
-				pathname: router.basePath,
-				query: newQuery
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
 	const metricName = ['Fees', 'Revenue', 'Holders Revenue', 'Open Interest'].includes(props.type)
 		? props.type
 		: props.type.includes('Volume')
@@ -354,24 +302,8 @@ export function AdapterByChain(props: IProps) {
 			: `${props.type} Volume`
 	const columnsKey = `columns-${props.type}`
 
-	const clearAllColumns = () => {
-		setStorageItem(columnsKey, '{}')
-		instance.getToggleAllColumnsVisibilityHandler()({ checked: false } as any)
-	}
-	const toggleAllColumns = () => {
-		const ops = JSON.stringify(Object.fromEntries(columnsOptions.map((option) => [option.key, true])))
-		setStorageItem(columnsKey, ops)
-		instance.getToggleAllColumnsVisibilityHandler()({ checked: true } as any)
-	}
-
-	const addColumn = (newOptions) => {
+	const setColumnOptions = (newOptions: string[]) => {
 		const ops = Object.fromEntries(instance.getAllLeafColumns().map((col) => [col.id, newOptions.includes(col.id)]))
-		setStorageItem(columnsKey, JSON.stringify(ops))
-		instance.setColumnVisibility(ops)
-	}
-
-	const addOnlyOneColumn = (newOption) => {
-		const ops = Object.fromEntries(instance.getAllLeafColumns().map((col) => [col.id, col.id === newOption]))
 		setStorageItem(columnsKey, JSON.stringify(ops))
 		instance.setColumnVisibility(ops)
 	}
@@ -491,10 +423,7 @@ export function AdapterByChain(props: IProps) {
 					<SelectWithCombobox
 						allValues={columnsOptions}
 						selectedValues={selectedColumns}
-						setSelectedValues={addColumn}
-						selectOnlyOne={addOnlyOneColumn}
-						toggleAll={toggleAllColumns}
-						clearAll={clearAllColumns}
+						setSelectedValues={setColumnOptions}
 						nestedMenu={false}
 						label={'Columns'}
 						labelType="smol"
@@ -507,10 +436,8 @@ export function AdapterByChain(props: IProps) {
 						<SelectWithCombobox
 							allValues={props.categories}
 							selectedValues={selectedCategories}
-							setSelectedValues={addCategory}
-							selectOnlyOne={addCategory}
-							toggleAll={toggleAllCategories}
-							clearAll={clearAllCategories}
+							includeQueryKey="category"
+							excludeQueryKey="excludeCategory"
 							nestedMenu={false}
 							label={'Category'}
 							labelType="smol"

--- a/src/containers/DimensionAdapters/ChainChart.tsx
+++ b/src/containers/DimensionAdapters/ChainChart.tsx
@@ -282,12 +282,7 @@ export const ChainsByAdapterChart = ({
 						allValues={allChains}
 						selectedValues={selectedChains}
 						setSelectedValues={setSelectedChains}
-						selectOnlyOne={(newChain) => {
-							setSelectedChains([newChain])
-						}}
 						label="Chains"
-						clearAll={() => setSelectedChains([])}
-						toggleAll={() => setSelectedChains(allChains)}
 						labelType="smol"
 						triggerProps={{
 							className:

--- a/src/containers/DimensionAdapters/ProtocolChart.tsx
+++ b/src/containers/DimensionAdapters/ProtocolChart.tsx
@@ -376,11 +376,6 @@ const ChartByType = ({
 					selectedValues={selectedTypes}
 					setSelectedValues={setSelectedTypes}
 					label={chartType === 'version' ? 'Versions' : 'Chains'}
-					clearAll={() => setSelectedTypes([])}
-					toggleAll={() => setSelectedTypes(breakdownNames)}
-					selectOnlyOne={(newType) => {
-						setSelectedTypes([newType])
-					}}
 					labelType="smol"
 					triggerProps={{
 						className:

--- a/src/containers/ProtocolOverview/Emissions/index.tsx
+++ b/src/containers/ProtocolOverview/Emissions/index.tsx
@@ -506,31 +506,8 @@ const ChartContainer = ({ data, isEmissionsPage }: { data: IEmission; isEmission
 							<SelectWithCombobox
 								allValues={availableCategories}
 								selectedValues={selectedCategories}
-								setSelectedValues={(newCategories) => {
-									if (newCategories.length === 0) return
-									setSelectedCategories(newCategories)
-								}}
-								selectOnlyOne={(newCategory) => {
-									setSelectedCategories([newCategory])
-								}}
+								setSelectedValues={setSelectedCategories}
 								label="Categories"
-								clearAll={() => {
-									if (selectedCategories.length > 0) {
-										setSelectedCategories([selectedCategories[0]])
-									}
-								}}
-								toggleAll={() => {
-									if (allocationMode === 'standard' && data.categoriesBreakdown) {
-										setSelectedCategories(Object.keys(data.categoriesBreakdown))
-									} else {
-										const filteredCategories = categoriesFromData.filter(
-											(cat) =>
-												!['Market Cap', 'Price'].includes(cat) &&
-												!data.categoriesBreakdown?.noncirculating?.includes(cat)
-										)
-										setSelectedCategories(filteredCategories)
-									}
-								}}
 								labelType="smol"
 								triggerProps={{
 									className:

--- a/src/containers/ProtocolsWithTokens/index.tsx
+++ b/src/containers/ProtocolsWithTokens/index.tsx
@@ -14,7 +14,7 @@ import { IProtocolsWithTokensByChainPageData } from './queries'
 export function ProtocolsWithTokens(props: IProtocolsWithTokensByChainPageData) {
 	const router = useRouter()
 
-	const { category, chain, ...queries } = router.query
+	const { category } = router.query
 	const hasCategoryParam = Object.prototype.hasOwnProperty.call(router.query, 'category')
 
 	const { selectedCategories, protocols } = useMemo(() => {
@@ -44,56 +44,6 @@ export function ProtocolsWithTokens(props: IProtocolsWithTokensByChainPageData) 
 		}
 	}, [category, hasCategoryParam, props.categories, props.protocols])
 
-	const addCategory = (newCategory) => {
-		router.push(
-			{
-				pathname: router.basePath,
-				query: {
-					...queries,
-					...(!router.basePath.includes('/chain/') && chain ? { chain } : {}),
-					category: newCategory
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
-	const toggleAllCategories = () => {
-		router.push(
-			{
-				pathname: router.basePath,
-				query: {
-					...queries,
-					...(!router.basePath.includes('/chain/') && chain ? { chain } : {}),
-					category: props.categories
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
-	const clearAllCategories = () => {
-		const newQuery: any = {
-			...queries,
-			...(!router.basePath.includes('/chain/') && chain ? { chain } : {})
-		}
-
-		if (props.categories.length > 0) {
-			newQuery.category = ''
-		}
-
-		router.push(
-			{
-				pathname: router.basePath,
-				query: newQuery
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
 	const { columns, sortingState } = getMetricNameAndColumns(props.type)
 
 	return (
@@ -112,10 +62,8 @@ export function ProtocolsWithTokens(props: IProtocolsWithTokensByChainPageData) 
 							<SelectWithCombobox
 								allValues={props.categories}
 								selectedValues={selectedCategories}
-								setSelectedValues={addCategory}
-								selectOnlyOne={addCategory}
-								toggleAll={toggleAllCategories}
-								clearAll={clearAllCategories}
+								includeQueryKey="category"
+								excludeQueryKey="excludeCategory"
 								nestedMenu={false}
 								label={'Category'}
 								labelType="smol"

--- a/src/containers/RWA/index.tsx
+++ b/src/containers/RWA/index.tsx
@@ -83,31 +83,11 @@ export const RWAOverview = (props: IRWAAssetsOverview) => {
 		maxDefiActiveTvlToActiveMcapPct,
 		includeStablecoins,
 		includeGovernance,
-		setSelectedCategories,
-		setSelectedAssetClasses,
-		setSelectedRwaClassifications,
-		setSelectedAccessModels,
-		setSelectedIssuers,
 		setDefiActiveTvlToOnChainPctRange,
 		setActiveMcapToOnChainPctRange,
 		setDefiActiveTvlToActiveMcapPctRange,
 		setIncludeStablecoins,
-		setIncludeGovernance,
-		selectOnlyOneCategory,
-		toggleAllCategories,
-		clearAllCategories,
-		selectOnlyOneAssetClass,
-		toggleAllAssetClasses,
-		clearAllAssetClasses,
-		selectOnlyOneRwaClassification,
-		toggleAllRwaClassifications,
-		clearAllRwaClassifications,
-		selectOnlyOneAccessModel,
-		toggleAllAccessModels,
-		clearAllAccessModels,
-		selectOnlyOneIssuer,
-		toggleAllIssuers,
-		clearAllIssuers
+		setIncludeGovernance
 	} = useRWATableQueryParams({
 		categories: props.categories,
 		assetClasses: props.assetClasses,
@@ -373,10 +353,8 @@ export const RWAOverview = (props: IRWAAssetsOverview) => {
 				<SelectWithCombobox
 					allValues={props.categories}
 					selectedValues={selectedCategories}
-					setSelectedValues={setSelectedCategories}
-					selectOnlyOne={selectOnlyOneCategory}
-					toggleAll={toggleAllCategories}
-					clearAll={clearAllCategories}
+					includeQueryKey="categories"
+					excludeQueryKey="categories"
 					label={'Categories'}
 					labelType="smol"
 					triggerProps={{
@@ -387,10 +365,8 @@ export const RWAOverview = (props: IRWAAssetsOverview) => {
 				<SelectWithCombobox
 					allValues={props.assetClassOptions}
 					selectedValues={selectedAssetClasses}
-					setSelectedValues={setSelectedAssetClasses}
-					selectOnlyOne={selectOnlyOneAssetClass}
-					toggleAll={toggleAllAssetClasses}
-					clearAll={clearAllAssetClasses}
+					includeQueryKey="assetClasses"
+					excludeQueryKey="assetClasses"
 					label={'Asset Classes'}
 					labelType="smol"
 					triggerProps={{
@@ -401,10 +377,8 @@ export const RWAOverview = (props: IRWAAssetsOverview) => {
 				<SelectWithCombobox
 					allValues={props.rwaClassificationOptions}
 					selectedValues={selectedRwaClassifications}
-					setSelectedValues={setSelectedRwaClassifications}
-					selectOnlyOne={selectOnlyOneRwaClassification}
-					toggleAll={toggleAllRwaClassifications}
-					clearAll={clearAllRwaClassifications}
+					includeQueryKey="rwaClassifications"
+					excludeQueryKey="rwaClassifications"
 					label={'RWA Classification'}
 					labelType="smol"
 					triggerProps={{
@@ -415,10 +389,8 @@ export const RWAOverview = (props: IRWAAssetsOverview) => {
 				<SelectWithCombobox
 					allValues={props.accessModelOptions}
 					selectedValues={selectedAccessModels}
-					setSelectedValues={setSelectedAccessModels}
-					selectOnlyOne={selectOnlyOneAccessModel}
-					toggleAll={toggleAllAccessModels}
-					clearAll={clearAllAccessModels}
+					includeQueryKey="accessModels"
+					excludeQueryKey="accessModels"
 					label={'Access Model'}
 					labelType="smol"
 					triggerProps={{
@@ -429,10 +401,8 @@ export const RWAOverview = (props: IRWAAssetsOverview) => {
 				<SelectWithCombobox
 					allValues={props.issuers}
 					selectedValues={selectedIssuers}
-					setSelectedValues={setSelectedIssuers}
-					selectOnlyOne={selectOnlyOneIssuer}
-					toggleAll={toggleAllIssuers}
-					clearAll={clearAllIssuers}
+					includeQueryKey="issuers"
+					excludeQueryKey="issuers"
 					label={'Issuers'}
 					labelType="smol"
 					triggerProps={{
@@ -1090,18 +1060,6 @@ const toNumberParam = (p: string | string[] | undefined): number | null => {
 	return parseNumberInput(p)
 }
 
-const updateArrayQuery = (key: string, values: string[] | 'None') => {
-	const nextQuery: Record<string, any> = { ...Router.query }
-	if (values === 'None') {
-		nextQuery[key] = 'None'
-	} else if (values.length > 0) {
-		nextQuery[key] = values
-	} else {
-		delete nextQuery[key]
-	}
-	Router.push({ pathname: Router.pathname, query: nextQuery }, undefined, { shallow: true })
-}
-
 const updateNumberRangeQuery = (
 	minKey: string,
 	maxKey: string,
@@ -1229,52 +1187,6 @@ const useRWATableQueryParams = ({
 		issuers
 	])
 
-	const setSelectedCategories = (values: string[]) => updateArrayQuery('categories', values)
-	const selectOnlyOneCategory = (category: string) => updateArrayQuery('categories', [category])
-	const toggleAllCategories = () => {
-		const nextQuery: Record<string, any> = { ...Router.query }
-		delete nextQuery.categories
-		Router.push({ pathname: Router.pathname, query: nextQuery }, undefined, { shallow: true })
-	}
-	const clearAllCategories = () => updateArrayQuery('categories', 'None')
-
-	const setSelectedAssetClasses = (values: string[]) => updateArrayQuery('assetClasses', values)
-	const selectOnlyOneAssetClass = (assetClass: string) => updateArrayQuery('assetClasses', [assetClass])
-	const toggleAllAssetClasses = () => {
-		const nextQuery: Record<string, any> = { ...Router.query }
-		delete nextQuery.assetClasses
-		Router.push({ pathname: Router.pathname, query: nextQuery }, undefined, { shallow: true })
-	}
-	const clearAllAssetClasses = () => updateArrayQuery('assetClasses', 'None')
-
-	const setSelectedRwaClassifications = (values: string[]) => updateArrayQuery('rwaClassifications', values)
-	const selectOnlyOneRwaClassification = (rwaClassification: string) =>
-		updateArrayQuery('rwaClassifications', [rwaClassification])
-	const toggleAllRwaClassifications = () => {
-		const nextQuery: Record<string, any> = { ...Router.query }
-		delete nextQuery.rwaClassifications
-		Router.push({ pathname: Router.pathname, query: nextQuery }, undefined, { shallow: true })
-	}
-	const clearAllRwaClassifications = () => updateArrayQuery('rwaClassifications', 'None')
-
-	const setSelectedAccessModels = (values: string[]) => updateArrayQuery('accessModels', values)
-	const selectOnlyOneAccessModel = (accessModel: string) => updateArrayQuery('accessModels', [accessModel])
-	const toggleAllAccessModels = () => {
-		const nextQuery: Record<string, any> = { ...Router.query }
-		delete nextQuery.accessModels
-		Router.push({ pathname: Router.pathname, query: nextQuery }, undefined, { shallow: true })
-	}
-	const clearAllAccessModels = () => updateArrayQuery('accessModels', 'None')
-
-	const setSelectedIssuers = (values: string[]) => updateArrayQuery('issuers', values)
-	const selectOnlyOneIssuer = (issuer: string) => updateArrayQuery('issuers', [issuer])
-	const toggleAllIssuers = () => {
-		const nextQuery: Record<string, any> = { ...Router.query }
-		delete nextQuery.issuers
-		Router.push({ pathname: Router.pathname, query: nextQuery }, undefined, { shallow: true })
-	}
-	const clearAllIssuers = () => updateArrayQuery('issuers', 'None')
-
 	const setDefiActiveTvlToOnChainPctRange = (minValue: string | number | null, maxValue: string | number | null) =>
 		updateNumberRangeQuery('minDefiActiveTvlToOnChainPct', 'maxDefiActiveTvlToOnChainPct', minValue, maxValue)
 	const setActiveMcapToOnChainPctRange = (minValue: string | number | null, maxValue: string | number | null) =>
@@ -1316,31 +1228,11 @@ const useRWATableQueryParams = ({
 		maxDefiActiveTvlToActiveMcapPct,
 		includeStablecoins,
 		includeGovernance,
-		setSelectedCategories,
-		setSelectedAssetClasses,
-		setSelectedRwaClassifications,
-		setSelectedAccessModels,
-		setSelectedIssuers,
 		setDefiActiveTvlToOnChainPctRange,
 		setActiveMcapToOnChainPctRange,
 		setDefiActiveTvlToActiveMcapPctRange,
 		setIncludeStablecoins,
-		setIncludeGovernance,
-		selectOnlyOneCategory,
-		toggleAllCategories,
-		clearAllCategories,
-		selectOnlyOneAssetClass,
-		toggleAllAssetClasses,
-		clearAllAssetClasses,
-		selectOnlyOneRwaClassification,
-		toggleAllRwaClassifications,
-		clearAllRwaClassifications,
-		selectOnlyOneAccessModel,
-		toggleAllAccessModels,
-		clearAllAccessModels,
-		selectOnlyOneIssuer,
-		toggleAllIssuers,
-		clearAllIssuers
+		setIncludeGovernance
 	}
 }
 

--- a/src/containers/RecentProtocols/Table.tsx
+++ b/src/containers/RecentProtocols/Table.tsx
@@ -74,62 +74,6 @@ export function RecentlyListedProtocolsTable({
 
 	const [projectName, setProjectName] = useTableSearch({ instance, columnToSearch: 'name' })
 
-	const selectChain = (newChain) => {
-		router.push(
-			{
-				pathname: router.pathname,
-				query: {
-					...queries,
-					chain: newChain
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
-	const clearAllChains = () => {
-		router.push(
-			{
-				pathname: router.pathname,
-				query: {
-					...queries,
-					chain: 'None'
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
-	const toggleAllChains = () => {
-		router.push(
-			{
-				pathname: router.pathname,
-				query: {
-					...queries,
-					chain: 'All'
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
-	const selectOnlyOneChain = (option: string) => {
-		router.push(
-			{
-				pathname: router.pathname,
-				query: {
-					...queries,
-					chain: option
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
 	const prepareCsv = () => {
 		const headers = ['Name', 'TVL', 'Change 1d', 'Change 7d', 'Change 1m', 'Listed At', 'Chains']
 		const csvData = data.map((row) => {
@@ -173,11 +117,9 @@ export function RecentlyListedProtocolsTable({
 						<SelectWithCombobox
 							label="Chains"
 							allValues={chainList}
-							clearAll={clearAllChains}
-							toggleAll={toggleAllChains}
-							selectOnlyOne={selectOnlyOneChain}
 							selectedValues={selectedChains}
-							setSelectedValues={selectChain}
+							includeQueryKey="chain"
+							excludeQueryKey="chain"
 							labelType="smol"
 							triggerProps={{
 								className:

--- a/src/containers/Stablecoins/Table/index.tsx
+++ b/src/containers/Stablecoins/Table/index.tsx
@@ -182,38 +182,10 @@ export function PeggedChainsTable({ data }) {
 
 	const [groupTvls, updater] = useLocalStorageSettingsManager('tvl_chains')
 
-	const clearAllAggrOptions = () => {
-		const selectedAggregateTypesSet = new Set(selectedAggregateTypes)
-		for (const item of CHAINS_CATEGORY_GROUP_SETTINGS) {
-			if (selectedAggregateTypesSet.has(item.key)) {
-				updater(item.key)
-			}
-		}
-	}
-
-	const toggleAllAggrOptions = () => {
-		const selectedAggregateTypesSet = new Set(selectedAggregateTypes)
-		for (const item of CHAINS_CATEGORY_GROUP_SETTINGS) {
-			if (!selectedAggregateTypesSet.has(item.key)) {
-				updater(item.key)
-			}
-		}
-	}
-
-	const addAggrOption = (selectedKeys: string[]) => {
+	const setAggrOptions = (selectedKeys: string[]) => {
 		const selectedSet = new Set(selectedKeys)
 		for (const item of CHAINS_CATEGORY_GROUP_SETTINGS) {
 			const shouldEnable = selectedSet.has(item.key)
-			if (groupTvls[item.key] !== shouldEnable) {
-				updater(item.key)
-			}
-		}
-	}
-
-	const addOnlyOneAggrOption = (newOption: string) => {
-		if (!isChainsCategoryGroupKey(newOption)) return
-		for (const item of CHAINS_CATEGORY_GROUP_SETTINGS) {
-			const shouldEnable = item.key === newOption
 			if (groupTvls[item.key] !== shouldEnable) {
 				updater(item.key)
 			}
@@ -247,10 +219,7 @@ export function PeggedChainsTable({ data }) {
 				<SelectWithCombobox
 					allValues={CHAINS_CATEGORY_GROUP_SETTINGS}
 					selectedValues={selectedAggregateTypes}
-					setSelectedValues={addAggrOption}
-					selectOnlyOne={addOnlyOneAggrOption}
-					toggleAll={toggleAllAggrOptions}
-					clearAll={clearAllAggrOptions}
+					setSelectedValues={setAggrOptions}
 					nestedMenu={false}
 					label={'Group Chains'}
 					labelType="smol"

--- a/src/containers/Unlocks/Table.tsx
+++ b/src/containers/Unlocks/Table.tsx
@@ -19,25 +19,7 @@ import { getStorageItem, setStorageItem, subscribeToStorageKey } from '~/context
 const optionsKey = 'unlockTable'
 const filterStatekey = 'unlockTableFilterState'
 
-const clearAllOptions = () => {
-	const opsObj: Record<string, boolean> = {}
-	for (const option of columnOptions) {
-		opsObj[option.key] = false
-	}
-	const ops = JSON.stringify(opsObj)
-	setStorageItem(optionsKey, ops)
-}
-
-const toggleAllOptions = () => {
-	const opsObj: Record<string, boolean> = {}
-	for (const option of columnOptions) {
-		opsObj[option.key] = true
-	}
-	const ops = JSON.stringify(opsObj)
-	setStorageItem(optionsKey, ops)
-}
-
-const addOption = (newOptions) => {
+const setColumnOptions = (newOptions: string[]) => {
 	const ops: Record<string, boolean> = {}
 	for (const col of columnOptions) {
 		ops[col.key] = newOptions.includes(col.key)
@@ -45,12 +27,8 @@ const addOption = (newOptions) => {
 	setStorageItem(optionsKey, JSON.stringify(ops))
 }
 
-const addOnlyOneOption = (newOption) => {
-	const ops: Record<string, boolean> = {}
-	for (const col of columnOptions) {
-		ops[col.key] = col.key === newOption
-	}
-	setStorageItem(optionsKey, JSON.stringify(ops))
+const toggleAllOptions = () => {
+	setColumnOptions(columnOptions.map((col) => col.key))
 }
 
 interface IUnlocksTableProps {
@@ -372,10 +350,7 @@ export const UnlocksTable = ({
 				<SelectWithCombobox
 					allValues={columnOptions}
 					selectedValues={selectedOptions}
-					setSelectedValues={addOption}
-					selectOnlyOne={addOnlyOneOption}
-					toggleAll={toggleAllOptions}
-					clearAll={clearAllOptions}
+					setSelectedValues={setColumnOptions}
 					nestedMenu={false}
 					label={'Columns'}
 					labelType="smol"
@@ -389,9 +364,6 @@ export const UnlocksTable = ({
 					allValues={UNLOCK_TYPE_OPTIONS}
 					selectedValues={selectedUnlockTypes}
 					setSelectedValues={setSelectedUnlockTypes}
-					selectOnlyOne={(value) => setSelectedUnlockTypes([value])}
-					toggleAll={() => setSelectedUnlockTypes(UNLOCK_TYPES)}
-					clearAll={() => setSelectedUnlockTypes([])}
 					nestedMenu={false}
 					label={'Unlock Types'}
 					labelType="smol"

--- a/src/containers/Yields/Filters/ColumnFilters.tsx
+++ b/src/containers/Yields/Filters/ColumnFilters.tsx
@@ -60,7 +60,7 @@ export function ColumnFilters({ nestedMenu, ...props }: IColumnFiltersProps) {
 		return { options, selectedOptions }
 	}, [router.query, props])
 
-	const addOption = (newOptions) => {
+	const setSelectedOptions = (newOptions: string[]) => {
 		const optionsObj: Record<string, boolean> = {}
 		for (const op of newOptions) {
 			optionsObj[op] = true
@@ -77,58 +77,11 @@ export function ColumnFilters({ nestedMenu, ...props }: IColumnFiltersProps) {
 		)
 	}
 
-	const addOnlyOneOption = (newOption) => {
-		router.push(
-			{
-				pathname: router.pathname,
-				query: { ...queries, [newOption]: true }
-			},
-			undefined,
-			{
-				shallow: true
-			}
-		)
-	}
-
-	const toggleAll = () => {
-		const optionsObj: Record<string, boolean> = {}
-		for (const op of options) {
-			optionsObj[op.key] = true
-		}
-		router.push(
-			{
-				pathname: router.pathname,
-				query: {
-					...queries,
-					...optionsObj
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
-	const clearAll = () => {
-		router.push(
-			{
-				pathname: router.pathname,
-				query: {
-					...queries
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
 	return (
 		<SelectWithCombobox
 			allValues={options}
 			selectedValues={selectedOptions}
-			setSelectedValues={addOption}
-			selectOnlyOne={addOnlyOneOption}
-			toggleAll={toggleAll}
-			clearAll={clearAll}
+			setSelectedValues={setSelectedOptions}
 			nestedMenu={nestedMenu}
 			label="Columns"
 			labelType="regular"

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -76,9 +76,6 @@ function MetricFilters({
 				allValues={options}
 				selectedValues={selectedValues}
 				setSelectedValues={setSelectedValues}
-				selectOnlyOne={(newOption) => {
-					setSelectedValues([newOption])
-				}}
 				label={label || 'Include in TVL'}
 				triggerProps={{
 					className:

--- a/src/pages/categories.tsx
+++ b/src/pages/categories.tsx
@@ -227,15 +227,6 @@ const pageName = ['Protocol Categories']
 
 export default function Protocols({ categories, tableData, chartData, extraTvlCharts }) {
 	const [selectedCategories, setSelectedCategories] = React.useState<Array<string>>(categories)
-	const clearAll = () => {
-		setSelectedCategories([])
-	}
-	const toggleAll = () => {
-		setSelectedCategories(categories)
-	}
-	const selectOnlyOne = (category: string) => {
-		setSelectedCategories([category])
-	}
 	const [extaTvlsEnabled] = useLocalStorageSettingsManager('tvl')
 	const enabledTvls = TVL_SETTINGS_KEYS.filter((key) => extaTvlsEnabled[key])
 
@@ -358,9 +349,6 @@ export default function Protocols({ categories, tableData, chartData, extraTvlCh
 						selectedValues={selectedCategories}
 						setSelectedValues={setSelectedCategories}
 						label="Categories"
-						clearAll={clearAll}
-						toggleAll={toggleAll}
-						selectOnlyOne={selectOnlyOne}
 						labelType="smol"
 					/>
 				</div>

--- a/src/pages/digital-asset-treasuries/[...asset].tsx
+++ b/src/pages/digital-asset-treasuries/[...asset].tsx
@@ -402,10 +402,7 @@ const MNAVChart = ({
 					allValues={institutionsNames}
 					selectedValues={selectedInstitution}
 					setSelectedValues={setSelectedInstitution}
-					selectOnlyOne={(institution) => setSelectedInstitution([institution])}
 					label="Institutions"
-					clearAll={() => setSelectedInstitution([])}
-					toggleAll={() => setSelectedInstitution(institutionsNames)}
 					labelType="smol"
 					triggerProps={{
 						className:

--- a/src/pages/etfs.tsx
+++ b/src/pages/etfs.tsx
@@ -188,12 +188,7 @@ const PageView = ({ snapshot, flows, totalsByAsset, lastUpdated }: PageViewProps
 							allValues={ASSET_VALUES}
 							selectedValues={tickers}
 							setSelectedValues={setTickers}
-							selectOnlyOne={(newOption) => {
-								setTickers([newOption])
-							}}
 							label={'ETF'}
-							clearAll={() => setTickers([])}
-							toggleAll={() => setTickers([...ASSET_VALUES])}
 							labelType="smol"
 							triggerProps={{
 								className:

--- a/src/pages/hacks/total-value-lost.tsx
+++ b/src/pages/hacks/total-value-lost.tsx
@@ -74,8 +74,6 @@ export default function TotalLostInHacks({ protocols }: IProtocolTotalValueLostI
 							allValues={columnIds}
 							selectedValues={selectedColumns}
 							setSelectedValues={setSelectedColumns}
-							clearAll={() => setSelectedColumns([])}
-							toggleAll={() => setSelectedColumns(columnIds)}
 							label="Columns"
 							labelType="smol"
 							triggerProps={{

--- a/src/pages/protocol/fees/[...protocol].tsx
+++ b/src/pages/protocol/fees/[...protocol].tsx
@@ -371,11 +371,6 @@ export default function Protocols(props) {
 								selectedValues={charts}
 								setSelectedValues={setCharts}
 								label="Charts"
-								clearAll={() => setCharts([])}
-								toggleAll={() => setCharts(props.defaultCharts)}
-								selectOnlyOne={(newChart) => {
-									setCharts([newChart])
-								}}
 								triggerProps={{
 									className:
 										'flex items-center justify-between gap-2 px-2 py-1.5 text-xs rounded-md cursor-pointer flex-nowrap relative border border-(--form-control-border) text-(--text-form) hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium'

--- a/src/pages/protocol/options/[...protocol].tsx
+++ b/src/pages/protocol/options/[...protocol].tsx
@@ -224,11 +224,6 @@ export default function Protocols(props) {
 								selectedValues={charts}
 								setSelectedValues={setCharts}
 								label="Charts"
-								clearAll={() => setCharts([])}
-								toggleAll={() => setCharts(props.defaultCharts)}
-								selectOnlyOne={(newChart) => {
-									setCharts([newChart])
-								}}
 								triggerProps={{
 									className:
 										'flex items-center justify-between gap-2 px-2 py-1.5 text-xs rounded-md cursor-pointer flex-nowrap relative border border-(--form-control-border) text-(--text-form) hover:bg-(--link-hover-bg) focus-visible:bg-(--link-hover-bg) font-medium'

--- a/src/pages/top-protocols.tsx
+++ b/src/pages/top-protocols.tsx
@@ -5,7 +5,7 @@ import {
 	getFilteredRowModel,
 	useReactTable
 } from '@tanstack/react-table'
-import Router, { useRouter } from 'next/router'
+import { useRouter } from 'next/router'
 import * as React from 'react'
 import { maxAgeForNext } from '~/api'
 import { getSimpleProtocolsPageData } from '~/api/categories/protocols'
@@ -176,117 +176,6 @@ export default function TopProtocols({ data, chains, uniqueCategories }) {
 
 	const [searchValue, setSearchValue] = useTableSearch({ instance: table, columnToSearch: 'name' })
 
-	const clearChainSelection = () => {
-		const { chain: _chain, ...queries } = router.query
-		Router.push(
-			{
-				pathname: router.pathname,
-				query: { ...queries, chain: 'None' }
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
-	const toggleAllChains = () => {
-		const { chain: _chain, ...queries } = router.query
-		Router.push(
-			{
-				pathname: router.pathname,
-				query: queries
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
-	const addChain = (newOptions: Array<string>) => {
-		const { chain: _chain, ...queries } = router.query
-		Router.push(
-			{
-				pathname: router.pathname,
-				query: {
-					...queries,
-					chain: newOptions
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
-	const selectOnlyOneChain = (chain: string) => {
-		const { chain: _currentChain, ...queries } = router.query
-		Router.push(
-			{
-				pathname: router.pathname,
-				query: {
-					...queries,
-					chain: chain
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
-	const clearAllColumns = () => {
-		const { column: _column, ...queries } = router.query
-		Router.push(
-			{
-				pathname: router.pathname,
-				query: {
-					...queries,
-					column: 'None'
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
-	const toggleAllColumns = () => {
-		const { column: _column, ...queries } = router.query
-		Router.push(
-			{
-				pathname: router.pathname,
-				query: queries
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
-	const addColumn = (newOptions: Array<string>) => {
-		const { column: _column, ...queries } = router.query
-		Router.push(
-			{
-				pathname: router.pathname,
-				query: {
-					...queries,
-					column: newOptions
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
-	const addOnlyOneColumn = (newOption: string) => {
-		const { column: _column, ...queries } = router.query
-		Router.push(
-			{
-				pathname: router.pathname,
-				query: {
-					...queries,
-					column: newOption
-				}
-			},
-			undefined,
-			{ shallow: true }
-		)
-	}
-
 	const prepareCsv = () => {
 		const visibleColumns = table.getAllLeafColumns().filter((col) => col.getIsVisible())
 		const headers = visibleColumns.map((col) => {
@@ -341,10 +230,8 @@ export default function TopProtocols({ data, chains, uniqueCategories }) {
 						<SelectWithCombobox
 							allValues={chains}
 							selectedValues={selectedChains}
-							setSelectedValues={addChain}
-							selectOnlyOne={selectOnlyOneChain}
-							toggleAll={toggleAllChains}
-							clearAll={clearChainSelection}
+							includeQueryKey="chain"
+							excludeQueryKey="chain"
 							nestedMenu={false}
 							label={'Chains'}
 							labelType="smol"
@@ -357,10 +244,8 @@ export default function TopProtocols({ data, chains, uniqueCategories }) {
 						<SelectWithCombobox
 							allValues={columnOptions}
 							selectedValues={selectedColumns}
-							setSelectedValues={addColumn}
-							selectOnlyOne={addOnlyOneColumn}
-							toggleAll={toggleAllColumns}
-							clearAll={clearAllColumns}
+							includeQueryKey="column"
+							excludeQueryKey="column"
 							nestedMenu={false}
 							label={'Columns'}
 							labelType="smol"


### PR DESCRIPTION
## Summary
- Remove clearAll, toggleAll, selectOnlyOne props from Select/SelectWithCombobox; auto-derive from setSelectedValues
- Refactor URL-based state to use includeQueryKey/excludeQueryKey props instead of manual router.push
- Add missing toggleAllOptions/toggleAllColumns functions to table components
- Net reduction of 725 lines of code (850 deletions, 125 insertions)

## Files Modified
Refactored 27 files across Select components, table components, and pages to eliminate redundant state management code and adopt a cleaner prop-based approach for URL query parameter handling.

## Test Plan
- Verify Select/SelectWithCombobox buttons (clear all, toggle all, select only) work correctly
- Test URL state persistence when filtering in: RWA, top-protocols, RecentProtocols, ProtocolsWithTokens, DimensionAdapters
- Check localStorage-based filters still update table column visibility correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Simplified Selection Controls**
* Consolidated and standardized selection controls across filter components for improved consistency
* Removed custom handler shortcuts (clear all, select only, bulk toggle) from specialized filters
* Simplified URL-based filtering logic in some table and overview pages for more straightforward state management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->