### PR TITLE
feat: add contextual prompts to llamaai

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -140,7 +140,7 @@ function App({ Component, pageProps }: AppProps) {
 				data-host-url="https://tasty.defillama.com"
 			/>
 
-			{showFloatingButton ? <LlamaAIFloatingButton /> : null}
+			{showFloatingButton ? <LlamaAIFloatingButton pageProps={pageProps} /> : null}
 
 			<Component {...pageProps} />
 		</>


### PR DESCRIPTION
When on a protocol/chain/stablecoin page, this adds an additional contextual prompt to the list of suggestions (making it 5 in total).

At the moment it's just `Give me a comprehensive overview of ${name}.`, which does give a great write-up tbf but could be expanded over time to pick from a list or be more interesting.

For example:
`What changed for ${protocol} over the last 7 days (TVL, volume, fees, revenue)?`
`What are the top protocols driving TVL on ${chain} this quarter?`
`Which chains saw the biggest net inflows/outflows of ${stablecoin} this month?`
etc.

<img width="663" height="881" alt="Screenshot 2026-01-29 at 22 31 13" src="https://github.com/user-attachments/assets/1837ea8f-3833-456f-aa7d-4877a50a04a2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI floating button now provides context-aware suggestions tailored to your current page, with the option to request a comprehensive overview of the entity being viewed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->