### PR TITLE
Add grouped mode for RWA perps time series

### DIFF
--- a/src/containers/RWA/Perps/Dashboard.test.tsx
+++ b/src/containers/RWA/Perps/Dashboard.test.tsx
@@ -276,18 +276,33 @@ describe('RWAPerpsDashboard treemap controls', () => {
 	})
 
 	it('renders the time-series metric switch labels from metric option names', () => {
+		routerQuery = { chartView: 'timeSeries' }
 		const html = renderToStaticMarkup(<RWAPerpsDashboard mode="overview" data={overviewData} />)
 
 		expect(html).toContain('Open Interest')
 		expect(html).toContain('Volume')
 		expect(html).toContain('Markets')
+		expect(html).toContain('Grouped')
+		expect(html).toContain('Base Asset')
+	})
+
+	it('renders the breakdown time-series mode label when selected', () => {
+		routerQuery = {
+			chartView: 'timeSeries',
+			timeSeriesMode: 'breakdown'
+		}
+
+		const html = renderToStaticMarkup(<RWAPerpsDashboard mode="overview" data={overviewData} />)
+
+		expect(html).toContain('Breakdown')
 	})
 
 	it('builds bar-series configs for time-series volume', () => {
 		expect(
 			buildRWAPerpsTimeSeriesCharts({
 				metric: 'volume24h',
-				dimensions: ['timestamp', 'Meta', 'NVIDIA']
+				dimensions: ['timestamp', 'Meta', 'NVIDIA'],
+				timeSeriesMode: 'breakdown'
 			})
 		).toMatchObject([
 			{ name: 'Meta', type: 'bar', stack: 'A' },
@@ -299,15 +314,34 @@ describe('RWAPerpsDashboard treemap controls', () => {
 		expect(
 			buildRWAPerpsTimeSeriesCharts({
 				metric: 'openInterest',
-				dimensions: ['timestamp', 'Meta']
+				dimensions: ['timestamp', 'Meta'],
+				timeSeriesMode: 'breakdown'
 			})
 		).toMatchObject([{ name: 'Meta', type: 'line', stack: 'A' }])
 		expect(
 			buildRWAPerpsTimeSeriesCharts({
 				metric: 'openInterest',
-				dimensions: ['timestamp', 'Meta']
+				dimensions: ['timestamp', 'Meta'],
+				timeSeriesMode: 'breakdown'
 			})[0]
 		).not.toHaveProperty('showSymbol')
+	})
+
+	it('builds a single non-stacked grouped time-series series', () => {
+		expect(
+			buildRWAPerpsTimeSeriesCharts({
+				metric: 'openInterest',
+				dimensions: ['timestamp', 'Total'],
+				timeSeriesMode: 'grouped'
+			})
+		).toEqual([
+			{
+				name: 'Total',
+				type: 'line',
+				encode: { x: 'timestamp', y: 'Total' },
+				color: expect.any(String)
+			}
+		])
 	})
 
 	it('renders 24h changes inline on the overview open interest and volume cards', () => {

--- a/src/containers/RWA/Perps/Dashboard.tsx
+++ b/src/containers/RWA/Perps/Dashboard.tsx
@@ -33,6 +33,8 @@ import {
 	getRWAPerpsChartBreakdownQueryValue,
 	getRWAPerpsChartMetricLabel,
 	getRWAPerpsChartMetricOptions,
+	getRWAPerpsTimeSeriesModeOptions,
+	getRWAPerpsTimeSeriesModeQueryValue,
 	getRWAPerpsChartMetricQueryValue,
 	getRWAPerpsTreemapNestedByLabel,
 	getRWAPerpsTreemapNestedByOptions,
@@ -41,6 +43,7 @@ import {
 	getRWAPerpsChartViewQueryValue,
 	parseRWAPerpsChartState,
 	setRWAPerpsChartBreakdown,
+	setRWAPerpsTimeSeriesMode,
 	setRWAPerpsTreemapNestedBy,
 	setRWAPerpsChartView
 } from './chartState'
@@ -48,6 +51,7 @@ import { perpsDefinitions as d } from './definitions'
 import {
 	buildRWAPerpsOverviewSnapshotBreakdownTotals,
 	buildRWAPerpsVenueSnapshotBreakdownTotals,
+	groupRWAPerpsTimeSeriesDataset,
 	hasEnoughTimeSeriesHistory
 } from './queries'
 import { buildRWAPerpsTreemapTreeData } from './treemap'
@@ -546,10 +550,12 @@ const venueColumnVisibility: VisibilityState = {
 
 export function buildRWAPerpsTimeSeriesCharts({
 	metric,
-	dimensions
+	dimensions,
+	timeSeriesMode
 }: {
 	metric: 'openInterest' | 'volume24h' | 'markets'
 	dimensions: string[]
+	timeSeriesMode: 'grouped' | 'breakdown'
 }): Array<MultiSeriesChart2SeriesConfig> {
 	const seriesKeys = dimensions.filter((dimension) => dimension !== 'timestamp')
 
@@ -558,7 +564,7 @@ export function buildRWAPerpsTimeSeriesCharts({
 		type: metric === 'volume24h' ? 'bar' : 'line',
 		encode: { x: 'timestamp', y: seriesName },
 		color: CHART_COLORS[index % CHART_COLORS.length],
-		stack: 'A'
+		...(timeSeriesMode === 'breakdown' ? { stack: 'A' } : {})
 	}))
 }
 
@@ -617,6 +623,7 @@ export function RWAPerpsDashboard(props: RWAPerpsDashboardProps) {
 	const chartMetricLabel = getRWAPerpsChartMetricLabel(chartState.metric, d)
 	const chartMetricOptions = getRWAPerpsChartMetricOptions(d)
 	const chartViewOptions = getRWAPerpsChartViewOptions()
+	const timeSeriesModeOptions = getRWAPerpsTimeSeriesModeOptions()
 	const chartBreakdownOptions = getRWAPerpsChartBreakdownOptions({ ...chartState, labels: d })
 	const showBreakdownSelect = chartBreakdownOptions.length > 1
 	const treemapBreakdown = chartState.breakdown as RWAPerpsOverviewTreemapBreakdown | RWAPerpsVenueTreemapBreakdown
@@ -662,19 +669,20 @@ export function RWAPerpsDashboard(props: RWAPerpsDashboardProps) {
 		enabled: chartState.view === 'timeSeries' && !shouldUseInitialTimeSeriesDataset
 	})
 
-	const selectedTimeSeriesDataset =
+	const rawTimeSeriesDataset =
 		chartState.view === 'timeSeries' && shouldUseInitialTimeSeriesDataset
 			? initialChartDataset
 			: (timeSeriesQuery.data ?? EMPTY_DATASET)
+	const selectedTimeSeriesDataset =
+		chartState.timeSeriesMode === 'grouped'
+			? groupRWAPerpsTimeSeriesDataset(rawTimeSeriesDataset)
+			: rawTimeSeriesDataset
 
-	const timeSeriesCharts = useMemo(
-		() =>
-			buildRWAPerpsTimeSeriesCharts({
-				metric: chartState.metric,
-				dimensions: selectedTimeSeriesDataset.dimensions
-			}),
-		[chartState.metric, selectedTimeSeriesDataset.dimensions]
-	)
+	const timeSeriesCharts = buildRWAPerpsTimeSeriesCharts({
+		metric: chartState.metric,
+		dimensions: selectedTimeSeriesDataset.dimensions,
+		timeSeriesMode: chartState.timeSeriesMode
+	})
 
 	const snapshotBreakdownRows = useMemo(
 		() =>
@@ -756,7 +764,7 @@ export function RWAPerpsDashboard(props: RWAPerpsDashboardProps) {
 	const treemapValueLabel = chartState.metric === 'volume24h' ? 'Daily Volume' : chartMetricLabel
 	const valueSymbol = chartState.metric === 'markets' ? '' : '$'
 	const pageLabel = props.mode === 'overview' ? 'RWA Perps' : `${props.data.venue} RWA Perps`
-	const timeSeriesFilename = `${props.mode === 'overview' ? 'rwa-perps-overview' : `rwa-perps-venue-${props.data.venue}`}-time-series-${chartState.metric}-${chartState.breakdown}`
+	const timeSeriesFilename = `${props.mode === 'overview' ? 'rwa-perps-overview' : `rwa-perps-venue-${props.data.venue}`}-time-series-${chartState.metric}-${chartState.breakdown}-${chartState.timeSeriesMode}`
 	const nonTimeSeriesFilename = `${props.mode === 'overview' ? 'rwa-perps-overview' : `rwa-perps-venue-${props.data.venue}`}-${chartState.view}-${chartState.metric}-${chartState.breakdown}`
 
 	const onSelectView = (value: string | string[]) => {
@@ -779,6 +787,14 @@ export function RWAPerpsDashboard(props: RWAPerpsDashboardProps) {
 				nextState.view === 'timeSeries' ? getRWAPerpsChartBreakdownQueryValue(nextState) : undefined,
 			nonTimeSeriesChartBreakdown:
 				nextState.view === 'timeSeries' ? undefined : getRWAPerpsChartBreakdownQueryValue(nextState)
+		})
+	}
+
+	const onSelectTimeSeriesMode = (value: string | string[]) => {
+		const selectedTimeSeriesMode = (Array.isArray(value) ? value[0] : value) as typeof chartState.timeSeriesMode
+		const nextState = setRWAPerpsTimeSeriesMode(chartState, selectedTimeSeriesMode)
+		void pushShallowQuery(router, {
+			timeSeriesMode: getRWAPerpsTimeSeriesModeQueryValue(nextState.timeSeriesMode)
 		})
 	}
 
@@ -899,6 +915,17 @@ export function RWAPerpsDashboard(props: RWAPerpsDashboardProps) {
 								variant="filter"
 							/>
 						) : null}
+						<Select
+							allValues={timeSeriesModeOptions}
+							selectedValues={chartState.timeSeriesMode}
+							setSelectedValues={onSelectTimeSeriesMode}
+							label={
+								timeSeriesModeOptions.find((option) => option.key === chartState.timeSeriesMode)?.name ??
+								timeSeriesModeOptions[0].name
+							}
+							labelType="none"
+							variant="filter"
+						/>
 						<ChartExportButtons
 							chartInstance={timeSeriesChartInstance}
 							filename={timeSeriesFilename}

--- a/src/containers/RWA/Perps/chartState.test.ts
+++ b/src/containers/RWA/Perps/chartState.test.ts
@@ -3,6 +3,8 @@ import {
 	getDefaultRWAPerpsChartBreakdown,
 	getRWAPerpsChartBreakdownOptions,
 	getRWAPerpsChartMetricOptions,
+	getRWAPerpsTimeSeriesModeOptions,
+	getRWAPerpsTimeSeriesModeQueryValue,
 	getRWAPerpsTreemapNestedByOptions,
 	parseRWAPerpsChartState,
 	setRWAPerpsChartView
@@ -31,11 +33,13 @@ describe('parseRWAPerpsChartState', () => {
 		expect(overviewState).toMatchObject({
 			view: 'treemap',
 			breakdown: 'assetGroup',
+			timeSeriesMode: 'grouped',
 			treemapNestedBy: 'baseAsset'
 		})
 		expect(venueState).toMatchObject({
 			view: 'treemap',
 			breakdown: 'assetGroup',
+			timeSeriesMode: 'grouped',
 			treemapNestedBy: 'baseAsset'
 		})
 	})
@@ -93,6 +97,18 @@ describe('parseRWAPerpsChartState', () => {
 			treemapNestedBy: 'contract'
 		})
 	})
+
+	it('parses a valid time-series mode query', () => {
+		const state = parseRWAPerpsChartState(
+			{
+				chartView: 'timeSeries',
+				timeSeriesMode: 'breakdown'
+			},
+			'overview'
+		)
+
+		expect(state.timeSeriesMode).toBe('breakdown')
+	})
 })
 
 describe('perps chartState options', () => {
@@ -111,6 +127,18 @@ describe('perps chartState options', () => {
 			{ key: 'volume24h', name: 'Volume' },
 			{ key: 'markets', name: 'Markets' }
 		])
+	})
+
+	it('exposes grouped and breakdown time-series mode options', () => {
+		expect(getRWAPerpsTimeSeriesModeOptions()).toEqual([
+			{ key: 'grouped', name: 'Grouped' },
+			{ key: 'breakdown', name: 'Breakdown' }
+		])
+	})
+
+	it('omits the default grouped time-series mode from the query', () => {
+		expect(getRWAPerpsTimeSeriesModeQueryValue('grouped')).toBeUndefined()
+		expect(getRWAPerpsTimeSeriesModeQueryValue('breakdown')).toBe('breakdown')
 	})
 
 	it('exposes the intended overview grouping matrix', () => {
@@ -231,6 +259,7 @@ describe('perps chartState options', () => {
 				view: 'pie',
 				metric: 'openInterest',
 				breakdown: 'assetClass',
+				timeSeriesMode: 'grouped',
 				treemapNestedBy: 'baseAsset'
 			},
 			'treemap'

--- a/src/containers/RWA/Perps/chartState.ts
+++ b/src/containers/RWA/Perps/chartState.ts
@@ -7,6 +7,7 @@ import type {
 	RWAPerpsOverviewNonTimeSeriesBreakdown,
 	RWAPerpsOverviewTimeSeriesBreakdown,
 	RWAPerpsOverviewTreemapBreakdown,
+	RWAPerpsTimeSeriesMode,
 	RWAPerpsTreemapNestedBy,
 	RWAPerpsVenueNonTimeSeriesBreakdown,
 	RWAPerpsVenueTimeSeriesBreakdown,
@@ -28,6 +29,7 @@ export type RWAPerpsChartState = {
 	view: RWAPerpsChartView
 	metric: RWAPerpsChartMetricKey
 	breakdown: RWAPerpsChartBreakdown
+	timeSeriesMode: RWAPerpsTimeSeriesMode
 	treemapNestedBy: RWAPerpsTreemapNestedBy
 }
 
@@ -51,6 +53,11 @@ const CHART_VIEW_OPTIONS: ReadonlyArray<RWAPerpsChartOption<RWAPerpsChartView>> 
 	{ key: 'pie', name: 'Pie Chart' },
 	{ key: 'treemap', name: 'Treemap Chart' },
 	{ key: 'hbar', name: 'HBar Chart' }
+]
+
+const TIME_SERIES_MODE_OPTIONS: ReadonlyArray<RWAPerpsChartOption<RWAPerpsTimeSeriesMode>> = [
+	{ key: 'grouped', name: 'Grouped' },
+	{ key: 'breakdown', name: 'Breakdown' }
 ]
 
 const CHART_METRIC_KEYS: ReadonlyArray<RWAPerpsChartMetricKey> = ['openInterest', 'volume24h', 'markets']
@@ -110,8 +117,10 @@ const DEFAULT_TREEMAP_NESTED_BY: Record<
 
 export const DEFAULT_CHART_VIEW: RWAPerpsChartView = 'treemap'
 const DEFAULT_CHART_METRIC: RWAPerpsChartMetricKey = 'openInterest'
+const DEFAULT_TIME_SERIES_MODE: RWAPerpsTimeSeriesMode = 'grouped'
 const VALID_CHART_VIEWS = new Set<RWAPerpsChartView>(CHART_VIEW_OPTIONS.map((option) => option.key))
 const VALID_CHART_METRICS = new Set<RWAPerpsChartMetricKey>(CHART_METRIC_KEYS)
+const VALID_TIME_SERIES_MODES = new Set<RWAPerpsTimeSeriesMode>(TIME_SERIES_MODE_OPTIONS.map((option) => option.key))
 
 function assert(condition: unknown, message: string): asserts condition {
 	if (!condition) {
@@ -121,6 +130,10 @@ function assert(condition: unknown, message: string): asserts condition {
 
 export function getRWAPerpsChartViewOptions() {
 	return CHART_VIEW_OPTIONS
+}
+
+export function getRWAPerpsTimeSeriesModeOptions() {
+	return TIME_SERIES_MODE_OPTIONS
 }
 
 export function getRWAPerpsChartMetricOptions(labels: RWAPerpsChartLabels) {
@@ -208,13 +221,14 @@ export function parseRWAPerpsChartState(query: ParsedUrlQuery, mode: RWAPerpsCha
 	const view = normalizeChartView(readSingleQueryValue(query.chartView))
 	const metric = normalizeChartMetric(readSingleQueryValue(query.chartType))
 	const breakdown = normalizeBreakdown(mode, view, readSingleQueryValue(query[getBreakdownQueryKey(view)]))
+	const timeSeriesMode = normalizeTimeSeriesMode(readSingleQueryValue(query.timeSeriesMode))
 	const treemapNestedBy = normalizeTreemapNestedBy(
 		mode,
 		view === 'treemap' ? (breakdown as RWAPerpsTreemapBreakdown) : getDefaultRWAPerpsChartBreakdown(mode, 'treemap'),
 		readSingleQueryValue(query.treemapNestedBy)
 	)
 
-	return { mode, view, metric, breakdown, treemapNestedBy }
+	return { mode, view, metric, breakdown, timeSeriesMode, treemapNestedBy }
 }
 
 export function setRWAPerpsChartView(state: RWAPerpsChartState, view: RWAPerpsChartView): RWAPerpsChartState {
@@ -263,12 +277,23 @@ export function setRWAPerpsTreemapNestedBy(
 	return { ...state, treemapNestedBy: nestedBy }
 }
 
+export function setRWAPerpsTimeSeriesMode(
+	state: RWAPerpsChartState,
+	timeSeriesMode: RWAPerpsTimeSeriesMode
+): RWAPerpsChartState {
+	return { ...state, timeSeriesMode }
+}
+
 export function getRWAPerpsChartViewQueryValue(view: RWAPerpsChartView) {
 	return view === DEFAULT_CHART_VIEW ? undefined : view
 }
 
 export function getRWAPerpsChartMetricQueryValue(metric: RWAPerpsChartMetricKey) {
 	return metric === DEFAULT_CHART_METRIC ? undefined : metric
+}
+
+export function getRWAPerpsTimeSeriesModeQueryValue(timeSeriesMode: RWAPerpsTimeSeriesMode) {
+	return timeSeriesMode === DEFAULT_TIME_SERIES_MODE ? undefined : timeSeriesMode
 }
 
 export function getRWAPerpsChartBreakdownQueryValue(state: RWAPerpsChartState) {
@@ -305,6 +330,14 @@ function normalizeChartView(value: string | undefined): RWAPerpsChartView {
 function normalizeChartMetric(value: string | undefined): RWAPerpsChartMetricKey {
 	if (value && VALID_CHART_METRICS.has(value as RWAPerpsChartMetricKey)) return value as RWAPerpsChartMetricKey
 	return DEFAULT_CHART_METRIC
+}
+
+function normalizeTimeSeriesMode(value: string | undefined): RWAPerpsTimeSeriesMode {
+	if (value && VALID_TIME_SERIES_MODES.has(value as RWAPerpsTimeSeriesMode)) {
+		return value as RWAPerpsTimeSeriesMode
+	}
+
+	return DEFAULT_TIME_SERIES_MODE
 }
 
 function normalizeBreakdown(

--- a/src/containers/RWA/Perps/queries.test.ts
+++ b/src/containers/RWA/Perps/queries.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
 	buildRWAPerpsOverviewSnapshotBreakdownTotals,
 	buildRWAPerpsVenueSnapshotBreakdownTotals,
+	groupRWAPerpsTimeSeriesDataset,
 	hasEnoughTimeSeriesHistory,
 	getRWAPerpsBreakdownChartDataset,
 	getRWAPerpsContractData,
@@ -740,6 +741,24 @@ describe('perps overview helpers', () => {
 				key: 'openInterest'
 			}).dimensions
 		).toEqual(['timestamp', 'alpha', 'beta', 'gamma'])
+	})
+
+	it('groups multi-series datasets into a single total series', () => {
+		expect(
+			groupRWAPerpsTimeSeriesDataset({
+				source: [
+					{ timestamp: 1774569600000, Meta: 80, NVIDIA: 20, ignored: null },
+					{ timestamp: 1774483200000, Meta: 100, NVIDIA: '5', Gold: undefined }
+				],
+				dimensions: ['timestamp', 'Meta', 'NVIDIA', 'Gold']
+			})
+		).toEqual({
+			source: [
+				{ timestamp: 1774483200000, Total: 105 },
+				{ timestamp: 1774569600000, Total: 100 }
+			],
+			dimensions: ['timestamp', 'Total']
+		})
 	})
 })
 

--- a/src/containers/RWA/Perps/queries.ts
+++ b/src/containers/RWA/Perps/queries.ts
@@ -215,6 +215,25 @@ export function hasEnoughTimeSeriesHistory(dataset: MultiSeriesChart2Dataset) {
 	return uniqueTimestamps.size >= 2 && dataset.dimensions.some((dimension) => dimension !== 'timestamp')
 }
 
+export function groupRWAPerpsTimeSeriesDataset(dataset: MultiSeriesChart2Dataset): MultiSeriesChart2Dataset {
+	const seriesDimensions = dataset.dimensions.filter((dimension) => dimension !== 'timestamp')
+	if (dataset.source.length === 0 || seriesDimensions.length === 0) return EMPTY_CHART_DATASET
+
+	return {
+		source: ensureChronologicalRows(
+			dataset.source.map((row) => ({
+				timestamp: row.timestamp,
+				Total: seriesDimensions.reduce((sum, dimension) => {
+					const value = row[dimension]
+					const numericValue = typeof value === 'number' ? value : Number(value)
+					return Number.isFinite(numericValue) ? sum + numericValue : sum
+				}, 0)
+			}))
+		),
+		dimensions: ['timestamp', 'Total']
+	}
+}
+
 function assertHasVenueBuckets(stats: IRWAPerpsStatsResponse | null): asserts stats is IRWAPerpsStatsResponse {
 	if (!stats?.byVenue || Object.keys(stats.byVenue).length === 0) {
 		throw new Error('Failed to get RWA perps venue stats')

--- a/src/containers/RWA/Perps/types.ts
+++ b/src/containers/RWA/Perps/types.ts
@@ -44,6 +44,7 @@ export type IRWAPerpsTimeSeriesRow = IRWAPerpsMarket | IRWAPerpsAggregateHistori
 
 export type RWAPerpsChartMetricKey = 'openInterest' | 'volume24h' | 'markets'
 export type RWAPerpsChartView = 'timeSeries' | 'pie' | 'treemap' | 'hbar'
+export type RWAPerpsTimeSeriesMode = 'grouped' | 'breakdown'
 export type RWAPerpsTreemapNestedBy = 'none' | 'venue' | 'assetClass' | 'baseAsset' | 'contract'
 
 export type RWAPerpsOverviewBreakdown = 'venue' | 'assetClass' | 'baseAsset' | 'contract'


### PR DESCRIPTION
## Summary
- add a grouped vs breakdown time-series mode for RWA perps overview and venue pages
- persist the new time-series mode in the URL and keep the existing breakdown selector alongside it
- group multi-series chart datasets client-side into a single Total series without changing the API surface

## Why
- make grouped time-series charts the default while preserving the existing breakdown view as an explicit option

## Testing
- bun run test -- src/containers/RWA/Perps/chartState.test.ts src/containers/RWA/Perps/Dashboard.test.tsx src/containers/RWA/Perps/queries.test.ts
- bun run format
- bun run lint
- bun run ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a time-series mode selector for the RWA Perps Dashboard, allowing users to toggle between "Grouped" and "Breakdown" views.
  * In Grouped mode, all data is aggregated into a single Total series.
  * In Breakdown mode, individual dimensions are displayed as stacked series.
  * Selected mode is preserved in the URL and reflected in exported filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->