### PR TITLE
Add TBD label and refactor styling on the unlocks chart

### DIFF
--- a/src/components/ECharts/MultiSeriesChart2/index.tsx
+++ b/src/components/ECharts/MultiSeriesChart2/index.tsx
@@ -64,6 +64,24 @@ function getZeroBaselineYAxisMin(extent: AxisExtent) {
 
 type GroupBy = NonNullable<IMultiSeriesChart2Props['groupBy']>
 
+function createHatchPattern(color: string, opacity: number): { image: HTMLCanvasElement; repeat: 'repeat' } | null {
+	if (typeof document === 'undefined') return null
+	const size = 8
+	const canvas = document.createElement('canvas')
+	canvas.width = size
+	canvas.height = size
+	const ctx = canvas.getContext('2d')
+	if (!ctx) return null
+	ctx.strokeStyle = color
+	ctx.globalAlpha = opacity
+	ctx.lineWidth = 1.5
+	ctx.beginPath()
+	ctx.moveTo(0, size)
+	ctx.lineTo(size, 0)
+	ctx.stroke()
+	return { image: canvas, repeat: 'repeat' }
+}
+
 function buildSeries({
 	effectiveCharts,
 	selectedCharts,
@@ -144,11 +162,21 @@ function buildSeries({
 		}
 
 		if (chart.isTBD) {
-			base.itemStyle = { ...base.itemStyle, opacity: 0.2 }
+			const hatch = createHatchPattern(resolvedColor, 0.4)
+			base.itemStyle = { ...base.itemStyle, opacity: 0.3 }
 			if (base.areaStyle) {
-				base.areaStyle = { ...base.areaStyle, opacity: 0.1 }
+				base.areaStyle = hatch ? { color: hatch, opacity: 0.6 } : { ...base.areaStyle, opacity: 0.1 }
 			}
-			base.lineStyle = { ...(base.lineStyle ?? {}), type: 'dashed', width: 1.5 }
+			base.lineStyle = { ...(base.lineStyle ?? {}), type: 'dashed', width: 1.5, opacity: 0.5 }
+
+			base.endLabel = {
+				show: true,
+				formatter: 'TBD',
+				fontSize: 16,
+				fontWeight: 'bold',
+				color: isThemeDark ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.3)',
+				offset: [-40, 10]
+			}
 		}
 
 		out.push(base)


### PR DESCRIPTION
Added a 'TBD' label and made some changes to the styling of TBD sections so it is clear that they're not confirmed unlocks

Examples:
<img width="1656" height="403" alt="Screenshot from 2026-04-11 20-51-18" src="https://github.com/user-attachments/assets/3e414764-3e71-409d-adce-d53b199a3758" />
<img width="1638" height="397" alt="Screenshot from 2026-04-11 20-47-23" src="https://github.com/user-attachments/assets/e6792d37-1048-4c89-bf96-85a444b1b3e0" />
<img width="1651" height="410" alt="Screenshot from 2026-04-11 20-47-14" src="https://github.com/user-attachments/assets/470d4bdd-4c33-4727-be09-decf7458f52a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced visual styling for "TBD" data series in charts with improved patterns, clearer line styling, and data labels for better visibility and distinction across all environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->