### PR TITLE
Add Funding Rate Arbitrage Scanner to tools

### DIFF
--- a/public/pages.json
+++ b/public/pages.json
@@ -898,6 +898,12 @@
       "route": "https://investors.defillama.com",
       "category": "Tools",
       "description": "Institutional-grade DeFi analytics and research tools for investors"
+    },
+    {
+      "name": "Funding Rate Arbitrage Scanner",
+      "route": "https://perpia.xyz",
+      "category": "Tools",
+      "description": "Cross-venue funding rate arbitrage scanner. 25+ CEX & DEX perps, net APR, backtester, Telegram alerts, position tracking."
     }
   ],
   "Main": [


### PR DESCRIPTION
## Summary

Adding [Funding Rate Arbitrage Scanner](https://perpia.xyz) to the Tools section.

**What it does:**
- Scans funding rate arbitrage opportunities across 25+ CEX & DEX perpetual markets
- Shows net APR after all fees (entry, exit, spread, slippage)
- Historical average APR (1d/3d/7d) to filter out temporary spikes
- Liquidity filters (volume, open interest, max notional)
- Backtester for historical strategy testing
- Telegram alerts for APR drops, spread monitoring, stop-loss
- Personal position cabinet with earnings tracking

**Why it fits in Tools:**
No similar funding rate arbitrage tool currently exists in the DefiLlama tools section. This fills a gap for DeFi traders looking to find and compare delta-neutral perpetuals opportunities across venues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Funding Rate Arbitrage Scanner tool to the platform navigation. This new feature enables users to identify and analyze cross-venue funding rate arbitrage opportunities across 25+ perpetual exchanges spanning both centralized and decentralized venues. The tool provides net APR calculations, backtesting capabilities, Telegram alerts for real-time notifications, and position tracking to optimize trading strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->