### PR TITLE
strip research report intermediate msg, allow md export n upload

### DIFF
--- a/src/containers/LlamaAI/components/MarkdownExportArtifact.tsx
+++ b/src/containers/LlamaAI/components/MarkdownExportArtifact.tsx
@@ -1,0 +1,32 @@
+import { Icon } from '~/components/Icon'
+
+interface MarkdownExportArtifactProps {
+	mdExport: {
+		id: string
+		title: string
+		url: string
+		filename: string
+	}
+}
+
+export function MarkdownExportArtifact({ mdExport }: MarkdownExportArtifactProps) {
+	return (
+		<a
+			href={mdExport.url}
+			download={mdExport.filename}
+			className="flex items-center gap-3 rounded-lg border border-[#e6e6e6] bg-white p-3 transition-colors hover:border-[#2172E5] hover:bg-[#2172E5]/5 dark:border-[#222324] dark:bg-[#181A1C] dark:hover:border-[#2172E5]"
+		>
+			<span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[#2172E5]/10">
+				<Icon name="file-text" className="h-5 w-5 text-[#2172E5]" />
+			</span>
+			<span className="flex min-w-0 flex-1 flex-col gap-0.5">
+				<span className="m-0 truncate text-sm font-medium text-(--text1)">{mdExport.title}</span>
+				<span className="m-0 text-xs text-(--text3)">Markdown file</span>
+			</span>
+			<span className="flex shrink-0 items-center gap-1.5 text-[#2172E5]">
+				<Icon name="download-paper" className="h-4 w-4" />
+				<span className="text-sm font-medium">.md</span>
+			</span>
+		</a>
+	)
+}

--- a/src/containers/LlamaAI/components/MarkdownExportArtifact.tsx
+++ b/src/containers/LlamaAI/components/MarkdownExportArtifact.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '~/components/Icon'
+import { sanitizeUrl } from '~/containers/LlamaAI/utils/markdownHelpers'
 
 interface MarkdownExportArtifactProps {
 	mdExport: {
@@ -10,9 +11,12 @@ interface MarkdownExportArtifactProps {
 }
 
 export function MarkdownExportArtifact({ mdExport }: MarkdownExportArtifactProps) {
+	const safeUrl = sanitizeUrl(mdExport.url)
+	if (!safeUrl) return null
+
 	return (
 		<a
-			href={mdExport.url}
+			href={safeUrl}
 			download={mdExport.filename}
 			className="flex items-center gap-3 rounded-lg border border-[#e6e6e6] bg-white p-3 transition-colors hover:border-[#2172E5] hover:bg-[#2172E5]/5 dark:border-[#222324] dark:bg-[#181A1C] dark:hover:border-[#2172E5]"
 		>

--- a/src/containers/LlamaAI/components/ResponseControls.tsx
+++ b/src/containers/LlamaAI/components/ResponseControls.tsx
@@ -243,6 +243,7 @@ export function ResponseControls({
 			convertedContent = convertedContent
 				.replace(/\[CHART:[^\]]+\]\n?/g, '')
 				.replace(/\[CSV:[^\]]+\]\n?/g, '')
+				.replace(/\[MD:[^\]]+\]\n?/g, '')
 				.replace(/\[ACTION:[^\]]+\]\n?/g, '')
 				.replace(/\[DASHBOARD:[^\]]+\]\n?/g, '')
 				.replace(/\[REPORT_START\]\n?/g, '')

--- a/src/containers/LlamaAI/components/ResponseControls.tsx
+++ b/src/containers/LlamaAI/components/ResponseControls.tsx
@@ -245,6 +245,7 @@ export function ResponseControls({
 				.replace(/\[CSV:[^\]]+\]\n?/g, '')
 				.replace(/\[MD:[^\]]+\]\n?/g, '')
 				.replace(/\[ACTION:[^\]]+\]\n?/g, '')
+				.replace(/\[ALERT:[^\]]+\]\n?/g, '')
 				.replace(/\[DASHBOARD:[^\]]+\]\n?/g, '')
 				.replace(/\[REPORT_START\]\n?/g, '')
 				.trim()

--- a/src/containers/LlamaAI/components/ResponseControls.tsx
+++ b/src/containers/LlamaAI/components/ResponseControls.tsx
@@ -239,7 +239,14 @@ export function ResponseControls({
 		if (!content) return
 		trackUmamiEvent('llamaai-copy-response')
 		try {
-			const convertedContent = convertLlamaLinksToDefillama(content)
+			let convertedContent = convertLlamaLinksToDefillama(content)
+			convertedContent = convertedContent
+				.replace(/\[CHART:[^\]]+\]\n?/g, '')
+				.replace(/\[CSV:[^\]]+\]\n?/g, '')
+				.replace(/\[ACTION:[^\]]+\]\n?/g, '')
+				.replace(/\[DASHBOARD:[^\]]+\]\n?/g, '')
+				.replace(/\[REPORT_START\]\n?/g, '')
+				.trim()
 			await navigator.clipboard.writeText(convertedContent)
 			dispatch({ type: 'setCopied', value: true })
 			if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current)

