### PR TITLE
add normalized volume metric on perp pages

### DIFF
--- a/public/definitions.ts
+++ b/public/definitions.ts
@@ -208,6 +208,29 @@ export const definitions = {
       "change7dover7d": "Change of last 7 days notional volume including leverage over the previous 7 days notional volume including leverage",
     }
   },
+  "normalizedVolume": {
+    "common": "Normalized trading volume, adjusted using active orderbook liquidity per market and a baseline from the most organic exchange to reduce inflated/inorganic volumes",
+    "protocol": {
+      "24h": "Normalized trading volume in the last 24 hours, adjusted using active orderbook liquidity per market and a baseline from the most organic exchange to reduce inflated/inorganic volumes",
+      "7d": "Normalized trading volume in the last 7 days, adjusted using active orderbook liquidity per market and a baseline from the most organic exchange to reduce inflated/inorganic volumes",
+      "30d": "Normalized trading volume in the last 30 days, adjusted using active orderbook liquidity per market and a baseline from the most organic exchange to reduce inflated/inorganic volumes",
+      "1y": "Normalized trading volume in the last 12 months, adjusted using active orderbook liquidity per market and a baseline from the most organic exchange to reduce inflated/inorganic volumes",
+      "cumulative": "Total normalized trading volume since the protocol was launched",
+      "annualized": "Total normalized trading volume in the last 30 days, multiplied by 12 to annualize it",
+      "change1d": "Day-over-day percentage change in normalized trading volume",
+      "change7d": "Week-over-week percentage change in normalized trading volume",
+      "change1m": "Month-over-month percentage change in normalized trading volume",
+      "change7dover7d": "Change of last 7 days normalized trading volume over the previous 7 days normalized trading volume",
+      "change30dover30d": "Change of last 30 days normalized trading volume over the previous 30 days normalized trading volume",
+      "average1y": "Average monthly normalized trading volume in the last 12 months"
+    },
+    "chain": {
+      "24h": "Normalized trading volume on the chain in the last 24 hours, adjusted using active orderbook liquidity per market and a baseline from the most organic exchange to reduce inflated/inorganic volumes. Updated daily at 00:00 UTC",
+      "7d": "Normalized trading volume on the chain in the last 7 days, adjusted using active orderbook liquidity per market and a baseline from the most organic exchange to reduce inflated/inorganic volumes. Updated daily at 00:00 UTC",
+      "30d": "Normalized trading volume on the chain in the last 30 days, adjusted using active orderbook liquidity per market and a baseline from the most organic exchange to reduce inflated/inorganic volumes. Updated daily at 00:00 UTC",
+      "change7dover7d": "Change of last 7 days normalized trading volume over the previous 7 days normalized trading volume",
+    }
+  },
   "perpsAggregators": {
     "common": "Notional volume of all trades including leverage routed through the perp aggregator",
     "protocol": {

--- a/src/containers/ChainOverview/types.ts
+++ b/src/containers/ChainOverview/types.ts
@@ -12,6 +12,7 @@ export interface IChainMetadata {
 	chainRevenue?: boolean
 	perps?: boolean
 	openInterest?: boolean
+	normalizedVolume?: boolean
 	dexAggregators?: boolean
 	optionsPremiumVolume?: boolean
 	optionsNotionalVolume?: boolean

--- a/src/containers/DimensionAdapters/AdapterByChain.tsx
+++ b/src/containers/DimensionAdapters/AdapterByChain.tsx
@@ -125,6 +125,18 @@ export function AdapterByChain(props: IProps) {
 	const excludeCategoryParam = router.query.excludeCategory
 	const hasCategoryParam = Object.prototype.hasOwnProperty.call(router.query, 'category')
 
+	const columns = useMemo(() => {
+		const baseColumns = getColumnsByType(props.chain !== 'All')[props.type] as ColumnDef<
+			IAdapterByChainPageData['protocols'][0]
+		>[]
+
+		// If the page data doesn't include normalized volume, do not show the normalized volume columns at all.
+		if (props.type !== 'Perp Volume' || props.normalizedVolume != null) return baseColumns
+
+		const hiddenIds = new Set(['normalizedVolume24h', 'normalizedVolume7d', 'normalizedVolume30d'])
+		return baseColumns.filter((c: any) => !hiddenIds.has(c?.id ?? c?.accessorKey))
+	}, [props.chain, props.type, props.normalizedVolume])
+
 	const { selectedCategories, protocols, columnsOptions } = useMemo(() => {
 		const excludeSet = parseExcludeParam(excludeCategoryParam)
 
@@ -226,7 +238,7 @@ export function AdapterByChain(props: IProps) {
 		return {
 			selectedCategories,
 			protocols: finalProtocols,
-			columnsOptions: getColumnsOptions(props.type)
+			columnsOptions: getColumnsOptions(props.type, columns)
 		}
 	}, [
 		categoryParam,
@@ -236,6 +248,7 @@ export function AdapterByChain(props: IProps) {
 		props.protocols,
 		props.adapterType,
 		props.type,
+		columns,
 		enabledSettings.bribes,
 		enabledSettings.tokentax
 	])
@@ -247,7 +260,7 @@ export function AdapterByChain(props: IProps) {
 
 	const instance = useReactTable({
 		data: protocols,
-		columns: getColumnsByType(props.chain !== 'All')[props.type] as any,
+		columns: columns as any,
 		state: {
 			sorting,
 			columnFilters,
@@ -270,6 +283,7 @@ export function AdapterByChain(props: IProps) {
 	})
 
 	const [projectName, setProjectName] = useTableSearch({ instance, columnToSearch: 'name' })
+
 	useSortColumnSizesAndOrders({
 		instance,
 		columnSizes,
@@ -361,6 +375,69 @@ export function AdapterByChain(props: IProps) {
 						) : null}
 
 						<div className="flex flex-col">
+							{props.normalizedVolume?.total24h != null ? (
+								props.normalizedVolume?.total7d != null || props.normalizedVolume?.total30d != null ? (
+									<details className="group">
+										<summary className="flex flex-wrap justify-start gap-4 border-b border-(--cards-border) py-1 group-last:border-none group-open:border-none group-open:font-semibold">
+											<Tooltip
+												content={definitions.normalizedVolume.chain['24h']}
+												className="text-(--text-label) underline decoration-dotted"
+											>
+												Normalized Volume (24h)
+											</Tooltip>
+											<Icon
+												name="chevron-down"
+												height={16}
+												width={16}
+												className="relative top-0.5 -ml-3 transition-transform duration-100 group-open:rotate-180"
+											/>
+											<span className="ml-auto font-jetbrains">
+												{formattedNum(props.normalizedVolume.total24h, true)}
+											</span>
+										</summary>
+										<div className="mb-3 flex flex-col">
+											{props.normalizedVolume?.total7d != null ? (
+												<p className="justify-stat flex flex-wrap gap-4 border-b border-dashed border-(--cards-border) py-1 last:border-none">
+													<Tooltip
+														content={definitions.normalizedVolume.chain['7d']}
+														className="text-(--text-label) underline decoration-dotted"
+													>
+														Normalized Volume (7d)
+													</Tooltip>
+													<span className="ml-auto font-jetbrains">
+														{formattedNum(props.normalizedVolume.total7d, true)}
+													</span>
+												</p>
+											) : null}
+											{props.normalizedVolume?.total30d != null ? (
+												<p className="justify-stat flex flex-wrap gap-4 border-b border-dashed border-(--cards-border) py-1 last:border-none">
+													<Tooltip
+														content={definitions.normalizedVolume.chain['30d']}
+														className="text-(--text-label) underline decoration-dotted"
+													>
+														Normalized Volume (30d)
+													</Tooltip>
+													<span className="ml-auto font-jetbrains">
+														{formattedNum(props.normalizedVolume.total30d, true)}
+													</span>
+												</p>
+											) : null}
+										</div>
+									</details>
+								) : (
+									<p className="group flex flex-wrap justify-start gap-4 border-b border-(--cards-border) py-1 last:border-none">
+										<Tooltip
+											content={definitions.normalizedVolume.chain['24h']}
+											className="text-(--text-label) underline decoration-dotted"
+										>
+											Normalized Volume (24h)
+										</Tooltip>
+										<span className="ml-auto font-jetbrains">
+											{formattedNum(props.normalizedVolume.total24h, true)}
+										</span>
+									</p>
+								)
+							) : null}
 							{props.openInterest ? (
 								<p className="group flex flex-wrap justify-start gap-4 border-b border-(--cards-border) py-1 last:border-none">
 									<Tooltip
@@ -373,19 +450,58 @@ export function AdapterByChain(props: IProps) {
 								</p>
 							) : null}
 							{props.total30d != null ? (
-								<p className="group flex flex-wrap justify-start gap-4 border-b border-(--cards-border) py-1 last:border-none">
-									{pageTypeByDefinition[props.type]?.['30d'] ? (
-										<Tooltip
-											content={pageTypeByDefinition[props.type]['30d']}
-											className="text-(--text-label) underline decoration-dotted"
-										>
-											{metricName} (30d)
-										</Tooltip>
-									) : (
-										<span className="text-(--text-label)">{metricName} (30d)</span>
-									)}
-									<span className="ml-auto font-jetbrains">{formattedNum(props.total30d, true)}</span>
-								</p>
+								props.total7d != null ? (
+									<details className="group">
+										<summary className="flex flex-wrap justify-start gap-4 border-b border-(--cards-border) py-1 group-last:border-none group-open:border-none group-open:font-semibold">
+											{pageTypeByDefinition[props.type]?.['30d'] ? (
+												<Tooltip
+													content={pageTypeByDefinition[props.type]['30d']}
+													className="text-(--text-label) underline decoration-dotted"
+												>
+													{metricName} (30d)
+												</Tooltip>
+											) : (
+												<span className="text-(--text-label)">{metricName} (30d)</span>
+											)}
+											<Icon
+												name="chevron-down"
+												height={16}
+												width={16}
+												className="relative top-0.5 -ml-3 transition-transform duration-100 group-open:rotate-180"
+											/>
+											<span className="ml-auto font-jetbrains">{formattedNum(props.total30d, true)}</span>
+										</summary>
+										<div className="mb-3 flex flex-col">
+											<p className="justify-stat flex flex-wrap gap-4 border-b border-dashed border-(--cards-border) py-1 last:border-none">
+												{pageTypeByDefinition[props.type]?.['7d'] ? (
+													<Tooltip
+														content={pageTypeByDefinition[props.type]['7d']}
+														className="text-(--text-label) underline decoration-dotted"
+													>
+														{metricName} (7d)
+													</Tooltip>
+												) : (
+													<span className="text-(--text-label)">{metricName} (7d)</span>
+												)}
+												<span className="ml-auto font-jetbrains">{formattedNum(props.total7d, true)}</span>
+											</p>
+										</div>
+									</details>
+								) : (
+									<p className="group flex flex-wrap justify-start gap-4 border-b border-(--cards-border) py-1 last:border-none">
+										{pageTypeByDefinition[props.type]?.['30d'] ? (
+											<Tooltip
+												content={pageTypeByDefinition[props.type]['30d']}
+												className="text-(--text-label) underline decoration-dotted"
+											>
+												{metricName} (30d)
+											</Tooltip>
+										) : (
+											<span className="text-(--text-label)">{metricName} (30d)</span>
+										)}
+										<span className="ml-auto font-jetbrains">{formattedNum(props.total30d, true)}</span>
+									</p>
+								)
 							) : null}
 							{props.change_7dover7d != null ? (
 								<p className="group flex flex-wrap justify-start gap-4 border-b border-(--cards-border) py-1 last:border-none">
@@ -479,8 +595,30 @@ const columnSizes: ColumnSizesByBreakpoint = {
 }
 
 const columnOrders: ColumnOrdersByBreakpoint = {
-	0: ['name', 'total24h', 'open_interest', 'total7d', 'total30d', 'category', 'definition'],
-	640: ['name', 'category', 'definition', 'total24h', 'open_interest', 'total7d', 'total30d']
+	0: [
+		'name',
+		'total24h',
+		'normalizedVolume24h',
+		'open_interest',
+		'total7d',
+		'normalizedVolume7d',
+		'total30d',
+		'normalizedVolume30d',
+		'category',
+		'definition'
+	],
+	640: [
+		'name',
+		'category',
+		'definition',
+		'total24h',
+		'normalizedVolume24h',
+		'open_interest',
+		'total7d',
+		'normalizedVolume7d',
+		'total30d',
+		'normalizedVolume30d'
+	]
 }
 
 const protocolChartsKeys: Partial<Record<IProps['type'], (typeof protocolCharts)[keyof typeof protocolCharts]>> = {
@@ -505,8 +643,8 @@ const chainChartsKeys: Partial<Record<IProps['type'], (typeof chainCharts)[keyof
 	'Perp Volume': 'perpsVolume'
 }
 
-const getColumnsOptions = (type) =>
-	columnsByType[type].map((c: any) => {
+const getColumnsOptions = (type: IProps['type'], columns: Array<ColumnDef<IAdapterByChainPageData['protocols'][0]>>) =>
+	columns.map((c: any) => {
 		let headerName: string
 		if (typeof c.header === 'function') {
 			switch (c.id) {
@@ -1017,6 +1155,17 @@ const getColumnsByType = (
 				size: 160
 			},
 			{
+				id: 'normalizedVolume24h',
+				header: 'Normalized Volume 24h',
+				accessorFn: (protocol) => protocol.normalizedVolume?.total24h,
+				cell: (info) => <>{info.getValue() != null ? formattedNum(info.getValue(), true) : null}</>,
+				meta: {
+					align: 'center',
+					headerHelperText: definitions.normalizedVolume.protocol['24h']
+				},
+				size: 180
+			},
+			{
 				header: 'Open Interest',
 				id: 'open_interest',
 				accessorFn: (protocol) => protocol.openInterest,
@@ -1065,6 +1214,17 @@ const getColumnsByType = (
 				size: 160
 			},
 			{
+				id: 'normalizedVolume7d',
+				header: 'Normalized Volume 7d',
+				accessorFn: (protocol) => protocol.normalizedVolume?.total7d,
+				cell: (info) => <>{info.getValue() != null ? formattedNum(info.getValue(), true) : null}</>,
+				meta: {
+					align: 'center',
+					headerHelperText: definitions.normalizedVolume.protocol['7d']
+				},
+				size: 180
+			},
+			{
 				id: 'total30d',
 				header: 'Perp Volume 30d',
 				accessorFn: (protocol) => protocol.total30d,
@@ -1100,6 +1260,17 @@ const getColumnsByType = (
 					headerHelperText: definitions.perps.protocol['30d']
 				},
 				size: 160
+			},
+			{
+				id: 'normalizedVolume30d',
+				header: 'Normalized Volume 30d',
+				accessorFn: (protocol) => protocol.normalizedVolume?.total30d,
+				cell: (info) => <>{info.getValue() != null ? formattedNum(info.getValue(), true) : null}</>,
+				meta: {
+					align: 'center',
+					headerHelperText: definitions.normalizedVolume.protocol['30d']
+				},
+				size: 180
 			}
 		],
 		'Open Interest': [
@@ -1380,5 +1551,3 @@ const getColumnsByType = (
 		]
 	}
 }
-
-const columnsByType = getColumnsByType()

--- a/src/containers/DimensionAdapters/constants.ts
+++ b/src/containers/DimensionAdapters/constants.ts
@@ -6,7 +6,8 @@ export enum ADAPTER_TYPES {
 	PERPS_AGGREGATOR = 'aggregator-derivatives',
 	OPTIONS = 'options',
 	BRIDGE_AGGREGATORS = 'bridge-aggregators',
-	OPEN_INTEREST = 'open-interest'
+	OPEN_INTEREST = 'open-interest',
+	NORMALIZED_VOLUME = 'normalized-volume'
 }
 
 export enum ADAPTER_DATA_TYPES {

--- a/src/containers/DimensionAdapters/types.ts
+++ b/src/containers/DimensionAdapters/types.ts
@@ -27,6 +27,13 @@ interface IProtocol {
 		totalAllTime: number | null
 	}
 	openInterest?: number | null
+	normalizedVolume?: {
+		total24h: number | null
+		total7d: number | null
+		total30d: number | null
+		total1y: number | null
+		totalAllTime: number | null
+	} | null
 	pf?: number | null
 	ps?: number | null
 	methodology?: string | null
@@ -54,6 +61,13 @@ export interface IAdapterByChainPageData {
 	change_1m: number | null
 	change_7dover7d: number | null
 	openInterest: number | null
+	normalizedVolume: {
+		total24h: number | null
+		total7d: number | null
+		total30d: number | null
+		total1y: number | null
+		totalAllTime: number | null
+	} | null
 }
 
 export interface IChainsByAdapterPageData {

--- a/src/containers/ProtocolOverview/types.ts
+++ b/src/containers/ProtocolOverview/types.ts
@@ -13,6 +13,7 @@ export interface IProtocolMetadata {
 	dexs?: boolean
 	perps?: boolean
 	openInterest?: boolean
+	normalizedVolume?: boolean
 	dexAggregators?: boolean
 	optionsPremiumVolume?: boolean
 	optionsNotionalVolume?: boolean

--- a/src/pages/api/datasets/index.ts
+++ b/src/pages/api/datasets/index.ts
@@ -1,2 +1,0 @@
-export { getCexData } from './cex'
-export type { ICexItem } from './cex'

--- a/src/pages/perps/chain/[chain].tsx
+++ b/src/pages/perps/chain/[chain].tsx
@@ -51,7 +51,9 @@ export const getStaticProps = withPerformanceLogging(
 		const data = await getAdapterByChainPageData({
 			adapterType,
 			chain: metadataCache.chainMetadata[chain].name,
-			route: 'perps'
+			route: 'perps',
+			hasOpenInterest: metadataCache.chainMetadata[chain].openInterest ?? false,
+			hasNormalizedVolume: metadataCache.chainMetadata[chain].normalizedVolume ?? false
 		}).catch((e) => console.info(`Chain page data not found ${adapterType} : chain:${chain}`, e))
 
 		if (!data) return { notFound: true }

--- a/src/pages/perps/index.tsx
+++ b/src/pages/perps/index.tsx
@@ -12,7 +12,9 @@ export const getStaticProps = withPerformanceLogging(`${type}/index`, async () =
 	const data = await getAdapterByChainPageData({
 		adapterType,
 		chain: 'All',
-		route: 'perps'
+		route: 'perps',
+		hasOpenInterest: true,
+		hasNormalizedVolume: true
 	}).catch((e) => console.info(`Chain page data not found ${adapterType} : ALL_CHAINS`, e))
 
 	if (!data) return { notFound: true }

--- a/src/pages/protocol/perps/[...protocol].tsx
+++ b/src/pages/protocol/perps/[...protocol].tsx
@@ -49,7 +49,9 @@ export const getStaticProps = withPerformanceLogging(
 			getAdapterProtocolSummary({
 				adapterType: 'derivatives',
 				protocol: metadata[1].displayName,
-				excludeTotalDataChart: false
+				excludeTotalDataChart: false,
+				hasOpenInterest: metadata[1].openInterest ?? false,
+				hasNormalizedVolume: metadata[1].normalizedVolume ?? false
 			})
 		])
 

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -19,6 +19,7 @@ interface IChainMetadata {
 	chainRevenue?: boolean
 	perps?: boolean
 	openInterest?: boolean
+	normalizedVolume?: boolean
 	dexAggregators?: boolean
 	optionsPremiumVolume?: boolean
 	optionsNotionalVolume?: boolean
@@ -47,6 +48,7 @@ interface IProtocolMetadata {
 	dexs?: boolean
 	perps?: boolean
 	openInterest?: boolean
+	normalizedVolume?: boolean
 	dexAggregators?: boolean
 	options?: boolean
 	perpsAggregators?: boolean

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,27 +3,25 @@
 		"target": "es2022",
 		"lib": ["dom", "dom.iterable", "esnext"],
 		"allowJs": true,
-		"baseUrl": ".",
-		"paths": {
-			"~/*": ["./src/*"],
-			"~/public/*": ["./public/*"]
-		},
 		"skipLibCheck": true,
 		"strict": false,
-		"forceConsistentCasingInFileNames": true,
 		"noEmit": true,
 		"esModuleInterop": true,
 		"module": "esnext",
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		"resolveJsonModule": true,
 		"isolatedModules": true,
 		"jsx": "react-jsx",
 		"incremental": true,
+		"paths": {
+			"~/*": ["./src/*"],
+			"~/public/*": ["./public/*"]
+		},
 		"downlevelIteration": true,
 		"allowSyntheticDefaultImports": true,
 		"noFallthroughCasesInSwitch": true,
 		"strictNullChecks": false
 	},
-	"exclude": ["node_modules"],
-	"include": ["**/*.js", "**/*.ts", "**/*.tsx"]
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts", "**/*.mts"],
+	"exclude": ["node_modules"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Normalized Volume metrics displaying 24h, 7d, 30d, 1y, and cumulative data at protocol and chain levels
  * Implemented expandable UI sections with tooltips for normalized volume information
  * Enabled conditional display and per-protocol/chain configuration for normalized volume features

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->