### PR TITLE
fix: scrolling contextual questions

### DIFF
--- a/src/components/EntityQuestionsStrip/index.tsx
+++ b/src/components/EntityQuestionsStrip/index.tsx
@@ -30,7 +30,7 @@ export function EntityQuestionsStrip({ questions, entitySlug, entityType, entity
 
 	return (
 		<div className="rounded-md border-l-2 border-l-[#C99A4A] bg-[#FDE0A9]/5 py-2 pr-2 pl-3 dark:border-l-[#FDE0A9] dark:bg-[#FDE0A9]/5">
-			<div className="scrollbar-none flex items-center gap-2 overflow-x-hidden">
+			<div className="no-scrollbar flex items-center gap-2 overflow-x-auto">
 				{/* Label with llama icon */}
 				<div className="flex shrink-0 items-center gap-1.5">
 					<img src="/assets/llamaai/llama-ai.svg" alt="" className="h-4 w-4" />


### PR DESCRIPTION
Keeps ugly scrollbar hidden but allows scrolling through contextual questions

<img width="1495" height="108" alt="Screenshot 2026-02-05 at 22 30 51" src="https://github.com/user-attachments/assets/0734aec6-cf82-4f50-803b-8ef1191a5755" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enabled horizontal scrolling for the questions section, allowing users to view more content within a compact layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->