--- a/src/containers/LlamaAI/components/input/ImageUpload.tsx
+++ b/src/containers/LlamaAI/components/input/ImageUpload.tsx
@@ -30,7 +30,7 @@ export function ImageUpload({
 			<input
 				ref={fileInputRef}
 				type="file"
-				accept="image/png,image/jpeg,image/gif,image/webp,application/pdf,text/csv,.pdf,.csv"
+				accept="image/png,image/jpeg,image/gif,image/webp,application/pdf,text/csv,.pdf,.csv,text/markdown,text/plain,.md,.txt"
 				multiple
 				onChange={handleImageSelect}
 				className="hidden"

--- a/src/containers/LlamaAI/components/messages/MessageBubble.tsx
+++ b/src/containers/LlamaAI/components/messages/MessageBubble.tsx
@@ -7,6 +7,7 @@ import { ChartRenderer } from '~/containers/LlamaAI/components/charts/ChartRende
 import { CSVExportArtifact } from '~/containers/LlamaAI/components/CSVExportArtifact'
 import { ImagePreviewModal } from '~/containers/LlamaAI/components/ImagePreviewModal'
 import { ChatMarkdownRenderer, SourcesList } from '~/containers/LlamaAI/components/markdown/ChatMarkdownRenderer'
+import { MarkdownExportArtifact } from '~/containers/LlamaAI/components/MarkdownExportArtifact'
 import { ResponseControls } from '~/containers/LlamaAI/components/ResponseControls'
 import {
 	ThinkingPanel,
@@ -282,7 +283,7 @@ function ArtifactBlockRenderer({
 	isStreaming,
 	sessionId
 }: {
-	block: Extract<MessageRenderBlock, { type: 'chart' | 'csv' | 'alert' | 'dashboard' }>
+	block: Extract<MessageRenderBlock, { type: 'chart' | 'csv' | 'md' | 'alert' | 'dashboard' }>
 	artifact?: ArtifactRecord
 	isStreaming: boolean
 	sessionId?: string | null
@@ -306,6 +307,21 @@ function ArtifactBlockRenderer({
 					title: artifact.title,
 					url: artifact.url,
 					rowCount: artifact.rowCount,
+					filename: artifact.filename
+				}}
+			/>
+		)
+	}
+
+	if (block.type === 'md') {
+		if (!artifact || isStreaming) return null
+		if (artifact.type !== 'md') return null
+		return (
+			<MarkdownExportArtifact
+				mdExport={{
+					id: artifact.id,
+					title: artifact.title,
+					url: artifact.url,
 					filename: artifact.filename
 				}}
 			/>

--- a/src/containers/LlamaAI/fetchAgenticResponse.ts
+++ b/src/containers/LlamaAI/fetchAgenticResponse.ts
@@ -16,6 +16,13 @@ export interface CsvExport {
 	filename: string
 }
 
+export interface MdExport {
+	id: string
+	title: string
+	url: string
+	filename: string
+}
+
 export interface SpawnProgressData {
 	agentId: string
 	status: 'started' | 'thinking' | 'tool_call' | 'completed' | 'error'
@@ -35,6 +42,7 @@ export interface AgenticSSECallbacks {
 	onSessionId: (sessionId: string, startedAt?: number) => void
 	onCitations: (citations: string[]) => void
 	onCsvExport?: (exports: CsvExport[]) => void
+	onMdExport?: (exports: MdExport[]) => void
 	onAlertProposed?: (data: AlertProposedData) => void
 	onDashboard?: (dashboard: DashboardArtifact) => void
 	onToolExecution?: (data: ToolExecution) => void
@@ -74,6 +82,11 @@ interface ChartsEvent {
 interface CsvExportEvent {
 	type: 'csv_export'
 	exports?: CsvExport[]
+}
+
+interface MdExportEvent {
+	type: 'md_export'
+	exports?: MdExport[]
 }
 
 interface AlertProposedEvent extends AlertProposedData {
@@ -159,6 +172,7 @@ type AgenticSSEEvent =
 	| ResponseChunkEvent
 	| ChartsEvent
 	| CsvExportEvent
+	| MdExportEvent
 	| AlertProposedEvent
 	| DashboardEvent
 	| ({ type: 'spawn_progress' } & SpawnProgressData)
@@ -262,6 +276,9 @@ export function parseSSEStream(
 					break
 				case 'csv_export':
 					callbacks.onCsvExport?.(data.exports || [])
+					break
+				case 'md_export':
+					callbacks.onMdExport?.(data.exports || [])
 					break
 				case 'alert_proposed':
 					callbacks.onAlertProposed?.(data)

--- a/src/containers/LlamaAI/hooks/useImageUpload.ts
+++ b/src/containers/LlamaAI/hooks/useImageUpload.ts
@@ -14,7 +14,6 @@ const ACCEPTED_TYPES = new Set([
 	'image/webp',
 	'application/pdf',
 	'text/csv',
-	'application/vnd.ms-excel',
 	'text/markdown',
 	'text/plain'
 ])
@@ -115,7 +114,7 @@ export function useImageUpload({
 					queueMicrotask(() => {
 						errorToast({
 							title: 'Unsupported file type',
-							description: 'Supported formats: PNG, JPEG, GIF, WebP, PDF, CSV, XLS, MD, TXT'
+							description: 'Supported formats: PNG, JPEG, GIF, WebP, PDF, CSV, MD, TXT'
 						})
 					})
 				}

--- a/src/containers/LlamaAI/hooks/useImageUpload.ts
+++ b/src/containers/LlamaAI/hooks/useImageUpload.ts
@@ -14,9 +14,11 @@ const ACCEPTED_TYPES = new Set([
 	'image/webp',
 	'application/pdf',
 	'text/csv',
-	'application/vnd.ms-excel'
+	'application/vnd.ms-excel',
+	'text/markdown',
+	'text/plain'
 ])
-const ACCEPTED_EXTENSIONS = new Set(['.pdf', '.csv'])
+const ACCEPTED_EXTENSIONS = new Set(['.pdf', '.csv', '.md', '.txt'])
 const IMAGE_MAX_SIZE = 10 * 1024 * 1024
 const FILE_MAX_SIZE = 30 * 1024 * 1024
 const MAX_TOTAL_BYTES = 50 * 1024 * 1024
@@ -113,7 +115,7 @@ export function useImageUpload({
 					queueMicrotask(() => {
 						errorToast({
 							title: 'Unsupported file type',
-							description: 'Supported formats: PNG, JPEG, GIF, WebP, PDF, CSV, XLS'
+							description: 'Supported formats: PNG, JPEG, GIF, WebP, PDF, CSV, XLS, MD, TXT'
 						})
 					})
 				}

--- a/src/containers/LlamaAI/index.tsx
+++ b/src/containers/LlamaAI/index.tsx
@@ -557,6 +557,10 @@ function createAgenticCallbacks({
 				dispatch({ type: 'CLEAR_ACTIVITY' })
 			}
 			buffer.text += content
+			const reportIdx = buffer.text.indexOf('[REPORT_START]')
+			if (reportIdx !== -1) {
+				buffer.text = buffer.text.slice(reportIdx + '[REPORT_START]'.length).trimStart()
+			}
 			dispatch({ type: 'APPEND_TOKEN', value: content })
 		},
 		onCharts: (charts, chartData) => {

--- a/src/containers/LlamaAI/index.tsx
+++ b/src/containers/LlamaAI/index.tsx
@@ -527,6 +527,8 @@ function createRequestSettleState(requestId: number): Exclude<RequestSettleState
 }
 
 // Build one callback bundle shared by live prompt submits and resumed server-side streams.
+const REPORT_START_MARKER = '[REPORT_START]'
+
 function createAgenticCallbacks({
 	requestId,
 	activeRequestIdRef,
@@ -557,16 +559,28 @@ function createAgenticCallbacks({
 	return {
 		onToken: (content) => {
 			if (!isActiveRequest(activeRequestIdRef, requestId)) return
+			const prevVisibleText = buffer.hasReportStarted ? buffer.text : ''
+			buffer.text += content
+			if (!buffer.hasReportStarted) {
+				const reportIdx = buffer.text.indexOf(REPORT_START_MARKER)
+				if (reportIdx !== -1) {
+					buffer.text = buffer.text.slice(reportIdx + REPORT_START_MARKER.length).trimStart()
+					buffer.hasReportStarted = true
+				}
+			}
+			const nextVisibleText = buffer.hasReportStarted ? buffer.text : ''
+			if (nextVisibleText === prevVisibleText) return
+			if (!buffer.hasStartedText && nextVisibleText.trim().length === 0) return
+			const shouldReplaceText = !buffer.hasStartedText || !nextVisibleText.startsWith(prevVisibleText)
+			if (shouldReplaceText) {
+				dispatch({ type: 'REPLACE_STREAM_TEXT', value: nextVisibleText })
+			} else {
+				dispatch({ type: 'APPEND_TOKEN', value: nextVisibleText.slice(prevVisibleText.length) })
+			}
 			if (!buffer.hasStartedText) {
 				buffer.hasStartedText = true
 				dispatch({ type: 'CLEAR_ACTIVITY' })
 			}
-			buffer.text += content
-			const reportIdx = buffer.text.indexOf('[REPORT_START]')
-			if (reportIdx !== -1) {
-				buffer.text = buffer.text.slice(reportIdx + '[REPORT_START]'.length).trimStart()
-			}
-			dispatch({ type: 'APPEND_TOKEN', value: content })
 		},
 		onCharts: (charts, chartData) => {
 			if (!isActiveRequest(activeRequestIdRef, requestId)) return

--- a/src/containers/LlamaAI/index.tsx
+++ b/src/containers/LlamaAI/index.tsx
@@ -113,6 +113,8 @@ interface PersistedMessageMetadata {
 		sourceDashboardId?: string
 	}
 	deliveryChannel?: 'email' | 'telegram'
+	mdExports?: Array<{ id: string; title: string; url: string; filename: string }>
+	x402_cost_usd?: string
 }
 
 interface PersistedMessage {
@@ -272,6 +274,7 @@ function mapPersistedMessage(message: PersistedMessage, index?: number): Message
 			message.charts && message.chartData ? [{ charts: message.charts, chartData: message.chartData }] : undefined,
 		citations: message.citations,
 		csvExports: message.csvExports,
+		mdExports: message.metadata?.mdExports,
 		dashboards: dashboardConfig
 			? [
 					(() => {
@@ -378,6 +381,7 @@ function mapSharedSessionMessage(message: SharedSessionMessage, index?: number):
 					]
 				: undefined,
 		csvExports: message.csvExports,
+		mdExports: (message as any).mdExports,
 		citations: message.citations,
 		alerts: buildRestoredAlerts({
 			messageId: message.messageId,
@@ -460,6 +464,7 @@ function appendBufferedAssistantMessage(
 		buffer.text ||
 		buffer.charts.length > 0 ||
 		buffer.csvExports.length > 0 ||
+		buffer.mdExports.length > 0 ||
 		buffer.alerts.length > 0 ||
 		buffer.dashboards.length > 0 ||
 		buffer.citations.length > 0 ||
@@ -574,6 +579,11 @@ function createAgenticCallbacks({
 			if (!isActiveRequest(activeRequestIdRef, requestId)) return
 			buffer.csvExports.push(...exports)
 			dispatch({ type: 'APPEND_CSV_EXPORTS', value: exports })
+		},
+		onMdExport: (exports) => {
+			if (!isActiveRequest(activeRequestIdRef, requestId)) return
+			buffer.mdExports.push(...exports)
+			dispatch({ type: 'APPEND_MD_EXPORTS', value: exports })
 		},
 		onAlertProposed: (data) => {
 			if (!isActiveRequest(activeRequestIdRef, requestId)) return
@@ -804,6 +814,7 @@ export function AgenticChat({ initialSessionId, sharedSession, readOnly = false 
 		text: streamingText,
 		charts: streamingCharts,
 		csvExports: streamingCsvExports,
+		mdExports: streamingMdExports,
 		alerts: streamingAlerts,
 		citations: streamingCitations,
 		toolExecutions: streamingToolExecutions,
@@ -878,6 +889,7 @@ export function AgenticChat({ initialSessionId, sharedSession, readOnly = false 
 			streamingText ||
 			streamingCharts.length > 0 ||
 			streamingCsvExports.length > 0 ||
+			streamingMdExports.length > 0 ||
 			streamingAlerts.length > 0 ||
 			streamingCitations.length > 0
 		if (!hasContent) return null
@@ -886,6 +898,7 @@ export function AgenticChat({ initialSessionId, sharedSession, readOnly = false 
 			content: streamingText || undefined,
 			charts: streamingCharts.length > 0 ? streamingCharts : undefined,
 			csvExports: streamingCsvExports.length > 0 ? streamingCsvExports : undefined,
+			mdExports: streamingMdExports.length > 0 ? streamingMdExports : undefined,
 			alerts: streamingAlerts.length > 0 ? streamingAlerts : undefined,
 			citations: streamingCitations.length > 0 ? streamingCitations : undefined,
 			toolExecutions: streamingToolExecutions.length > 0 ? streamingToolExecutions : undefined
@@ -895,6 +908,7 @@ export function AgenticChat({ initialSessionId, sharedSession, readOnly = false 
 		streamingText,
 		streamingCharts,
 		streamingCsvExports,
+		streamingMdExports,
 		streamingAlerts,
 		streamingCitations,
 		streamingToolExecutions

--- a/src/containers/LlamaAI/index.tsx
+++ b/src/containers/LlamaAI/index.tsx
@@ -381,7 +381,7 @@ function mapSharedSessionMessage(message: SharedSessionMessage, index?: number):
 					]
 				: undefined,
 		csvExports: message.csvExports,
-		mdExports: (message as any).mdExports,
+		mdExports: message.metadata?.mdExports,
 		citations: message.citations,
 		alerts: buildRestoredAlerts({
 			messageId: message.messageId,

--- a/src/containers/LlamaAI/index.tsx
+++ b/src/containers/LlamaAI/index.tsx
@@ -527,8 +527,6 @@ function createRequestSettleState(requestId: number): Exclude<RequestSettleState
 }
 
 // Build one callback bundle shared by live prompt submits and resumed server-side streams.
-const REPORT_START_MARKER = '[REPORT_START]'
-
 function createAgenticCallbacks({
 	requestId,
 	activeRequestIdRef,
@@ -559,28 +557,16 @@ function createAgenticCallbacks({
 	return {
 		onToken: (content) => {
 			if (!isActiveRequest(activeRequestIdRef, requestId)) return
-			const prevVisibleText = buffer.hasReportStarted ? buffer.text : ''
-			buffer.text += content
-			if (!buffer.hasReportStarted) {
-				const reportIdx = buffer.text.indexOf(REPORT_START_MARKER)
-				if (reportIdx !== -1) {
-					buffer.text = buffer.text.slice(reportIdx + REPORT_START_MARKER.length).trimStart()
-					buffer.hasReportStarted = true
-				}
-			}
-			const nextVisibleText = buffer.hasReportStarted ? buffer.text : ''
-			if (nextVisibleText === prevVisibleText) return
-			if (!buffer.hasStartedText && nextVisibleText.trim().length === 0) return
-			const shouldReplaceText = !buffer.hasStartedText || !nextVisibleText.startsWith(prevVisibleText)
-			if (shouldReplaceText) {
-				dispatch({ type: 'REPLACE_STREAM_TEXT', value: nextVisibleText })
-			} else {
-				dispatch({ type: 'APPEND_TOKEN', value: nextVisibleText.slice(prevVisibleText.length) })
-			}
 			if (!buffer.hasStartedText) {
 				buffer.hasStartedText = true
 				dispatch({ type: 'CLEAR_ACTIVITY' })
 			}
+			buffer.text += content
+			const reportIdx = buffer.text.indexOf('[REPORT_START]')
+			if (reportIdx !== -1) {
+				buffer.text = buffer.text.slice(reportIdx + '[REPORT_START]'.length).trimStart()
+			}
+			dispatch({ type: 'APPEND_TOKEN', value: content })
 		},
 		onCharts: (charts, chartData) => {
 			if (!isActiveRequest(activeRequestIdRef, requestId)) return

--- a/src/containers/LlamaAI/renderModel.ts
+++ b/src/containers/LlamaAI/renderModel.ts
@@ -266,6 +266,10 @@ export function parseMessageToRenderModel(
 				blocks.push({ type: 'csv', key: `csv-${artifactId}-fallback`, artifactId })
 				continue
 			}
+			if (artifact.type === 'md') {
+				blocks.push({ type: 'md', key: `md-${artifactId}-fallback`, artifactId })
+				continue
+			}
 			if (artifact.type === 'dashboard') {
 				blocks.push({ type: 'dashboard', key: `dashboard-${artifactId}-fallback`, artifactId })
 				continue

--- a/src/containers/LlamaAI/renderModel.ts
+++ b/src/containers/LlamaAI/renderModel.ts
@@ -26,13 +26,26 @@ export type AlertArtifactRecord = {
 	savedAlertIds?: string[]
 }
 
+export type MdArtifactRecord = {
+	type: 'md'
+	id: string
+	title: string
+	url: string
+	filename: string
+}
+
 export type DashboardArtifactRecord = {
 	type: 'dashboard'
 	id: string
 	dashboard: DashboardArtifact
 }
 
-export type ArtifactRecord = ChartArtifactRecord | CsvArtifactRecord | AlertArtifactRecord | DashboardArtifactRecord
+export type ArtifactRecord =
+	| ChartArtifactRecord
+	| CsvArtifactRecord
+	| MdArtifactRecord
+	| AlertArtifactRecord
+	| DashboardArtifactRecord
 
 export type ArtifactRegistry = Map<string, ArtifactRecord>
 
@@ -41,6 +54,7 @@ export type MessageRenderBlock =
 	| { type: 'sources'; key: string; citations: string[] }
 	| { type: 'chart'; key: string; artifactId: string }
 	| { type: 'csv'; key: string; artifactId: string }
+	| { type: 'md'; key: string; artifactId: string }
 	| { type: 'alert'; key: string; artifactId: string }
 	| { type: 'dashboard'; key: string; artifactId: string }
 	| { type: 'action-group'; key: string; actions: Array<{ label: string; message: string }> }
@@ -73,6 +87,16 @@ function buildArtifactRegistry(message: Message): ArtifactRegistry {
 			url: csv.url,
 			rowCount: csv.rowCount,
 			filename: csv.filename
+		})
+	}
+
+	for (const md of message.mdExports ?? []) {
+		artifacts.set(md.id, {
+			type: 'md',
+			id: md.id,
+			title: md.title,
+			url: md.url,
+			filename: md.filename
 		})
 	}
 
@@ -172,6 +196,17 @@ export function parseMessageToRenderModel(
 				type: 'csv',
 				key: `csv-${part.csvId}-${blocks.length}`,
 				artifactId: part.csvId
+			})
+			continue
+		}
+
+		if (part.type === 'md') {
+			if (usedArtifactIds.has(part.mdId)) continue
+			usedArtifactIds.add(part.mdId)
+			blocks.push({
+				type: 'md',
+				key: `md-${part.mdId}-${blocks.length}`,
+				artifactId: part.mdId
 			})
 			continue
 		}

--- a/src/containers/LlamaAI/streamState.ts
+++ b/src/containers/LlamaAI/streamState.ts
@@ -1,5 +1,5 @@
 import type { Dispatch } from 'react'
-import type { CsvExport } from '~/containers/LlamaAI/fetchAgenticResponse'
+import type { CsvExport, MdExport } from '~/containers/LlamaAI/fetchAgenticResponse'
 import type {
 	AlertProposedData,
 	ChartSet,
@@ -43,6 +43,7 @@ export interface StreamState {
 	text: string
 	charts: ChartSet[]
 	csvExports: CsvExport[]
+	mdExports: MdExport[]
 	alerts: AlertProposedData[]
 	dashboards: DashboardArtifact[]
 	citations: string[]
@@ -64,6 +65,7 @@ export interface StreamBuffer {
 	text: string
 	charts: ChartSet[]
 	csvExports: CsvExport[]
+	mdExports: MdExport[]
 	alerts: AlertProposedData[]
 	dashboards: DashboardArtifact[]
 	citations: string[]
@@ -85,6 +87,7 @@ export type StreamAction =
 	| { type: 'APPEND_TOKEN'; value: string }
 	| { type: 'APPEND_CHARTS'; value: ChartSet }
 	| { type: 'APPEND_CSV_EXPORTS'; value: CsvExport[] }
+	| { type: 'APPEND_MD_EXPORTS'; value: MdExport[] }
 	| { type: 'APPEND_ALERT'; value: AlertProposedData }
 	| { type: 'APPEND_DASHBOARD'; value: DashboardArtifact }
 	| { type: 'MERGE_CITATIONS'; value: string[] }
@@ -108,6 +111,7 @@ const createEmptyRuntimeState = () => ({
 	text: '',
 	charts: [] as ChartSet[],
 	csvExports: [] as CsvExport[],
+	mdExports: [] as MdExport[],
 	alerts: [] as AlertProposedData[],
 	dashboards: [] as DashboardArtifact[],
 	citations: [] as string[],
@@ -139,6 +143,7 @@ export const createStreamBuffer = (): StreamBuffer => ({
 	text: '',
 	charts: [],
 	csvExports: [],
+	mdExports: [],
 	alerts: [],
 	dashboards: [],
 	citations: [],
@@ -183,6 +188,8 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 			return { ...state, charts: [...state.charts, action.value] }
 		case 'APPEND_CSV_EXPORTS':
 			return { ...state, csvExports: [...state.csvExports, ...action.value] }
+		case 'APPEND_MD_EXPORTS':
+			return { ...state, mdExports: [...state.mdExports, ...action.value] }
 		case 'APPEND_ALERT':
 			return { ...state, alerts: [...state.alerts, action.value] }
 		case 'APPEND_DASHBOARD':
@@ -261,6 +268,7 @@ export function buildAssistantMessage(buffer: StreamBuffer, messageId?: string):
 		content: buffer.text || undefined,
 		charts: buffer.charts.length > 0 ? buffer.charts : undefined,
 		csvExports: buffer.csvExports.length > 0 ? buffer.csvExports : undefined,
+		mdExports: buffer.mdExports.length > 0 ? buffer.mdExports : undefined,
 		alerts: buffer.alerts.length > 0 ? buffer.alerts : undefined,
 		dashboards: buffer.dashboards.length > 0 ? buffer.dashboards : undefined,
 		citations: buffer.citations.length > 0 ? buffer.citations : undefined,

--- a/src/containers/LlamaAI/streamState.ts
+++ b/src/containers/LlamaAI/streamState.ts
@@ -72,6 +72,7 @@ export interface StreamBuffer {
 	toolExecutions: ToolExecution[]
 	thinking: string
 	hasStartedText: boolean
+	hasReportStarted: boolean
 	spawnStarted: boolean
 	receivedEventCount: number
 	messageMetadata?: MessageMetadata
@@ -84,6 +85,7 @@ export type StreamAction =
 	| { type: 'SET_ERROR'; value: string | null }
 	| { type: 'SET_LAST_FAILED_REQUEST'; value: FailedRequest | null }
 	| { type: 'SET_RATE_LIMIT_DETAILS'; value: RateLimitDetails | null }
+	| { type: 'REPLACE_STREAM_TEXT'; value: string }
 	| { type: 'APPEND_TOKEN'; value: string }
 	| { type: 'APPEND_CHARTS'; value: ChartSet }
 	| { type: 'APPEND_CSV_EXPORTS'; value: CsvExport[] }
@@ -150,6 +152,7 @@ export const createStreamBuffer = (): StreamBuffer => ({
 	toolExecutions: [],
 	thinking: '',
 	hasStartedText: false,
+	hasReportStarted: false,
 	spawnStarted: false,
 	receivedEventCount: 0
 })
@@ -176,14 +179,10 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 			return { ...state, lastFailedRequest: action.value }
 		case 'SET_RATE_LIMIT_DETAILS':
 			return { ...state, rateLimitDetails: action.value }
-		case 'APPEND_TOKEN': {
-			let newText = state.text + action.value
-			const reportIdx = newText.indexOf('[REPORT_START]')
-			if (reportIdx !== -1) {
-				newText = newText.slice(reportIdx + '[REPORT_START]'.length).trimStart()
-			}
-			return { ...state, text: newText }
-		}
+		case 'REPLACE_STREAM_TEXT':
+			return { ...state, text: action.value }
+		case 'APPEND_TOKEN':
+			return { ...state, text: state.text + action.value }
 		case 'APPEND_CHARTS':
 			return { ...state, charts: [...state.charts, action.value] }
 		case 'APPEND_CSV_EXPORTS':

--- a/src/containers/LlamaAI/streamState.ts
+++ b/src/containers/LlamaAI/streamState.ts
@@ -72,7 +72,6 @@ export interface StreamBuffer {
 	toolExecutions: ToolExecution[]
 	thinking: string
 	hasStartedText: boolean
-	hasReportStarted: boolean
 	spawnStarted: boolean
 	receivedEventCount: number
 	messageMetadata?: MessageMetadata
@@ -85,7 +84,6 @@ export type StreamAction =
 	| { type: 'SET_ERROR'; value: string | null }
 	| { type: 'SET_LAST_FAILED_REQUEST'; value: FailedRequest | null }
 	| { type: 'SET_RATE_LIMIT_DETAILS'; value: RateLimitDetails | null }
-	| { type: 'REPLACE_STREAM_TEXT'; value: string }
 	| { type: 'APPEND_TOKEN'; value: string }
 	| { type: 'APPEND_CHARTS'; value: ChartSet }
 	| { type: 'APPEND_CSV_EXPORTS'; value: CsvExport[] }
@@ -152,7 +150,6 @@ export const createStreamBuffer = (): StreamBuffer => ({
 	toolExecutions: [],
 	thinking: '',
 	hasStartedText: false,
-	hasReportStarted: false,
 	spawnStarted: false,
 	receivedEventCount: 0
 })
@@ -179,10 +176,14 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 			return { ...state, lastFailedRequest: action.value }
 		case 'SET_RATE_LIMIT_DETAILS':
 			return { ...state, rateLimitDetails: action.value }
-		case 'REPLACE_STREAM_TEXT':
-			return { ...state, text: action.value }
-		case 'APPEND_TOKEN':
-			return { ...state, text: state.text + action.value }
+		case 'APPEND_TOKEN': {
+			let newText = state.text + action.value
+			const reportIdx = newText.indexOf('[REPORT_START]')
+			if (reportIdx !== -1) {
+				newText = newText.slice(reportIdx + '[REPORT_START]'.length).trimStart()
+			}
+			return { ...state, text: newText }
+		}
 		case 'APPEND_CHARTS':
 			return { ...state, charts: [...state.charts, action.value] }
 		case 'APPEND_CSV_EXPORTS':

--- a/src/containers/LlamaAI/streamState.ts
+++ b/src/containers/LlamaAI/streamState.ts
@@ -171,8 +171,14 @@ export function streamReducer(state: StreamState, action: StreamAction): StreamS
 			return { ...state, lastFailedRequest: action.value }
 		case 'SET_RATE_LIMIT_DETAILS':
 			return { ...state, rateLimitDetails: action.value }
-		case 'APPEND_TOKEN':
-			return { ...state, text: state.text + action.value }
+		case 'APPEND_TOKEN': {
+			let newText = state.text + action.value
+			const reportIdx = newText.indexOf('[REPORT_START]')
+			if (reportIdx !== -1) {
+				newText = newText.slice(reportIdx + '[REPORT_START]'.length).trimStart()
+			}
+			return { ...state, text: newText }
+		}
 		case 'APPEND_CHARTS':
 			return { ...state, charts: [...state.charts, action.value] }
 		case 'APPEND_CSV_EXPORTS':

--- a/src/containers/LlamaAI/types.ts
+++ b/src/containers/LlamaAI/types.ts
@@ -215,6 +215,7 @@ export interface Message {
 	content?: string
 	charts?: Array<{ charts: ChartConfiguration[]; chartData: Record<string, any[]> }>
 	csvExports?: CsvExport[]
+	mdExports?: Array<{ id: string; title: string; url: string; filename: string }>
 	citations?: string[]
 	alerts?: AlertProposedData[]
 	savedAlertIds?: string[]

--- a/src/containers/LlamaAI/utils/markdownHelpers.ts
+++ b/src/containers/LlamaAI/utils/markdownHelpers.ts
@@ -73,7 +73,10 @@ interface ParsedContent {
  * Placeholders follow the format [CHART:id], [CSV:id], and [ALERT:id].
  */
 export function parseArtifactPlaceholders(content: string): ParsedContent {
-	content = content.replace(/\[REPORT_START\]\n?/g, '')
+	const reportStartIdx = content.indexOf('[REPORT_START]')
+	if (reportStartIdx !== -1) {
+		content = content.slice(reportStartIdx + '[REPORT_START]'.length).trimStart()
+	}
 	const chartPlaceholderPattern = /\[CHART:([^\]]+)\]/g
 	const csvPlaceholderPattern = /\[CSV:([^\]]+)\]/g
 	const alertPlaceholderPattern = /\[ALERT:([^\]]+)\]/g

--- a/src/containers/LlamaAI/utils/markdownHelpers.ts
+++ b/src/containers/LlamaAI/utils/markdownHelpers.ts
@@ -53,13 +53,14 @@ interface ActionPlaceholderData {
 }
 
 type ArtifactMatch =
-	| { index: number; length: number; type: 'chart' | 'csv' | 'alert' | 'dashboard'; id: string }
+	| { index: number; length: number; type: 'chart' | 'csv' | 'md' | 'alert' | 'dashboard'; id: string }
 	| { index: number; length: number; type: 'action'; id: ActionPlaceholderData }
 
 export type ContentPart =
 	| { type: 'text'; content: string }
 	| { type: 'chart'; chartId: string }
 	| { type: 'csv'; csvId: string }
+	| { type: 'md'; mdId: string }
 	| { type: 'alert'; alertId: string }
 	| { type: 'dashboard'; dashboardId: string }
 	| { type: 'action'; actionLabel: string; actionMessage: string }
@@ -79,6 +80,7 @@ export function parseArtifactPlaceholders(content: string): ParsedContent {
 	}
 	const chartPlaceholderPattern = /\[CHART:([^\]]+)\]/g
 	const csvPlaceholderPattern = /\[CSV:([^\]]+)\]/g
+	const mdPlaceholderPattern = /\[MD:([^\]]+)\]/g
 	const alertPlaceholderPattern = /\[ALERT:([^\]]+)\]/g
 	const dashboardPlaceholderPattern = /\[DASHBOARD:([^\]]+)\]/g
 	const actionPlaceholderPattern = /\[ACTION:([^|\]]+)(?:\|([^\]]*))?\]/g
@@ -92,6 +94,9 @@ export function parseArtifactPlaceholders(content: string): ParsedContent {
 	}
 	while ((match = csvPlaceholderPattern.exec(content)) !== null) {
 		allMatches.push({ index: match.index, length: match[0].length, type: 'csv', id: match[1] })
+	}
+	while ((match = mdPlaceholderPattern.exec(content)) !== null) {
+		allMatches.push({ index: match.index, length: match[0].length, type: 'md', id: match[1] })
 	}
 	while ((match = alertPlaceholderPattern.exec(content)) !== null) {
 		allMatches.push({ index: match.index, length: match[0].length, type: 'alert', id: match[1] })
@@ -123,6 +128,8 @@ export function parseArtifactPlaceholders(content: string): ParsedContent {
 			parts.push({ type: 'chart', chartId: m.id })
 		} else if (m.type === 'csv') {
 			parts.push({ type: 'csv', csvId: m.id })
+		} else if (m.type === 'md') {
+			parts.push({ type: 'md', mdId: m.id })
 		} else if (m.type === 'dashboard') {
 			parts.push({ type: 'dashboard', dashboardId: m.id })
 		} else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upload Markdown (.md) and plain-text (.txt) files alongside existing document types
  * AI-generated Markdown exports are surfaced in conversations with direct download links
  * Markdown exports persist and restore with sessions/shared links

* **Bug Fixes**
  * Clipboard copy now strips internal formatting/markers for cleaner pasted text
<!-- end of auto-generated comment: release notes by coderabbit.ai -->