### PR TITLE
feat: delete dashboards from settings

### DIFF
--- a/src/containers/ProDashboard/components/DashboardSettingsModal.tsx
+++ b/src/containers/ProDashboard/components/DashboardSettingsModal.tsx
@@ -1,6 +1,8 @@
 import * as Ariakit from '@ariakit/react'
 import { useEffect, useState } from 'react'
 import { Icon } from '~/components/Icon'
+import { LoadingSpinner } from '~/components/Loaders'
+import { ConfirmationModal } from './ConfirmationModal'
 
 interface DashboardSettingsModalProps {
 	isOpen: boolean
@@ -9,6 +11,7 @@ interface DashboardSettingsModalProps {
 	visibility: 'private' | 'public'
 	tags: string[]
 	description: string
+	dashboardId: string | null
 	onDashboardNameChange: (name: string) => void
 	onVisibilityChange: (visibility: 'private' | 'public') => void
 	onTagsChange: (tags: string[]) => void
@@ -19,6 +22,7 @@ interface DashboardSettingsModalProps {
 		tags?: string[]
 		description?: string
 	}) => void
+	onDelete?: (dashboardId: string) => Promise<void>
 }
 
 export function DashboardSettingsModal({
@@ -28,17 +32,21 @@ export function DashboardSettingsModal({
 	visibility,
 	tags,
 	description,
+	dashboardId,
 	onDashboardNameChange,
 	onVisibilityChange,
 	onTagsChange,
 	onDescriptionChange,
-	onSave
+	onSave,
+	onDelete
 }: DashboardSettingsModalProps) {
 	const [localDashboardName, setLocalDashboardName] = useState(dashboardName)
 	const [localVisibility, setLocalVisibility] = useState(visibility)
 	const [localTags, setLocalTags] = useState(tags)
 	const [localDescription, setLocalDescription] = useState(description)
 	const [tagInput, setTagInput] = useState('')
+	const [isDeleting, setIsDeleting] = useState(false)
+	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
 	useEffect(() => {
 		setLocalDashboardName(dashboardName)
@@ -80,129 +88,175 @@ export function DashboardSettingsModal({
 		}
 	}
 
+	const handleDeleteClick = () => {
+		setShowDeleteConfirm(true)
+	}
+
+	const handleConfirmDelete = async () => {
+		if (!onDelete || !dashboardId) return
+
+		setIsDeleting(true)
+		try {
+			await onDelete(dashboardId)
+			setShowDeleteConfirm(false)
+			onClose()
+		} catch (error) {
+			console.error('Failed to delete dashboard:', error)
+		} finally {
+			setIsDeleting(false)
+		}
+	}
+
 	return (
-		<Ariakit.DialogProvider
-			open={isOpen}
-			setOpen={(open) => {
-				if (!open) onClose()
-			}}
-		>
-			<Ariakit.Dialog
-				className="dialog w-full max-w-lg gap-0 border pro-dashboard border-(--cards-border) bg-(--cards-bg) p-6 shadow-2xl"
-				unmountOnHide
-				portal
-				hideOnInteractOutside
+		<>
+			<Ariakit.DialogProvider
+				open={isOpen}
+				setOpen={(open) => {
+					if (!open) onClose()
+				}}
 			>
-				<div className="mb-6 flex items-center justify-between">
-					<h2 className="text-xl font-semibold pro-text1">Dashboard Settings</h2>
-					<Ariakit.DialogDismiss className="rounded-md pro-hover-bg p-1 transition-colors">
-						<Icon name="x" height={20} width={20} className="pro-text2" />
-						<span className="sr-only">Close dialog</span>
-					</Ariakit.DialogDismiss>
-				</div>
-
-				<div className="space-y-6">
-					<div>
-						<label className="mb-3 block text-sm font-medium pro-text1">Dashboard Name</label>
-						<input
-							type="text"
-							value={localDashboardName}
-							onChange={(e) => setLocalDashboardName(e.target.value)}
-							placeholder="Enter dashboard name"
-							className="w-full rounded-md border pro-border px-3 py-2 pro-text1 placeholder:pro-text3 focus:ring-1 focus:ring-(--primary) focus:outline-hidden"
-						/>
+				<Ariakit.Dialog
+					className="dialog w-full max-w-lg gap-0 border pro-dashboard border-(--cards-border) bg-(--cards-bg) p-6 shadow-2xl"
+					unmountOnHide
+					portal
+					hideOnInteractOutside
+				>
+					<div className="mb-6 flex items-center justify-between">
+						<h2 className="text-xl font-semibold pro-text1">Dashboard Settings</h2>
+						<Ariakit.DialogDismiss className="rounded-md pro-hover-bg p-1 transition-colors">
+							<Icon name="x" height={20} width={20} className="pro-text2" />
+							<span className="sr-only">Close dialog</span>
+						</Ariakit.DialogDismiss>
 					</div>
 
-					<div>
-						<label className="mb-3 block text-sm font-medium pro-text1">Visibility</label>
-						<div className="flex gap-3">
-							<button
-								onClick={() => setLocalVisibility('public')}
-								className={`flex-1 rounded-md border px-4 py-3 transition-colors ${
-									localVisibility === 'public' ? 'pro-btn-blue' : 'pro-border pro-text2 hover:pro-text1'
-								}`}
-							>
-								<Icon name="earth" height={16} width={16} className="mr-2 inline" />
-								Public
-							</button>
-							<button
-								onClick={() => setLocalVisibility('private')}
-								className={`flex-1 rounded-md border px-4 py-3 transition-colors ${
-									localVisibility === 'private' ? 'pro-btn-blue' : 'pro-border pro-text2 hover:pro-text1'
-								}`}
-							>
-								<Icon name="key" height={16} width={16} className="mr-2 inline" />
-								Private
-							</button>
-						</div>
-						{localVisibility === 'public' && (
-							<p className="mt-2 text-sm pro-text3">Public dashboards are visible in the Discover tab</p>
-						)}
-					</div>
-
-					<div>
-						<label className="mb-3 block text-sm font-medium pro-text1">Tags</label>
-						<div className="flex gap-2">
+					<div className="space-y-6">
+						<div>
+							<label className="mb-3 block text-sm font-medium pro-text1">Dashboard Name</label>
 							<input
 								type="text"
-								value={tagInput}
-								onChange={(e) => setTagInput(e.target.value)}
-								onKeyDown={handleTagInputKeyDown}
-								placeholder="Enter tag name"
-								className="flex-1 rounded-md border pro-border px-3 py-2 pro-text1 placeholder:pro-text3 focus:ring-1 focus:ring-(--primary) focus:outline-hidden"
+								value={localDashboardName}
+								onChange={(e) => setLocalDashboardName(e.target.value)}
+								placeholder="Enter dashboard name"
+								className="w-full rounded-md border pro-border px-3 py-2 pro-text1 placeholder:pro-text3 focus:ring-1 focus:ring-(--primary) focus:outline-hidden"
 							/>
-							<button
-								onClick={() => handleAddTag(tagInput)}
-								disabled={!tagInput.trim()}
-								className={`rounded-md border px-4 py-2 transition-colors ${
-									tagInput.trim() ? 'pro-btn-blue-outline' : 'cursor-not-allowed pro-border pro-text3'
-								}`}
-							>
-								Add Tag
-							</button>
 						</div>
 
-						<p className="mt-2 text-xs pro-text3">Press Enter to add tag</p>
+						<div>
+							<label className="mb-3 block text-sm font-medium pro-text1">Visibility</label>
+							<div className="flex gap-3">
+								<button
+									onClick={() => setLocalVisibility('public')}
+									className={`flex-1 rounded-md border px-4 py-3 transition-colors ${
+										localVisibility === 'public' ? 'pro-btn-blue' : 'pro-border pro-text2 hover:pro-text1'
+									}`}
+								>
+									<Icon name="earth" height={16} width={16} className="mr-2 inline" />
+									Public
+								</button>
+								<button
+									onClick={() => setLocalVisibility('private')}
+									className={`flex-1 rounded-md border px-4 py-3 transition-colors ${
+										localVisibility === 'private' ? 'pro-btn-blue' : 'pro-border pro-text2 hover:pro-text1'
+									}`}
+								>
+									<Icon name="key" height={16} width={16} className="mr-2 inline" />
+									Private
+								</button>
+							</div>
+							{localVisibility === 'public' && (
+								<p className="mt-2 text-sm pro-text3">Public dashboards are visible in the Discover tab</p>
+							)}
+						</div>
 
-						{localTags.length > 0 && (
-							<div className="mt-3 flex flex-wrap gap-2">
-								{localTags.map((tag) => (
-									<span
-										key={tag}
-										className="flex items-center gap-1 rounded-md border pro-border px-3 py-1 text-sm pro-text2"
-									>
-										{tag}
-										<button onClick={() => handleRemoveTag(tag)} className="hover:text-pro-blue-400">
-											<Icon name="x" height={12} width={12} />
-										</button>
-									</span>
-								))}
+						<div>
+							<label className="mb-3 block text-sm font-medium pro-text1">Tags</label>
+							<div className="flex gap-2">
+								<input
+									type="text"
+									value={tagInput}
+									onChange={(e) => setTagInput(e.target.value)}
+									onKeyDown={handleTagInputKeyDown}
+									placeholder="Enter tag name"
+									className="flex-1 rounded-md border pro-border px-3 py-2 pro-text1 placeholder:pro-text3 focus:ring-1 focus:ring-(--primary) focus:outline-hidden"
+								/>
+								<button
+									onClick={() => handleAddTag(tagInput)}
+									disabled={!tagInput.trim()}
+									className={`rounded-md border px-4 py-2 transition-colors ${
+										tagInput.trim() ? 'pro-btn-blue-outline' : 'cursor-not-allowed pro-border pro-text3'
+									}`}
+								>
+									Add Tag
+								</button>
+							</div>
+
+							<p className="mt-2 text-xs pro-text3">Press Enter to add tag</p>
+
+							{localTags.length > 0 && (
+								<div className="mt-3 flex flex-wrap gap-2">
+									{localTags.map((tag) => (
+										<span
+											key={tag}
+											className="flex items-center gap-1 rounded-md border pro-border px-3 py-1 text-sm pro-text2"
+										>
+											{tag}
+											<button onClick={() => handleRemoveTag(tag)} className="hover:text-pro-blue-400">
+												<Icon name="x" height={12} width={12} />
+											</button>
+										</span>
+									))}
+								</div>
+							)}
+						</div>
+
+						<div>
+							<label className="mb-3 block text-sm font-medium pro-text1">Description</label>
+							<textarea
+								value={localDescription}
+								onChange={(e) => setLocalDescription(e.target.value)}
+								placeholder="Describe your dashboard..."
+								rows={3}
+								className="w-full resize-none rounded-md border pro-border px-3 py-2 pro-text1 placeholder:pro-text3 focus:ring-1 focus:ring-(--primary) focus:outline-hidden"
+							/>
+							<p className="mt-1 text-xs pro-text3">{localDescription.length}/200 characters</p>
+						</div>
+
+						{onDelete && dashboardId && (
+							<div className="border-t border-(--cards-border) pt-6">
+								<label className="mb-3 block text-sm font-medium pro-text1 text-red-500">Danger Zone</label>
+								<p className="mb-4 text-sm pro-text3">Once you delete a dashboard, there is no going back.</p>
+								<button
+									onClick={handleDeleteClick}
+									disabled={isDeleting}
+									className="flex items-center gap-2 rounded-md bg-red-500/10 px-4 py-2 text-sm font-medium text-red-500 transition-colors hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+								>
+									{isDeleting ? <LoadingSpinner size={16} /> : <Icon name="trash-2" height={16} width={16} />}
+									<span>Delete Dashboard</span>
+								</button>
 							</div>
 						)}
 					</div>
 
-					<div>
-						<label className="mb-3 block text-sm font-medium pro-text1">Description</label>
-						<textarea
-							value={localDescription}
-							onChange={(e) => setLocalDescription(e.target.value)}
-							placeholder="Describe your dashboard..."
-							rows={3}
-							className="w-full resize-none rounded-md border pro-border px-3 py-2 pro-text1 placeholder:pro-text3 focus:ring-1 focus:ring-(--primary) focus:outline-hidden"
-						/>
-						<p className="mt-1 text-xs pro-text3">{localDescription.length}/200 characters</p>
+					<div className="mt-8 flex gap-3">
+						<Ariakit.DialogDismiss className="flex-1 rounded-md border pro-border pro-hover-bg px-4 py-2 pro-text2 transition-colors hover:pro-text1">
+							Cancel
+						</Ariakit.DialogDismiss>
+						<button onClick={handleSave} className="flex-1 rounded-md pro-btn-blue px-4 py-2 transition-colors">
+							Save Changes
+						</button>
 					</div>
-				</div>
+				</Ariakit.Dialog>
+			</Ariakit.DialogProvider>
 
-				<div className="mt-8 flex gap-3">
-					<Ariakit.DialogDismiss className="flex-1 rounded-md border pro-border pro-hover-bg px-4 py-2 pro-text2 transition-colors hover:pro-text1">
-						Cancel
-					</Ariakit.DialogDismiss>
-					<button onClick={handleSave} className="flex-1 rounded-md pro-btn-blue px-4 py-2 transition-colors">
-						Save Changes
-					</button>
-				</div>
-			</Ariakit.Dialog>
-		</Ariakit.DialogProvider>
+			<ConfirmationModal
+				isOpen={showDeleteConfirm}
+				onClose={() => setShowDeleteConfirm(false)}
+				onConfirm={handleConfirmDelete}
+				title="Delete Dashboard"
+				message="Are you sure you want to delete this dashboard? This action cannot be undone."
+				confirmText="Delete"
+				cancelText="Cancel"
+			/>
+		</>
 	)
 }

--- a/src/containers/ProDashboard/hooks/useDashboardAPI.ts
+++ b/src/containers/ProDashboard/hooks/useDashboardAPI.ts
@@ -164,12 +164,10 @@ export function useDashboardAPI() {
 		Router.push(`/pro/${id}`)
 	}
 
-	// Delete dashboard with confirmation
+	// Delete dashboard (confirmation handled in UI)
 	const deleteDashboardWithConfirmation = useCallback(
 		async (id: string) => {
-			if (confirm('Are you sure you want to delete this dashboard?')) {
-				await deleteDashboardMutation.mutateAsync(id)
-			}
+			await deleteDashboardMutation.mutateAsync(id)
 		},
 		[deleteDashboardMutation]
 	)

--- a/src/containers/ProDashboard/index.tsx
+++ b/src/containers/ProDashboard/index.tsx
@@ -77,7 +77,8 @@ function ProDashboardContent() {
 		skipRating,
 		dismissRating,
 		undoAIGeneration,
-		canUndo
+		canUndo,
+		deleteDashboard
 	} = useProDashboardDashboard()
 	const {
 		createDashboardDialogStore,
@@ -358,11 +359,13 @@ function ProDashboardContent() {
 					visibility={dashboardVisibility}
 					tags={dashboardTags}
 					description={dashboardDescription}
+					dashboardId={dashboardId}
 					onDashboardNameChange={setDashboardName}
 					onVisibilityChange={setDashboardVisibility}
 					onTagsChange={setDashboardTags}
 					onDescriptionChange={setDashboardDescription}
 					onSave={saveDashboard}
+					onDelete={deleteDashboard}
 				/>
 			</Suspense>
 


### PR DESCRIPTION
Adds an option to delete your custom dashboard from within the dashboard settings, not just from My Dashboards.

Also changes both delete confirmations to use `confirmationModal` to match styling rather than the default browser confirm.

### Screenshots
**Delete option in settings**
<img width="611" height="836" alt="Screenshot 2026-02-05 at 21 58 48" src="https://github.com/user-attachments/assets/0213621f-de64-4baa-a1e0-4c74b8f891ba" /><br />

**Delete confirmation modal after:**
<img width="1074" height="682" alt="Screenshot 2026-02-05 at 21 59 06" src="https://github.com/user-attachments/assets/af57a901-e386-4791-a5af-bc9df6fe6a56" /><br />


**Delete confirmation modal before:**
<img width="1066" height="480" alt="Screenshot 2026-02-05 at 21 59 25" src="https://github.com/user-attachments/assets/56e737e6-18b6-4f9f-aaf0-4620d9c6fa7c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard deletion capability now available directly in the settings modal
  * Delete action requires explicit user confirmation via confirmation dialog

* **Improvements**
  * Enhanced safety for dashboard management with integrated confirmation step to prevent accidental removal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->