### PR TITLE
Fix stablecoin name filtering

### DIFF
--- a/src/containers/Stablecoins/queries.server.tsx
+++ b/src/containers/Stablecoins/queries.server.tsx
@@ -121,8 +121,10 @@ export async function getPeggedOverviewPageData(chain) {
 		let lastTimestamp = 0
 		const doublecountedIds = []
 		chartDataByPeggedAsset = peggedAssets.map((elem, i) => {
-			if (peggedAssetNamesSet.has(elem.symbol)) peggedAssetNamesSet.add(`${elem.name}`)
-			else peggedAssetNamesSet.add(elem.symbol)
+			let key = elem.symbol
+			if (peggedAssetNamesSet.has(key)) key = elem.name
+			if (!peggedAssetNamesSet.has(key)) peggedAssetNamesSet.add(key)
+			else peggedAssetNamesSet.add(elem.gecko_id)
 
 			peggedNameToChartDataIndex[elem.name] = i
 			let charts = breakdown[elem.id] ?? []


### PR DESCRIPTION
Fixed an index mismatch between the peggedAssetNamesSet and peggedAssets variables by using the unique gecko_id for coins with identical symbols and names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stablecoin data handling to prevent duplicate asset entries and ensure accurate data retrieval in edge cases with naming conflicts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->