### PR TITLE
Fix rwa csv columns

### DIFF
--- a/src/containers/ProtocolsByCategoryOrTag/index.tsx
+++ b/src/containers/ProtocolsByCategoryOrTag/index.tsx
@@ -86,7 +86,6 @@ export function ProtocolsByCategoryOrTag(props: IProtocolByCategoryOrTagPageData
 						? col?.accessorFn?.(protocol)
 						: protocol[col.id as keyof typeof protocol]
 				if (value == null) return ''
-				if (col.id === 'name') return `"${protocol.name}"`
 				if (typeof value === 'number') return value
 				return String(value).includes(',') ? `"${String(value)}"` : String(value)
 			})
@@ -451,7 +450,7 @@ const revenue24hColumn: Column = {
 const rwaAssetClassColumn = (category: string): Column => ({
 	id: 'asset_class',
 	header: 'Asset Class',
-	accessorFn: (protocol) => protocol.tvl,
+	accessorFn: (protocol) => protocol.tags?.join(', '),
 	enableSorting: false,
 	cell: (info) => {
 		if (info.row.original.tags.length === 0) return null


### PR DESCRIPTION
The asset class was copying the tvl, and the names were in "" for some reason. I checked some other pages & we don't usually do that 🤔  is it an accidental change or there can be a "," in protocol name you wanted to protect against?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed CSV export handling for protocol names to remove unnecessary special character wrapping.
  * Corrected the Asset Class column to display protocol tags instead of TVL data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->