### PR TITLE
fix: metric data sampling size

### DIFF
--- a/src/containers/ProDashboard/hooks/useMetricData.ts
+++ b/src/containers/ProDashboard/hooks/useMetricData.ts
@@ -245,7 +245,22 @@ export function useMetricData(metric: MetricConfig) {
 			}
 		}
 
-		const sparklineData = inWindow.length > 60 ? inWindow.slice(inWindow.length - 60) : inWindow
+		// Scale data points based on window size - charts handle their own sampling
+		const maxPoints =
+			window === '7d'
+				? 7
+				: window === '30d'
+					? 30
+					: window === '90d'
+						? 90
+						: window === '365d'
+							? 365
+							: window === 'ytd'
+								? 365
+								: window === '3y'
+									? 1095
+									: 1500
+		const sparklineData = inWindow.length > maxPoints ? inWindow.slice(inWindow.length - maxPoints) : inWindow
 		const lastUpdatedTs =
 			inWindow.length > 0
 				? inWindow[inWindow.length - 1][0]


### PR DESCRIPTION
### What
- Improve metric data sampling size so point count matches the selected window (7d/30d/90d/365d/etc)

### Why
- Sampling was capped previously at 60 data points so 90d/365d/3y sparklines looked identical despite having different data

### Screenshots
**90 days before:**
<img width="996" height="292" alt="Screenshot 2026-01-28 at 23 25 34" src="https://github.com/user-attachments/assets/20c6c995-70a4-425f-975b-cce80cd1aa1f" /><br />

**365 days before:**
<img width="968" height="301" alt="Screenshot 2026-01-28 at 23 22 44" src="https://github.com/user-attachments/assets/8088554b-0046-430c-8df0-81412fa8a2d5" /><br />


**90 days after:**
<img width="998" height="301" alt="Screenshot 2026-01-28 at 23 25 40" src="https://github.com/user-attachments/assets/7568020c-d6c8-4f4e-90f6-815f4d651941" /><br />

**365 days after:**
<img width="982" height="292" alt="Screenshot 2026-01-28 at 23 22 58" src="https://github.com/user-attachments/assets/93f6a902-8b52-461c-a569-833ed600a358" />

