### PR TITLE
Route client chart fetches through API endpoints

### DIFF
--- a/src/containers/Bridges/queries.client.tsx
+++ b/src/containers/Bridges/queries.client.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { getBridgeOverviewPageData } from './queries.server'
+import { fetchJson } from '~/utils/async'
 
 export const useGetBridgeChartDataByChain = (chain?: string) => {
 	return useQuery({
@@ -7,21 +7,12 @@ export const useGetBridgeChartDataByChain = (chain?: string) => {
 		queryFn:
 			chain && chain !== 'All'
 				? () =>
-						getBridgeOverviewPageData(chain)
-							.catch(() => null)
-							.then((data) =>
-								data
-									? data?.chainVolumeData?.map((volume) => [
-											volume?.date ?? null,
-											volume?.Deposits ?? null,
-											volume.Withdrawals ?? null
-										])
-									: null
-							)
-							.catch((err) => {
-								console.log(err)
-								return null
-							})
+						fetchJson<Array<[number | null, number | null, number | null]> | null>(
+							`/api/charts/chain?kind=net-inflows&chain=${encodeURIComponent(chain)}`
+						).catch((err) => {
+							console.log(err)
+							return null
+						})
 				: () => null,
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,

--- a/src/containers/ChainOverview/useFetchChainChartData.tsx
+++ b/src/containers/ChainOverview/useFetchChainChartData.tsx
@@ -3,15 +3,10 @@ import dayjs from 'dayjs'
 import { useMemo, useState } from 'react'
 import type { ChartTimeGroupingWithCumulative } from '~/components/ECharts/types'
 import { formatBarChart, formatLineChart } from '~/components/ECharts/utils'
-import { CACHE_SERVER } from '~/constants'
-import { fetchChainAssetsChart } from '~/containers/BridgedTVL/api'
 import { useGetBridgeChartDataByChain } from '~/containers/Bridges/queries.client'
-import { fetchAdapterChainChartData, fetchAdapterProtocolChartData } from '~/containers/DimensionAdapters/api'
-import { fetchRaises } from '~/containers/Raises/api'
 import { useGetStabelcoinsChartDataByChain } from '~/containers/Stablecoins/queries.client'
-import { getProtocolUnlockUsdChart } from '~/containers/Unlocks/queries'
 import { TVL_SETTINGS_KEYS } from '~/contexts/LocalStorage'
-import { getPercentChange, slug } from '~/utils'
+import { getPercentChange } from '~/utils'
 import { fetchJson } from '~/utils/async'
 import type { ChainChartLabels } from './constants'
 
@@ -59,6 +54,16 @@ const normalizeActivityChart = (values: Array<[number, number]> | null): Array<[
 	values && values.length > 0
 		? values.map(([date, value]): [number, number] => [date * 1e3, +value]).sort((a, b) => a[0] - b[0])
 		: null
+
+const buildChainChartApiUrl = (params: Record<string, string | undefined>) => {
+	const searchParams = new URLSearchParams()
+	for (const [key, value] of Object.entries(params)) {
+		if (value != null) {
+			searchParams.set(key, value)
+		}
+	}
+	return `/api/charts/chain?${searchParams.toString()}`
+}
 
 export const useFetchChainChartData = ({
 	denomination,
@@ -110,7 +115,7 @@ export const useFetchChainChartData = ({
 	}>({
 		queryKey: ['chain-overview', 'price-history', denominationGeckoId],
 		queryFn: () =>
-			fetchJson(`${CACHE_SERVER}/cgchart/${denominationGeckoId}?fullChart=true`).then((res) => {
+			fetchJson(`/api/charts/coingecko/${encodeURIComponent(denominationGeckoId!)}?fullChart=true`).then((res) => {
 				if (!res.data?.prices?.length) return null
 
 				const store = {}
@@ -130,10 +135,7 @@ export const useFetchChainChartData = ({
 	const { data: chainFeesDataChart = null, isLoading: fetchingChainFees } = useQuery<Array<[number, number]>>({
 		queryKey: ['chain-overview', 'chain-fees', selectedChain],
 		queryFn: () =>
-			fetchAdapterProtocolChartData({
-				adapterType: 'fees',
-				protocol: selectedChain
-			}),
+			fetchJson(buildChainChartApiUrl({ kind: 'adapter-protocol', adapterType: 'fees', protocol: selectedChain })),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,
@@ -144,11 +146,14 @@ export const useFetchChainChartData = ({
 	const { data: chainRevenueDataChart = null, isLoading: fetchingChainRevenue } = useQuery<Array<[number, number]>>({
 		queryKey: ['chain-overview', 'chain-revenue', selectedChain],
 		queryFn: () =>
-			fetchAdapterProtocolChartData({
-				adapterType: 'fees',
-				protocol: selectedChain,
-				dataType: 'dailyRevenue'
-			}),
+			fetchJson(
+				buildChainChartApiUrl({
+					kind: 'adapter-protocol',
+					adapterType: 'fees',
+					protocol: selectedChain,
+					dataType: 'dailyRevenue'
+				})
+			),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,
@@ -159,10 +164,7 @@ export const useFetchChainChartData = ({
 	const { data: dexVolumeDataChart = null, isLoading: fetchingDexVolume } = useQuery<Array<[number, number]>>({
 		queryKey: ['chain-overview', 'dex-volume', selectedChain],
 		queryFn: () =>
-			fetchAdapterChainChartData({
-				chain: selectedChain,
-				adapterType: 'dexs'
-			}),
+			fetchJson(buildChainChartApiUrl({ kind: 'adapter-chain', chain: selectedChain, adapterType: 'dexs' })),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,
@@ -173,10 +175,7 @@ export const useFetchChainChartData = ({
 	const { data: perpsVolumeDataChart = null, isLoading: fetchingPerpVolume } = useQuery<Array<[number, number]>>({
 		queryKey: ['chain-overview', 'perp-volume', selectedChain],
 		queryFn: () =>
-			fetchAdapterChainChartData({
-				chain: selectedChain,
-				adapterType: 'derivatives'
-			}),
+			fetchJson(buildChainChartApiUrl({ kind: 'adapter-chain', chain: selectedChain, adapterType: 'derivatives' })),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,
@@ -187,11 +186,14 @@ export const useFetchChainChartData = ({
 	const { data: chainAppFeesDataChart = null, isLoading: fetchingChainAppFees } = useQuery<Array<[number, number]>>({
 		queryKey: ['chain-overview', 'app-fees', selectedChain],
 		queryFn: () =>
-			fetchAdapterChainChartData({
-				adapterType: 'fees',
-				chain: selectedChain,
-				dataType: 'dailyAppFees'
-			}),
+			fetchJson(
+				buildChainChartApiUrl({
+					kind: 'adapter-chain',
+					adapterType: 'fees',
+					chain: selectedChain,
+					dataType: 'dailyAppFees'
+				})
+			),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,
@@ -204,11 +206,14 @@ export const useFetchChainChartData = ({
 	>({
 		queryKey: ['chain-overview', 'app-revenue', selectedChain],
 		queryFn: () =>
-			fetchAdapterChainChartData({
-				adapterType: 'fees',
-				chain: selectedChain,
-				dataType: 'dailyAppRevenue'
-			}),
+			fetchJson(
+				buildChainChartApiUrl({
+					kind: 'adapter-chain',
+					adapterType: 'fees',
+					chain: selectedChain,
+					dataType: 'dailyAppRevenue'
+				})
+			),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,
@@ -228,10 +233,13 @@ export const useFetchChainChartData = ({
 	> | null>({
 		queryKey: ['chain-overview', 'active-addresses', selectedChain],
 		queryFn: () =>
-			fetchAdapterChainChartData({
-				adapterType: 'active-users',
-				chain: selectedChain
-			})
+			fetchJson<Array<[number, number]>>(
+				buildChainChartApiUrl({
+					kind: 'adapter-chain',
+					adapterType: 'active-users',
+					chain: selectedChain
+				})
+			)
 				.then((values) => normalizeActivityChart(values))
 				.catch(() => null),
 		staleTime: 60 * 60 * 1000,
@@ -243,10 +251,13 @@ export const useFetchChainChartData = ({
 	const { data: newAddressesData = null, isLoading: fetchingNewAddresses } = useQuery<Array<[number, number]> | null>({
 		queryKey: ['chain-overview', 'new-addresses', selectedChain],
 		queryFn: () =>
-			fetchAdapterChainChartData({
-				adapterType: 'new-users',
-				chain: selectedChain
-			})
+			fetchJson<Array<[number, number]>>(
+				buildChainChartApiUrl({
+					kind: 'adapter-chain',
+					adapterType: 'new-users',
+					chain: selectedChain
+				})
+			)
 				.then((values) => normalizeActivityChart(values))
 				.catch(() => null),
 		staleTime: 60 * 60 * 1000,
@@ -258,11 +269,14 @@ export const useFetchChainChartData = ({
 	const { data: transactionsData = null, isLoading: fetchingTransactions } = useQuery<Array<[number, number]> | null>({
 		queryKey: ['chain-overview', 'transactions', selectedChain],
 		queryFn: () =>
-			fetchAdapterChainChartData({
-				adapterType: 'active-users',
-				chain: selectedChain,
-				dataType: 'dailyTransactionsCount'
-			})
+			fetchJson<Array<[number, number]>>(
+				buildChainChartApiUrl({
+					kind: 'adapter-chain',
+					adapterType: 'active-users',
+					chain: selectedChain,
+					dataType: 'dailyTransactionsCount'
+				})
+			)
 				.then((values) => normalizeActivityChart(values))
 				.catch(() => null),
 		staleTime: 60 * 60 * 1000,
@@ -274,11 +288,14 @@ export const useFetchChainChartData = ({
 	const { data: gasUsedData = null, isLoading: fetchingGasUsed } = useQuery<Array<[number, number]> | null>({
 		queryKey: ['chain-overview', 'gas-used', selectedChain],
 		queryFn: () =>
-			fetchAdapterChainChartData({
-				adapterType: 'active-users',
-				chain: selectedChain,
-				dataType: 'dailyGasUsed'
-			})
+			fetchJson<Array<[number, number]>>(
+				buildChainChartApiUrl({
+					kind: 'adapter-chain',
+					adapterType: 'active-users',
+					chain: selectedChain,
+					dataType: 'dailyGasUsed'
+				})
+			)
 				.then((values) => normalizeActivityChart(values))
 				.catch(() => null),
 		staleTime: 60 * 60 * 1000,
@@ -290,7 +307,9 @@ export const useFetchChainChartData = ({
 	const isBridgedTvlEnabled = toggledChartsSet.has('Bridged TVL')
 	const { data: bridgedTvlData = null, isLoading: fetchingBridgedTvlData } = useQuery({
 		queryKey: ['chain-overview', 'bridged-tvl', selectedChain],
-		queryFn: isBridgedTvlEnabled ? () => fetchChainAssetsChart(selectedChain) : () => null,
+		queryFn: isBridgedTvlEnabled
+			? () => fetchJson(buildChainChartApiUrl({ kind: 'bridged-tvl', chain: selectedChain }))
+			: () => null,
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,
@@ -300,21 +319,7 @@ export const useFetchChainChartData = ({
 	const isRaisesEnabled = toggledChartsSet.has('Raises')
 	const { data: raisesData = null, isLoading: fetchingRaises } = useQuery<Array<[number, number]>>({
 		queryKey: ['chain-overview', 'raises'],
-		queryFn: () =>
-			fetchRaises().then((data) => {
-				const store = (data?.raises ?? []).reduce(
-					(acc, curr) => {
-						acc[curr.date] = (acc[curr.date] ?? 0) + +(curr.amount ?? 0)
-						return acc
-					},
-					{} as Record<string, number>
-				)
-				const chart = []
-				for (const date in store) {
-					chart.push([+date * 1e3, store[date] * 1e6])
-				}
-				return chart
-			}),
+		queryFn: () => fetchJson(buildChainChartApiUrl({ kind: 'raises' })),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,
@@ -325,13 +330,7 @@ export const useFetchChainChartData = ({
 	const { data: chainIncentivesData = null, isLoading: fetchingChainIncentives } = useQuery({
 		queryKey: ['chain-overview', 'token-incentives', selectedChain],
 		queryFn: () =>
-			getProtocolUnlockUsdChart(slug(selectedChain))
-				.then((chart) => {
-					if (!chart) return null
-					const nonZeroIndex = chart.findIndex(([_, value]) => value > 0)
-					return chart.slice(nonZeroIndex)
-				})
-				.catch(() => null),
+			fetchJson(buildChainChartApiUrl({ kind: 'token-incentives', protocol: selectedChain })).catch(() => null),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,

--- a/src/containers/Downloads/MultiMetricModal.tsx
+++ b/src/containers/Downloads/MultiMetricModal.tsx
@@ -44,11 +44,7 @@ interface MultiMetricModalProps {
 	isPreview: boolean
 }
 
-function resolveDatasetValue(
-	paramValue: string,
-	paramType: ParamType,
-	datasetOptions: ParamOption[]
-): string | null {
+function resolveDatasetValue(paramValue: string, paramType: ParamType, datasetOptions: ParamOption[]): string | null {
 	if (paramType === 'protocol') {
 		// All protocol datasets share the toSlug(p.name) convention.
 		return datasetOptions.find((o) => o.value === paramValue)?.value ?? null
@@ -85,26 +81,15 @@ function metricDisplayName(dataset: ChartDatasetDefinition): string {
 	return dataset.name.replace(/^Protocol\s+/i, '')
 }
 
-export function MultiMetricModal({
-	chartOptionsMap,
-	authorizedFetch,
-	onClose,
-	isPreview
-}: MultiMetricModalProps) {
+export function MultiMetricModal({ chartOptionsMap, authorizedFetch, onClose, isPreview }: MultiMetricModalProps) {
 	const subscribeModalStore = Ariakit.useDialogStore()
 	const [paramType, setParamType] = useState<ParamType>('protocol')
 	const [param, setParam] = useState<ParamOption | null>(null)
 	const [selectedMetrics, setSelectedMetrics] = useState<string[]>([])
 	const [activeMetric, setActiveMetric] = useState<string | null>(null)
 
-	const protocolOptions = useMemo<ParamOption[]>(
-		() => chartOptionsMap['protocol-tvl-chart'] ?? [],
-		[chartOptionsMap]
-	)
-	const chainOptions = useMemo<ParamOption[]>(
-		() => chartOptionsMap['chain-tvl-chart'] ?? [],
-		[chartOptionsMap]
-	)
+	const protocolOptions = useMemo<ParamOption[]>(() => chartOptionsMap['protocol-tvl-chart'] ?? [], [chartOptionsMap])
+	const chainOptions = useMemo<ParamOption[]>(() => chartOptionsMap['chain-tvl-chart'] ?? [], [chartOptionsMap])
 	const paramOptions = paramType === 'protocol' ? protocolOptions : chainOptions
 
 	const availableMetrics = useMemo(() => {
@@ -168,7 +153,7 @@ export function MultiMetricModal({
 	const activeCsvText = (activeQuery?.data as string | undefined) ?? undefined
 	const activeLoading = !!activeQuery?.isLoading
 	const activeError = activeQuery?.error
-	const activeDataset = activeMetric ? chartDatasetsBySlug.get(activeMetric) ?? null : null
+	const activeDataset = activeMetric ? (chartDatasetsBySlug.get(activeMetric) ?? null) : null
 
 	const parsedActive = useMemo(() => (activeCsvText ? parseCsv(activeCsvText) : null), [activeCsvText])
 
@@ -287,13 +272,11 @@ export function MultiMetricModal({
 	const isBulk = selectedMetrics.length > 1
 	const hasSelection = selectedMetrics.length > 0
 	const downloadLabel = isBulk ? 'Download combined' : 'Download CSV'
-	const topBarDownloadDisabled = !isPreview && (
-		!param ||
-		!hasSelection ||
-		(isBulk
-			? loadingCount === selectedMetrics.length || readyCount === 0
-			: activeLoading || !activeCsvText)
-	)
+	const topBarDownloadDisabled =
+		!isPreview &&
+		(!param ||
+			!hasSelection ||
+			(isBulk ? loadingCount === selectedMetrics.length || readyCount === 0 : activeLoading || !activeCsvText))
 
 	const headerSubtitle = (() => {
 		if (!param) return `${PARAM_LABELS[paramType].verb} to begin`
@@ -315,10 +298,7 @@ export function MultiMetricModal({
 		return ''
 	})()
 
-	const suggestions = useMemo(
-		() => paramOptions.slice(0, SUGGESTED_COUNT),
-		[paramOptions]
-	)
+	const suggestions = useMemo(() => paramOptions.slice(0, SUGGESTED_COUNT), [paramOptions])
 
 	return (
 		<>
@@ -338,9 +318,7 @@ export function MultiMetricModal({
 						<div className="flex items-center gap-3 px-4 py-2.5">
 							<div className="mr-auto min-w-0">
 								<div className="flex items-center gap-2">
-									<h2 className="truncate text-base font-semibold">
-										{param ? param.label : 'Combined report'}
-									</h2>
+									<h2 className="truncate text-base font-semibold">{param ? param.label : 'Combined report'}</h2>
 									<span className="rounded-full bg-(--primary)/15 px-2 py-0.5 text-[10px] font-semibold tracking-wide text-(--primary) uppercase">
 										Combined
 									</span>
@@ -391,9 +369,7 @@ export function MultiMetricModal({
 								/>
 							) : null}
 
-							{isPreview ? (
-								<p className="ml-auto text-[11px] text-(--text-tertiary)">Preview — last 10 rows</p>
-							) : null}
+							{isPreview ? <p className="ml-auto text-[11px] text-(--text-tertiary)">Preview — last 10 rows</p> : null}
 						</div>
 					</div>
 
@@ -428,11 +404,9 @@ export function MultiMetricModal({
 
 						{param && hasSelection ? (
 							<MetricsSidebar
-								selectedMetrics={
-									selectedMetrics
-										.map((slug) => chartDatasetsBySlug.get(slug))
-										.filter((d): d is ChartDatasetDefinition => !!d)
-								}
+								selectedMetrics={selectedMetrics
+									.map((slug) => chartDatasetsBySlug.get(slug))
+									.filter((d): d is ChartDatasetDefinition => !!d)}
 								csvQueries={csvQueries as ReadonlyArray<CsvQueryStatus>}
 								activeMetric={activeMetric}
 								onSetActive={handleSetActive}
@@ -520,9 +494,7 @@ function ParamPickerEmpty({
 					<Icon name="layers" className="h-5 w-5 text-(--primary)" />
 				</div>
 				<div className="flex flex-col gap-1">
-					<p className="text-base font-medium text-(--text-primary)">
-						Choose a {labels.singular} to begin
-					</p>
+					<p className="text-base font-medium text-(--text-primary)">Choose a {labels.singular} to begin</p>
 					<p className="text-xs text-(--text-tertiary)">
 						Pick a {labels.singular} — we&rsquo;ll show its available metrics so you can combine them.
 					</p>
@@ -532,7 +504,7 @@ function ParamPickerEmpty({
 
 				<div className="w-full">
 					<Ariakit.PopoverProvider store={popoverStore}>
-						<Ariakit.PopoverDisclosure className="group flex w-full items-center justify-between gap-3 rounded-lg border border-(--form-control-border) bg-(--bg-primary) px-3.5 py-2.5 text-sm transition-colors hover:border-(--primary)/50 focus:border-(--primary) focus:outline-none focus:ring-2 focus:ring-(--primary)/20">
+						<Ariakit.PopoverDisclosure className="group flex w-full items-center justify-between gap-3 rounded-lg border border-(--form-control-border) bg-(--bg-primary) px-3.5 py-2.5 text-sm transition-colors hover:border-(--primary)/50 focus:border-(--primary) focus:ring-2 focus:ring-(--primary)/20 focus:outline-none">
 							<span className="flex items-center gap-2 text-(--text-tertiary)">
 								<Icon name="search" className="h-4 w-4" />
 								Search a {labels.singular}
@@ -688,7 +660,7 @@ function PreviewTable({ parsed }: { parsed: { headers: string[]; rows: ParsedCsv
 	const { headers, rows } = parsed
 	const display = rows.slice(0, PREVIEW_ROWS)
 	return (
-		<div className="thin-scrollbar relative min-h-0 flex-1 overflow-auto">
+		<div className="relative thin-scrollbar min-h-0 flex-1 overflow-auto">
 			<table className="w-full text-xs">
 				<thead className="sticky top-0 z-10 bg-(--cards-bg)">
 					<tr>
@@ -713,9 +685,7 @@ function PreviewTable({ parsed }: { parsed: { headers: string[]; rows: ParsedCsv
 							{headers.map((_, i) => (
 								<td
 									key={i}
-									className={`px-3 py-1.5 whitespace-nowrap text-(--text-primary) ${
-										i === 0 ? '' : 'tabular-nums'
-									}`}
+									className={`px-3 py-1.5 whitespace-nowrap text-(--text-primary) ${i === 0 ? '' : 'tabular-nums'}`}
 								>
 									{row.values[i] ?? ''}
 								</td>
@@ -767,9 +737,7 @@ function MetricsSidebar({
 		<aside className="hidden w-72 shrink-0 flex-col border-l border-(--divider) bg-(--bg-primary) sm:flex">
 			<div className="flex items-center justify-between gap-2 border-b border-(--divider) px-3 py-2">
 				<div className="min-w-0">
-					<p className="text-xs font-semibold text-(--text-primary)">
-						Selected metrics ({selectedMetrics.length})
-					</p>
+					<p className="text-xs font-semibold text-(--text-primary)">Selected metrics ({selectedMetrics.length})</p>
 					{loadingCount > 0 ? (
 						<p className="text-[10px] text-(--text-tertiary)">
 							Ready {readyCount}/{selectedMetrics.length}
@@ -906,9 +874,7 @@ function ParamPickerPopover({
 		<Ariakit.PopoverProvider store={popoverStore}>
 			<Ariakit.PopoverDisclosure
 				className={`flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-(--link-hover-bg) hover:text-(--text-primary) ${
-					value
-						? 'border-(--divider) text-(--text-secondary)'
-						: 'border-(--primary)/40 text-(--primary)'
+					value ? 'border-(--divider) text-(--text-secondary)' : 'border-(--primary)/40 text-(--primary)'
 				}`}
 			>
 				<Icon name="chevron-down" className="h-3.5 w-3.5" />
@@ -1025,9 +991,7 @@ function MetricMultiPickerPopover({
 				<Icon name="chevron-down" className="h-3.5 w-3.5" />
 				<span>{triggerLabel}</span>
 				{selected.length > 0 ? (
-					<span className="rounded bg-(--primary) px-1 text-[10px] font-semibold text-white">
-						{selected.length}
-					</span>
+					<span className="rounded bg-(--primary) px-1 text-[10px] font-semibold text-white">{selected.length}</span>
 				) : null}
 			</Ariakit.PopoverDisclosure>
 			<Ariakit.Popover

--- a/src/containers/Governance/queries.client.tsx
+++ b/src/containers/Governance/queries.client.tsx
@@ -120,7 +120,12 @@ export const useFetchProtocolGovernanceData = (governanceApis: Array<string> | n
 	const isEnabled = governanceApis != null && governanceApis.length > 0
 	return useQuery({
 		queryKey: ['governance', 'protocol', JSON.stringify(governanceApis)],
-		queryFn: isEnabled ? () => fetchAndFormatGovernanceData(governanceApis) : () => Promise.resolve(null),
+		queryFn: isEnabled
+			? () =>
+					fetchJson<GovernanceDataEntry[]>(
+						`/api/charts/protocol?kind=governance&apis=${encodeURIComponent(JSON.stringify(governanceApis))}`
+					)
+			: () => Promise.resolve(null),
 		staleTime: 60 * 60 * 1000,
 		retry: 0,
 		enabled: isEnabled

--- a/src/containers/Governance/queries.client.tsx
+++ b/src/containers/Governance/queries.client.tsx
@@ -122,9 +122,16 @@ export const useFetchProtocolGovernanceData = (governanceApis: Array<string> | n
 		queryKey: ['governance', 'protocol', JSON.stringify(governanceApis)],
 		queryFn: isEnabled
 			? () =>
-					fetchJson<GovernanceDataEntry[]>(
-						`/api/charts/protocol?kind=governance&apis=${encodeURIComponent(JSON.stringify(governanceApis))}`
-					)
+					fetchJson<GovernanceDataEntry[]>('/api/charts/protocol', {
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json'
+						},
+						body: JSON.stringify({
+							kind: 'governance',
+							apis: governanceApis
+						})
+					})
 			: () => Promise.resolve(null),
 		staleTime: 60 * 60 * 1000,
 		retry: 0,

--- a/src/containers/ProtocolOverview/queries.client.tsx
+++ b/src/containers/ProtocolOverview/queries.client.tsx
@@ -1,11 +1,7 @@
 import { useQueries, useQuery } from '@tanstack/react-query'
 import type { UseQueryOptions, UseQueryResult } from '@tanstack/react-query'
 import { useMemo } from 'react'
-import { fetchProtocolTokenLiquidityChart } from '~/api'
-import { YIELD_PROJECT_MEDIAN_API } from '~/constants'
-import { fetchAdapterProtocolChartData } from '~/containers/DimensionAdapters/api'
 import { fetchJson } from '~/utils/async'
-import { fetchProtocolTreasuryChart, fetchProtocolTvlChart } from './api'
 import type {
 	IProtocolChainBreakdownChart,
 	IProtocolChartV2Params,
@@ -39,6 +35,16 @@ type IProtocolChartQueryKey = [
 	string | undefined
 ]
 
+const buildProtocolChartApiUrl = (params: Record<string, string | undefined>) => {
+	const searchParams = new URLSearchParams()
+	for (const [key, value] of Object.entries(params)) {
+		if (value != null) {
+			searchParams.set(key, value)
+		}
+	}
+	return `/api/charts/protocol?${searchParams.toString()}`
+}
+
 const getProtocolChartQueryOptions = ({
 	source,
 	protocol,
@@ -57,9 +63,15 @@ const getProtocolChartQueryOptions = ({
 	return {
 		queryKey: ['protocol-overview', chartKey, protocol, key, currency, breakdownType],
 		queryFn: () =>
-			source === 'tvl'
-				? fetchProtocolTvlChart({ protocol: protocol!, key, currency, breakdownType })
-				: fetchProtocolTreasuryChart({ protocol: protocol!, key, currency, breakdownType }),
+			fetchJson<IProtocolChartQueryData>(
+				buildProtocolChartApiUrl({
+					kind: source,
+					protocol: protocol!,
+					key,
+					currency,
+					breakdownType
+				})
+			),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,
@@ -93,7 +105,14 @@ export const useFetchProtocolActivityChart = ({
 	return useQuery({
 		queryKey: ['protocol-overview', queryKey, protocol],
 		queryFn: () =>
-			fetchAdapterProtocolChartData({ adapterType, protocol: protocol!, dataType })
+			fetchJson<Array<[number, number]>>(
+				buildProtocolChartApiUrl({
+					kind: 'adapter',
+					adapterType,
+					protocol: protocol!,
+					dataType
+				})
+			)
 				.then((values) => normalizeActivityChart(values))
 				.catch(() => null),
 		staleTime: 60 * 60 * 1000,
@@ -107,7 +126,7 @@ export const useFetchProtocolTokenLiquidity = (token: string | null) => {
 	const isEnabled = !!token
 	return useQuery({
 		queryKey: ['protocol-overview', 'token-liquidity', token],
-		queryFn: () => fetchProtocolTokenLiquidityChart(token!),
+		queryFn: () => fetchJson(buildProtocolChartApiUrl({ kind: 'token-liquidity', protocolId: token! })),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,
@@ -120,18 +139,9 @@ export const useFetchProtocolMedianAPY = (protocolName: string | null) => {
 	return useQuery({
 		queryKey: ['protocol-overview', 'median-apy', protocolName],
 		queryFn: () =>
-			fetchJson(`${YIELD_PROJECT_MEDIAN_API}/${protocolName}`)
-				.then((values: { data: Array<{ timestamp: string; medianAPY: number; [key: string]: unknown }> } | null) => {
-					return values && values.data.length > 0
-						? values.data.map((item: { timestamp: string; medianAPY: number; [key: string]: unknown }) => ({
-								...item,
-								date: Math.floor(new Date(item.timestamp).getTime() / 1000)
-							}))
-						: null
-				})
-				.catch(() => {
-					return []
-				}),
+			fetchJson(buildProtocolChartApiUrl({ kind: 'median-apy', protocol: protocolName! })).catch(() => {
+				return []
+			}),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,

--- a/src/containers/ProtocolOverview/queries.client.tsx
+++ b/src/containers/ProtocolOverview/queries.client.tsx
@@ -139,9 +139,7 @@ export const useFetchProtocolMedianAPY = (protocolName: string | null) => {
 	return useQuery({
 		queryKey: ['protocol-overview', 'median-apy', protocolName],
 		queryFn: () =>
-			fetchJson(buildProtocolChartApiUrl({ kind: 'median-apy', protocol: protocolName! })).catch(() => {
-				return []
-			}),
+			fetchJson(buildProtocolChartApiUrl({ kind: 'median-apy', protocol: protocolName! })).catch(() => null),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,

--- a/src/containers/ProtocolOverview/useFetchProtocolChartData.ts
+++ b/src/containers/ProtocolOverview/useFetchProtocolChartData.ts
@@ -1,32 +1,21 @@
 import { useQuery } from '@tanstack/react-query'
 import { useRouter } from 'next/router'
 import { useMemo } from 'react'
-import { fetchProtocolTokenLiquidityChart } from '~/api'
 import type { DenominationPriceHistory } from '~/api/coingecko.types'
 import type { ChartTimeGroupingWithCumulative } from '~/components/ECharts/types'
 import { formatBarChart, formatLineChart, getBucketTimestampSec } from '~/components/ECharts/utils'
-import { CACHE_SERVER, oracleProtocols } from '~/constants'
-import { fetchBridgeVolumeBySlug } from '~/containers/Bridges/api'
-import { fetchAdapterProtocolChartData } from '~/containers/DimensionAdapters/api'
+import { oracleProtocols } from '~/constants'
 import { useFetchProtocolGovernanceData } from '~/containers/Governance/queries.client'
-import { fetchNftMarketplaceVolumes } from '~/containers/Nft/api'
-import { fetchOracleProtocolChart } from '~/containers/Oracles/api'
 import {
 	useFetchProtocolActivityChart,
 	useFetchProtocolMedianAPY,
 	useFetchProtocolTVLChart
 } from '~/containers/ProtocolOverview/queries.client'
 import type { EmissionsChartRow } from '~/containers/Unlocks/api.types'
-import { getProtocolEmissionsCharts } from '~/containers/Unlocks/queries'
 import { slug } from '~/utils'
 import { fetchJson } from '~/utils/async'
-import { fetchProtocolTreasuryChart } from './api'
 import { ADAPTER_CHART_DESCRIPTORS_BY_LABEL } from './chartDescriptors'
-import {
-	normalizeBridgeVolumeToChartMs,
-	normalizeSeriesToMilliseconds,
-	normalizeSeriesToSeconds
-} from './chartSeries.utils'
+import { normalizeSeriesToMilliseconds, normalizeSeriesToSeconds } from './chartSeries.utils'
 import { protocolCharts, type ProtocolChartsLabels } from './constants'
 import type { IProtocolOverviewPageData, IToggledMetrics } from './types'
 import { usePrefetchedProtocolChartQuery } from './usePrefetchedProtocolChartQuery'
@@ -204,6 +193,16 @@ const buildUsdInflowsFromTvlChart = (tvlChart: Array<[number, number | null]>): 
 	return inflows.length > 0 ? inflows : null
 }
 
+const buildProtocolChartApiUrl = (params: Record<string, string | undefined>) => {
+	const searchParams = new URLSearchParams()
+	for (const [key, value] of Object.entries(params)) {
+		if (value != null) {
+			searchParams.set(key, value)
+		}
+	}
+	return `/api/charts/protocol?${searchParams.toString()}`
+}
+
 export const useFetchProtocolChartData = ({
 	name,
 	id: protocolId,
@@ -266,7 +265,7 @@ export const useFetchProtocolChartData = ({
 	> | null>({
 		queryKey: ['protocol-overview', protocolSlug, 'denomination-price-history', denominationGeckoId],
 		queryFn: () =>
-			fetchJson(`${CACHE_SERVER}/cgchart/${denominationGeckoId}?fullChart=true`).then(
+			fetchJson(`/api/charts/coingecko/${encodeURIComponent(denominationGeckoId!)}?fullChart=true`).then(
 				(res: { data?: { prices?: Array<[number, number]> } }) => {
 					if (!res.data?.prices?.length) return null
 					const store: Record<string, number> = {}
@@ -287,7 +286,7 @@ export const useFetchProtocolChartData = ({
 		useQuery<DenominationPriceHistory | null>({
 			queryKey: ['protocol-overview', protocolSlug, 'token-price-history', geckoId],
 			queryFn: () =>
-				fetchJson(`${CACHE_SERVER}/cgchart/${geckoId}?fullChart=true`).then(
+				fetchJson(`/api/charts/coingecko/${encodeURIComponent(geckoId!)}?fullChart=true`).then(
 					(res: { data?: DenominationPriceHistory }) => (res.data?.prices?.length ? res.data : null)
 				),
 			staleTime: 60 * 60 * 1000,
@@ -306,9 +305,9 @@ export const useFetchProtocolChartData = ({
 	const { data: tokenTotalSupply = null, isLoading: fetchingTokenTotalSupply } = useQuery<number | null>({
 		queryKey: ['protocol-overview', protocolSlug, 'token-supply', geckoId],
 		queryFn: () =>
-			fetchJson(`${CACHE_SERVER}/supply/${geckoId}`).then(
-				(res: { data?: { total_supply?: number } }) => res.data?.['total_supply'] ?? null
-			),
+			fetchJson<{ totalSupply: number | null }>(
+				`/api/charts/coingecko/${encodeURIComponent(geckoId!)}?kind=supply`
+			).then((res) => res.totalSupply ?? null),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,
@@ -318,7 +317,7 @@ export const useFetchProtocolChartData = ({
 		[string | number, number]
 	> | null>({
 		queryKey: ['protocol-overview', protocolSlug, 'token-liquidity', protocolId],
-		queryFn: () => fetchProtocolTokenLiquidityChart(protocolId),
+		queryFn: () => fetchJson(buildProtocolChartApiUrl({ kind: 'token-liquidity', protocolId })),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,
@@ -446,10 +445,14 @@ export const useFetchProtocolChartData = ({
 		queryKey: ['protocol-overview', protocolSlug, 'fees'],
 		enabled: isFeesEnabled,
 		queryFn: () =>
-			fetchAdapterProtocolChartData({
-				...feesDescriptor!.chartRequest,
-				protocol: name
-			})
+			fetchJson(
+				buildProtocolChartApiUrl({
+					kind: 'adapter',
+					adapterType: feesDescriptor!.chartRequest.adapterType,
+					protocol: name,
+					dataType: feesDescriptor!.chartRequest.dataType
+				})
+			)
 	})
 
 	const isRevenueEnabled = !!(toggledMetrics.revenue === 'true' && metrics.revenue && isRouterReady)
@@ -459,10 +462,14 @@ export const useFetchProtocolChartData = ({
 		queryKey: ['protocol-overview', protocolSlug, 'revenue'],
 		enabled: isRevenueEnabled,
 		queryFn: () =>
-			fetchAdapterProtocolChartData({
-				...revenueDescriptor!.chartRequest,
-				protocol: name
-			})
+			fetchJson(
+				buildProtocolChartApiUrl({
+					kind: 'adapter',
+					adapterType: revenueDescriptor!.chartRequest.adapterType,
+					protocol: name,
+					dataType: revenueDescriptor!.chartRequest.dataType
+				})
+			)
 	})
 
 	const isHoldersRevenueEnabled = !!(
@@ -476,10 +483,14 @@ export const useFetchProtocolChartData = ({
 		queryKey: ['protocol-overview', protocolSlug, 'holders-revenue'],
 		enabled: isHoldersRevenueEnabled,
 		queryFn: () =>
-			fetchAdapterProtocolChartData({
-				...holdersRevenueDescriptor!.chartRequest,
-				protocol: name
-			})
+			fetchJson(
+				buildProtocolChartApiUrl({
+					kind: 'adapter',
+					adapterType: holdersRevenueDescriptor!.chartRequest.adapterType,
+					protocol: name,
+					dataType: holdersRevenueDescriptor!.chartRequest.dataType
+				})
+			)
 	})
 
 	const isBribesEnabled = !!(
@@ -492,11 +503,14 @@ export const useFetchProtocolChartData = ({
 		queryKey: ['protocol-overview', protocolSlug, 'bribes'],
 		queryFn: () =>
 			isBribesEnabled
-				? fetchAdapterProtocolChartData({
-						adapterType: 'fees',
-						dataType: 'dailyBribesRevenue',
-						protocol: name
-					})
+				? fetchJson(
+						buildProtocolChartApiUrl({
+							kind: 'adapter',
+							adapterType: 'fees',
+							dataType: 'dailyBribesRevenue',
+							protocol: name
+						})
+					)
 				: Promise.resolve(null),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
@@ -514,11 +528,14 @@ export const useFetchProtocolChartData = ({
 		queryKey: ['protocol-overview', protocolSlug, 'token-taxes'],
 		queryFn: () =>
 			isTokenTaxesEnabled
-				? fetchAdapterProtocolChartData({
-						adapterType: 'fees',
-						dataType: 'dailyTokenTaxes',
-						protocol: name
-					})
+				? fetchJson(
+						buildProtocolChartApiUrl({
+							kind: 'adapter',
+							adapterType: 'fees',
+							dataType: 'dailyTokenTaxes',
+							protocol: name
+						})
+					)
 				: Promise.resolve(null),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
@@ -532,7 +549,15 @@ export const useFetchProtocolChartData = ({
 		prefetchedCharts: prefetchedChartsInSeconds,
 		queryKey: ['protocol-overview', protocolSlug, 'dex-volume'],
 		enabled: isDexVolumeEnabled,
-		queryFn: () => fetchAdapterProtocolChartData({ ...dexVolumeDescriptor!.chartRequest, protocol: name })
+		queryFn: () =>
+			fetchJson(
+				buildProtocolChartApiUrl({
+					kind: 'adapter',
+					adapterType: dexVolumeDescriptor!.chartRequest.adapterType,
+					protocol: name,
+					dataType: dexVolumeDescriptor!.chartRequest.dataType
+				})
+			)
 	})
 
 	const isDexNotionalVolumeEnabled = !!(
@@ -545,7 +570,15 @@ export const useFetchProtocolChartData = ({
 		prefetchedCharts: prefetchedChartsInSeconds,
 		queryKey: ['protocol-overview', protocolSlug, 'dex-notional-volume'],
 		enabled: isDexNotionalVolumeEnabled,
-		queryFn: () => fetchAdapterProtocolChartData({ ...dexNotionalVolumeDescriptor!.chartRequest, protocol: name })
+		queryFn: () =>
+			fetchJson(
+				buildProtocolChartApiUrl({
+					kind: 'adapter',
+					adapterType: dexNotionalVolumeDescriptor!.chartRequest.adapterType,
+					protocol: name,
+					dataType: dexNotionalVolumeDescriptor!.chartRequest.dataType
+				})
+			)
 	})
 
 	const isPerpsVolumeEnabled = !!(toggledMetrics.perpVolume === 'true' && metrics.perps && isRouterReady)
@@ -554,7 +587,15 @@ export const useFetchProtocolChartData = ({
 		prefetchedCharts: prefetchedChartsInSeconds,
 		queryKey: ['protocol-overview', protocolSlug, 'perp-volume'],
 		enabled: isPerpsVolumeEnabled,
-		queryFn: () => fetchAdapterProtocolChartData({ ...perpVolumeDescriptor!.chartRequest, protocol: name })
+		queryFn: () =>
+			fetchJson(
+				buildProtocolChartApiUrl({
+					kind: 'adapter',
+					adapterType: perpVolumeDescriptor!.chartRequest.adapterType,
+					protocol: name,
+					dataType: perpVolumeDescriptor!.chartRequest.dataType
+				})
+			)
 	})
 
 	const isOpenInterestEnabled = !!(toggledMetrics.openInterest === 'true' && metrics.openInterest && isRouterReady)
@@ -563,7 +604,15 @@ export const useFetchProtocolChartData = ({
 		prefetchedCharts: prefetchedChartsInSeconds,
 		queryKey: ['protocol-overview', protocolSlug, 'open-interest'],
 		enabled: isOpenInterestEnabled,
-		queryFn: () => fetchAdapterProtocolChartData({ ...openInterestDescriptor!.chartRequest, protocol: name })
+		queryFn: () =>
+			fetchJson(
+				buildProtocolChartApiUrl({
+					kind: 'adapter',
+					adapterType: openInterestDescriptor!.chartRequest.adapterType,
+					protocol: name,
+					dataType: openInterestDescriptor!.chartRequest.dataType
+				})
+			)
 	})
 
 	const isOptionsPremiumVolumeEnabled = !!(
@@ -577,7 +626,15 @@ export const useFetchProtocolChartData = ({
 			prefetchedCharts: prefetchedChartsInSeconds,
 			queryKey: ['protocol-overview', protocolSlug, 'options-premium-volume'],
 			enabled: isOptionsPremiumVolumeEnabled,
-			queryFn: () => fetchAdapterProtocolChartData({ ...optionsPremiumDescriptor!.chartRequest, protocol: name })
+			queryFn: () =>
+				fetchJson(
+					buildProtocolChartApiUrl({
+						kind: 'adapter',
+						adapterType: optionsPremiumDescriptor!.chartRequest.adapterType,
+						protocol: name,
+						dataType: optionsPremiumDescriptor!.chartRequest.dataType
+					})
+				)
 		})
 
 	const isOptionsNotionalVolumeEnabled = !!(
@@ -591,7 +648,15 @@ export const useFetchProtocolChartData = ({
 			prefetchedCharts: prefetchedChartsInSeconds,
 			queryKey: ['protocol-overview', protocolSlug, 'options-notional-volume'],
 			enabled: isOptionsNotionalVolumeEnabled,
-			queryFn: () => fetchAdapterProtocolChartData({ ...optionsNotionalDescriptor!.chartRequest, protocol: name })
+			queryFn: () =>
+				fetchJson(
+					buildProtocolChartApiUrl({
+						kind: 'adapter',
+						adapterType: optionsNotionalDescriptor!.chartRequest.adapterType,
+						protocol: name,
+						dataType: optionsNotionalDescriptor!.chartRequest.dataType
+					})
+				)
 		})
 
 	const isDexAggregatorsVolumeEnabled = !!(
@@ -605,7 +670,15 @@ export const useFetchProtocolChartData = ({
 			prefetchedCharts: prefetchedChartsInSeconds,
 			queryKey: ['protocol-overview', protocolSlug, 'dex-aggregator-volume'],
 			enabled: isDexAggregatorsVolumeEnabled,
-			queryFn: () => fetchAdapterProtocolChartData({ ...dexAggregatorsDescriptor!.chartRequest, protocol: name })
+			queryFn: () =>
+				fetchJson(
+					buildProtocolChartApiUrl({
+						kind: 'adapter',
+						adapterType: dexAggregatorsDescriptor!.chartRequest.adapterType,
+						protocol: name,
+						dataType: dexAggregatorsDescriptor!.chartRequest.dataType
+					})
+				)
 		})
 
 	const isPerpsAggregatorsVolumeEnabled = !!(
@@ -619,7 +692,15 @@ export const useFetchProtocolChartData = ({
 			prefetchedCharts: prefetchedChartsInSeconds,
 			queryKey: ['protocol-overview', protocolSlug, 'perp-aggregator-volume'],
 			enabled: isPerpsAggregatorsVolumeEnabled,
-			queryFn: () => fetchAdapterProtocolChartData({ ...perpsAggregatorsDescriptor!.chartRequest, protocol: name })
+			queryFn: () =>
+				fetchJson(
+					buildProtocolChartApiUrl({
+						kind: 'adapter',
+						adapterType: perpsAggregatorsDescriptor!.chartRequest.adapterType,
+						protocol: name,
+						dataType: perpsAggregatorsDescriptor!.chartRequest.dataType
+					})
+				)
 		})
 
 	const isBridgeAggregatorsVolumeEnabled = !!(
@@ -633,7 +714,15 @@ export const useFetchProtocolChartData = ({
 			prefetchedCharts: prefetchedChartsInSeconds,
 			queryKey: ['protocol-overview', protocolSlug, 'bridge-aggregator-volume'],
 			enabled: isBridgeAggregatorsVolumeEnabled,
-			queryFn: () => fetchAdapterProtocolChartData({ ...bridgeAggregatorsDescriptor!.chartRequest, protocol: name })
+			queryFn: () =>
+				fetchJson(
+					buildProtocolChartApiUrl({
+						kind: 'adapter',
+						adapterType: bridgeAggregatorsDescriptor!.chartRequest.adapterType,
+						protocol: name,
+						dataType: bridgeAggregatorsDescriptor!.chartRequest.dataType
+					})
+				)
 		})
 
 	const isUnlocksEnabled = !!(
@@ -646,24 +735,10 @@ export const useFetchProtocolChartData = ({
 		unlockUsdChart: Array<[string | number, number]> | null
 	} | null>({
 		queryKey: ['protocol-overview', protocolSlug, 'unlocks'],
-		queryFn: async () => {
-			if (!isUnlocksEnabled) return null
-			const result = await getProtocolEmissionsCharts(slug(name))
-			return {
-				...result,
-				unlockUsdChart: Array.isArray(result.unlockUsdChart)
-					? result.unlockUsdChart
-							.filter(
-								(item): item is [string | number, string | number] =>
-									Array.isArray(item) &&
-									item.length >= 2 &&
-									Number.isFinite(Number(item[0])) &&
-									Number.isFinite(Number(item[1]))
-							)
-							.map((item): [number, number] => [Number(item[0]), Number(item[1])])
-					: null
-			}
-		},
+		queryFn: () =>
+			isUnlocksEnabled
+				? fetchJson(buildProtocolChartApiUrl({ kind: 'unlocks', protocol: name }))
+				: Promise.resolve(null),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,
@@ -677,7 +752,9 @@ export const useFetchProtocolChartData = ({
 		queryKey: ['protocol-overview', protocolSlug, 'treasury'],
 		enabled: isTreasuryEnabled,
 		queryFn: () =>
-			fetchProtocolTreasuryChart({ protocol: protocolSlug }).then((chart) => normalizeSeriesToMilliseconds(chart))
+			fetchJson<Array<[number, number]> | null>(
+				buildProtocolChartApiUrl({ kind: 'treasury', protocol: protocolSlug })
+			).then((chart) => (chart ? normalizeSeriesToMilliseconds(chart) : null))
 	})
 
 	const isUsdInflowsEnabled = !!(toggledMetrics.usdInflows === 'true' && metrics.tvl && isRouterReady)
@@ -703,9 +780,7 @@ export const useFetchProtocolChartData = ({
 		queryKey: ['protocol-overview', protocolSlug, 'bridge-volume'],
 		enabled: isBridgeVolumeEnabled,
 		queryFn: () =>
-			fetchBridgeVolumeBySlug(slug(name))
-				.then((data) => normalizeBridgeVolumeToChartMs(data.dailyVolumes))
-				.catch(() => null)
+			fetchJson<Array<[number, number]> | null>(buildProtocolChartApiUrl({ kind: 'bridge-volume', protocol: name }))
 	})
 
 	const isTvsEnabled = !!(toggledMetrics.tvs === 'true' && isRouterReady && availableCharts.includes('TVS'))
@@ -715,8 +790,10 @@ export const useFetchProtocolChartData = ({
 		queryKey: ['protocol-overview', protocolSlug, 'tvs'],
 		enabled: isTvsEnabled,
 		queryFn: () =>
-			fetchOracleProtocolChart({ protocol: oracleProtocolName })
-				.then((chart) => normalizeSeriesToSeconds(chart))
+			fetchJson<Array<[number, number]> | null>(
+				buildProtocolChartApiUrl({ kind: 'oracle-chart', protocol: oracleProtocolName })
+			)
+				.then((chart) => (chart ? normalizeSeriesToSeconds(chart) : null))
 				.catch(() => null)
 	})
 
@@ -766,13 +843,9 @@ export const useFetchProtocolChartData = ({
 		queryKey: ['protocol-overview', protocolSlug, 'nft-volume'],
 		queryFn: () =>
 			isNftVolumeEnabled
-				? fetchNftMarketplaceVolumes()
-						.then((r) =>
-							r
-								.filter((item) => slug(item.exchangeName) === slug(name))
-								.map(({ day, sumUsd }): [number, number] => [new Date(day).getTime(), sumUsd])
-						)
-						.catch((): Array<[number, number]> => [])
+				? fetchJson<Array<[number, number]> | null>(
+						buildProtocolChartApiUrl({ kind: 'nft-volume', protocol: name })
+					).catch((): Array<[number, number]> => [])
 				: Promise.resolve(null),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,

--- a/src/containers/RWA/breakdownDataset.test.ts
+++ b/src/containers/RWA/breakdownDataset.test.ts
@@ -3,12 +3,14 @@ import { ensureChronologicalRows } from '~/components/ECharts/utils'
 import { toBreakdownChartDataset } from './breakdownDataset'
 
 describe('rwa breakdownDataset', () => {
-	it.each([null, []])('returns an empty dataset when toBreakdownChartDataset receives %j', (rows) => {
-		expect(toBreakdownChartDataset(rows)).toEqual({
-			source: [],
-			dimensions: ['timestamp']
+	for (const rows of [null, []] as Array<Parameters<typeof toBreakdownChartDataset>[0]>) {
+		it(`returns an empty dataset when toBreakdownChartDataset receives ${JSON.stringify(rows)}`, () => {
+			expect(toBreakdownChartDataset(rows)).toEqual({
+				source: [],
+				dimensions: ['timestamp']
+			})
 		})
-	})
+	}
 
 	it('sorts chart rows chronologically before building the dataset', () => {
 		expect(

--- a/src/containers/Stablecoins/queries.client.tsx
+++ b/src/containers/Stablecoins/queries.client.tsx
@@ -11,7 +11,6 @@ const buildStablecoinMcapSeries = async (chain: string): Promise<StablecoinMcapS
 		return null
 	}
 }
-
 export const useGetStabelcoinsChartDataByChain = (chain?: string) => {
 	const { data, isLoading, error } = useQuery({
 		queryKey: ['stablecoins', 'chart-by-chain', chain],

--- a/src/containers/Unlocks/api.ts
+++ b/src/containers/Unlocks/api.ts
@@ -120,11 +120,7 @@ export async function fetchProtocolEmission(protocolName: string): Promise<Proto
 	if (!protocolName) return null
 	const encodedProtocolName = encodeURIComponent(protocolName)
 	try {
-		const url =
-			typeof window !== 'undefined'
-				? `/api/emission/${encodedProtocolName}`
-				: `${PROTOCOL_EMISSION_API}/${encodedProtocolName}`
-		const raw = await fetchJson<unknown>(url)
+		const raw = await fetchJson<unknown>(`${PROTOCOL_EMISSION_API}/${encodedProtocolName}`)
 		return parseProtocolEmissionApiResponse(raw)
 	} catch (error) {
 		console.error(`Failed to fetch protocol emission for ${protocolName}:`, error)

--- a/src/pages/api/charts/chain.ts
+++ b/src/pages/api/charts/chain.ts
@@ -10,9 +10,19 @@ import { slug } from '~/utils'
 
 type ResponseData = unknown[] | Record<string, unknown> | { error: string } | null
 type StablecoinMcapSeriesPoint = [number, number]
+const SUCCESS_CACHE_CONTROL = 'public, s-maxage=3600, stale-while-revalidate=600'
+const NO_STORE_CACHE_CONTROL = 'no-store'
 
 const getQueryParam = (value: string | string[] | undefined): string | undefined =>
 	Array.isArray(value) ? value[0] : value
+
+const setSuccessCacheHeaders = (res: NextApiResponse<ResponseData>) => {
+	res.setHeader('Cache-Control', SUCCESS_CACHE_CONTROL)
+}
+
+const setNoStoreHeaders = (res: NextApiResponse<ResponseData>) => {
+	res.setHeader('Cache-Control', NO_STORE_CACHE_CONTROL)
+}
 
 const buildStablecoinMcapSeries = async (chain: string): Promise<StablecoinMcapSeriesPoint[] | null> => {
 	try {
@@ -42,17 +52,17 @@ const buildStablecoinMcapSeries = async (chain: string): Promise<StablecoinMcapS
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ResponseData>) {
 	if (req.method !== 'GET') {
 		res.setHeader('Allow', ['GET'])
+		setNoStoreHeaders(res)
 		return res.status(405).json({ error: 'Method Not Allowed' })
 	}
 
 	const kind = getQueryParam(req.query.kind)
 	if (!kind) {
+		setNoStoreHeaders(res)
 		return res.status(400).json({ error: 'kind parameter is required' })
 	}
 
 	try {
-		res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600')
-
 		if (kind === 'adapter-chain') {
 			const adapterType = getQueryParam(req.query.adapterType)
 			const chain = getQueryParam(req.query.chain)
@@ -60,6 +70,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 			const category = getQueryParam(req.query.category)
 
 			if (!adapterType || !chain) {
+				setNoStoreHeaders(res)
 				return res.status(400).json({ error: 'adapterType and chain parameters are required' })
 			}
 
@@ -69,6 +80,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 				...(dataType ? { dataType: dataType as Parameters<typeof fetchAdapterChainChartData>[0]['dataType'] } : {}),
 				...(category ? { category } : {})
 			})
+			setSuccessCacheHeaders(res)
 			return res.status(200).json(data)
 		}
 
@@ -78,6 +90,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 			const dataType = getQueryParam(req.query.dataType)
 
 			if (!adapterType || !protocol) {
+				setNoStoreHeaders(res)
 				return res.status(400).json({ error: 'adapterType and protocol parameters are required' })
 			}
 
@@ -86,16 +99,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 				protocol,
 				...(dataType ? { dataType: dataType as Parameters<typeof fetchAdapterProtocolChartData>[0]['dataType'] } : {})
 			})
+			setSuccessCacheHeaders(res)
 			return res.status(200).json(data)
 		}
 
 		if (kind === 'bridged-tvl') {
 			const chain = getQueryParam(req.query.chain)
 			if (!chain) {
+				setNoStoreHeaders(res)
 				return res.status(400).json({ error: 'chain parameter is required' })
 			}
 
 			const data = await fetchChainAssetsChart(chain)
+			setSuccessCacheHeaders(res)
 			return res.status(200).json(data)
 		}
 
@@ -116,22 +132,31 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 				return chart
 			})
 
+			setSuccessCacheHeaders(res)
 			return res.status(200).json(data)
 		}
 
 		if (kind === 'stablecoins-mcap') {
 			const chain = getQueryParam(req.query.chain)
 			if (!chain) {
+				setNoStoreHeaders(res)
 				return res.status(400).json({ error: 'chain parameter is required' })
 			}
 
 			const data = await buildStablecoinMcapSeries(chain)
+			if (data === null) {
+				setNoStoreHeaders(res)
+				return res.status(200).json(null)
+			}
+
+			setSuccessCacheHeaders(res)
 			return res.status(200).json(data)
 		}
 
 		if (kind === 'net-inflows') {
 			const chain = getQueryParam(req.query.chain)
 			if (!chain) {
+				setNoStoreHeaders(res)
 				return res.status(400).json({ error: 'chain parameter is required' })
 			}
 
@@ -148,26 +173,37 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 					return null
 				})
 
+			if (data === null) {
+				setNoStoreHeaders(res)
+				return res.status(200).json(null)
+			}
+
+			setSuccessCacheHeaders(res)
 			return res.status(200).json(data)
 		}
 
 		if (kind === 'token-incentives') {
 			const protocol = getQueryParam(req.query.protocol)
 			if (!protocol) {
+				setNoStoreHeaders(res)
 				return res.status(400).json({ error: 'protocol parameter is required' })
 			}
 
 			const chart = await getProtocolUnlockUsdChart(slug(protocol)).catch(() => null)
 			if (!chart) {
+				setNoStoreHeaders(res)
 				return res.status(200).json(null)
 			}
 
 			const nonZeroIndex = chart.findIndex((point) => Array.isArray(point) && Number(point[1]) > 0)
-			return res.status(200).json(chart.slice(nonZeroIndex))
+			setSuccessCacheHeaders(res)
+			return res.status(200).json(chart.slice(nonZeroIndex >= 0 ? nonZeroIndex : 0))
 		}
 
+		setNoStoreHeaders(res)
 		return res.status(400).json({ error: `Unsupported kind: ${kind}` })
 	} catch (error) {
+		setNoStoreHeaders(res)
 		console.log('Failed to fetch chain chart data', error)
 		return res.status(500).json({ error: 'Failed to load chain chart data' })
 	}

--- a/src/pages/api/charts/chain.ts
+++ b/src/pages/api/charts/chain.ts
@@ -1,0 +1,174 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { fetchChainAssetsChart } from '~/containers/BridgedTVL/api'
+import { getBridgeOverviewPageData } from '~/containers/Bridges/queries.server'
+import { fetchAdapterChainChartData, fetchAdapterProtocolChartData } from '~/containers/DimensionAdapters/api'
+import { fetchRaises } from '~/containers/Raises/api'
+import { getStablecoinsByChainPageData } from '~/containers/Stablecoins/queries.server'
+import { buildStablecoinChartData } from '~/containers/Stablecoins/utils'
+import { getProtocolUnlockUsdChart } from '~/containers/Unlocks/queries'
+import { slug } from '~/utils'
+
+type ResponseData = unknown[] | Record<string, unknown> | { error: string } | null
+type StablecoinMcapSeriesPoint = [number, number]
+
+const getQueryParam = (value: string | string[] | undefined): string | undefined =>
+	Array.isArray(value) ? value[0] : value
+
+const buildStablecoinMcapSeries = async (chain: string): Promise<StablecoinMcapSeriesPoint[] | null> => {
+	try {
+		const data = await getStablecoinsByChainPageData(chain === 'All' ? null : chain)
+		const { peggedAreaTotalData } = buildStablecoinChartData({
+			chartDataByAssetOrChain: data.chartDataByPeggedAsset,
+			assetsOrChainsList: data.peggedAssetNames,
+			filteredIndexes: Object.values(data.peggedNameToChartDataIndex),
+			issuanceType: 'mcap',
+			selectedChain: chain,
+			doublecountedIds: data.doublecountedIds
+		})
+
+		return peggedAreaTotalData
+			.map(({ date, Mcap }): StablecoinMcapSeriesPoint | null => {
+				const timestamp = Number(date) * 1e3
+				if (!Number.isFinite(timestamp) || !Number.isFinite(Mcap)) return null
+				return [timestamp, Mcap]
+			})
+			.filter((point): point is StablecoinMcapSeriesPoint => point !== null)
+	} catch (error) {
+		console.log('Failed to build stablecoin chart series', error)
+		return null
+	}
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<ResponseData>) {
+	if (req.method !== 'GET') {
+		res.setHeader('Allow', ['GET'])
+		return res.status(405).json({ error: 'Method Not Allowed' })
+	}
+
+	const kind = getQueryParam(req.query.kind)
+	if (!kind) {
+		return res.status(400).json({ error: 'kind parameter is required' })
+	}
+
+	try {
+		res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600')
+
+		if (kind === 'adapter-chain') {
+			const adapterType = getQueryParam(req.query.adapterType)
+			const chain = getQueryParam(req.query.chain)
+			const dataType = getQueryParam(req.query.dataType)
+			const category = getQueryParam(req.query.category)
+
+			if (!adapterType || !chain) {
+				return res.status(400).json({ error: 'adapterType and chain parameters are required' })
+			}
+
+			const data = await fetchAdapterChainChartData({
+				adapterType: adapterType as Parameters<typeof fetchAdapterChainChartData>[0]['adapterType'],
+				chain,
+				...(dataType ? { dataType: dataType as Parameters<typeof fetchAdapterChainChartData>[0]['dataType'] } : {}),
+				...(category ? { category } : {})
+			})
+			return res.status(200).json(data)
+		}
+
+		if (kind === 'adapter-protocol') {
+			const adapterType = getQueryParam(req.query.adapterType)
+			const protocol = getQueryParam(req.query.protocol)
+			const dataType = getQueryParam(req.query.dataType)
+
+			if (!adapterType || !protocol) {
+				return res.status(400).json({ error: 'adapterType and protocol parameters are required' })
+			}
+
+			const data = await fetchAdapterProtocolChartData({
+				adapterType: adapterType as Parameters<typeof fetchAdapterProtocolChartData>[0]['adapterType'],
+				protocol,
+				...(dataType ? { dataType: dataType as Parameters<typeof fetchAdapterProtocolChartData>[0]['dataType'] } : {})
+			})
+			return res.status(200).json(data)
+		}
+
+		if (kind === 'bridged-tvl') {
+			const chain = getQueryParam(req.query.chain)
+			if (!chain) {
+				return res.status(400).json({ error: 'chain parameter is required' })
+			}
+
+			const data = await fetchChainAssetsChart(chain)
+			return res.status(200).json(data)
+		}
+
+		if (kind === 'raises') {
+			const data = await fetchRaises().then((response) => {
+				const store = (response?.raises ?? []).reduce(
+					(acc, curr) => {
+						acc[curr.date] = (acc[curr.date] ?? 0) + +(curr.amount ?? 0)
+						return acc
+					},
+					{} as Record<string, number>
+				)
+
+				const chart: Array<[number, number]> = []
+				for (const date in store) {
+					chart.push([+date * 1e3, store[date] * 1e6])
+				}
+				return chart
+			})
+
+			return res.status(200).json(data)
+		}
+
+		if (kind === 'stablecoins-mcap') {
+			const chain = getQueryParam(req.query.chain)
+			if (!chain) {
+				return res.status(400).json({ error: 'chain parameter is required' })
+			}
+
+			const data = await buildStablecoinMcapSeries(chain)
+			return res.status(200).json(data)
+		}
+
+		if (kind === 'net-inflows') {
+			const chain = getQueryParam(req.query.chain)
+			if (!chain) {
+				return res.status(400).json({ error: 'chain parameter is required' })
+			}
+
+			const data = await getBridgeOverviewPageData(chain)
+				.then((pageData) =>
+					pageData?.chainVolumeData?.map((volume) => [
+						volume?.date ?? null,
+						volume?.Deposits ?? null,
+						volume?.Withdrawals ?? null
+					])
+				)
+				.catch((error) => {
+					console.log(error)
+					return null
+				})
+
+			return res.status(200).json(data)
+		}
+
+		if (kind === 'token-incentives') {
+			const protocol = getQueryParam(req.query.protocol)
+			if (!protocol) {
+				return res.status(400).json({ error: 'protocol parameter is required' })
+			}
+
+			const chart = await getProtocolUnlockUsdChart(slug(protocol)).catch(() => null)
+			if (!chart) {
+				return res.status(200).json(null)
+			}
+
+			const nonZeroIndex = chart.findIndex((point) => Array.isArray(point) && Number(point[1]) > 0)
+			return res.status(200).json(chart.slice(nonZeroIndex))
+		}
+
+		return res.status(400).json({ error: `Unsupported kind: ${kind}` })
+	} catch (error) {
+		console.log('Failed to fetch chain chart data', error)
+		return res.status(500).json({ error: 'Failed to load chain chart data' })
+	}
+}

--- a/src/pages/api/charts/chain.ts
+++ b/src/pages/api/charts/chain.ts
@@ -162,11 +162,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
 			const data = await getBridgeOverviewPageData(chain)
 				.then((pageData) =>
-					pageData?.chainVolumeData?.map((volume) => [
-						volume?.date ?? null,
-						volume?.Deposits ?? null,
-						volume?.Withdrawals ?? null
-					])
+					pageData?.chainVolumeData
+						? pageData.chainVolumeData.map((volume) => [
+								volume?.date ?? null,
+								volume?.Deposits ?? null,
+								volume?.Withdrawals ?? null
+							])
+						: null
 				)
 				.catch((error) => {
 					console.log(error)

--- a/src/pages/api/charts/coingecko/[geckoId].ts
+++ b/src/pages/api/charts/coingecko/[geckoId].ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { fetchCoinGeckoChartByIdWithCacheFallback } from '~/api/coingecko'
+import type { CgChartResponse } from '~/api/coingecko.types'
+import { CACHE_SERVER } from '~/constants'
+import { fetchJson } from '~/utils/async'
+
+type ResponseData = CgChartResponse | { totalSupply: number | null } | { error: string } | null
+
+const getQueryParam = (value: string | string[] | undefined): string | undefined =>
+	Array.isArray(value) ? value[0] : value
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<ResponseData>) {
+	if (req.method !== 'GET') {
+		res.setHeader('Allow', ['GET'])
+		return res.status(405).json({ error: 'Method Not Allowed' })
+	}
+
+	const geckoId = getQueryParam(req.query.geckoId)
+	if (!geckoId) {
+		return res.status(400).json({ error: 'geckoId parameter is required' })
+	}
+
+	const kind = getQueryParam(req.query.kind)
+
+	try {
+		res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600')
+
+		if (kind === 'supply') {
+			const data = await fetchJson<{ data?: { total_supply?: number } }>(`${CACHE_SERVER}/supply/${geckoId}`).catch(
+				() => null
+			)
+			return res.status(200).json({ totalSupply: data?.data?.total_supply ?? null })
+		}
+
+		const fullChart = getQueryParam(req.query.fullChart) !== 'false'
+		const chart = await fetchCoinGeckoChartByIdWithCacheFallback(geckoId, { fullChart })
+		return res.status(200).json(chart)
+	} catch (error) {
+		console.log('Failed to fetch coingecko chart data', error)
+		return res.status(500).json({ error: 'Failed to load coingecko chart data' })
+	}
+}

--- a/src/pages/api/charts/coingecko/[geckoId].ts
+++ b/src/pages/api/charts/coingecko/[geckoId].ts
@@ -5,37 +5,60 @@ import { CACHE_SERVER } from '~/constants'
 import { fetchJson } from '~/utils/async'
 
 type ResponseData = CgChartResponse | { totalSupply: number | null } | { error: string } | null
+const SUCCESS_CACHE_CONTROL = 'public, s-maxage=3600, stale-while-revalidate=600'
+const NO_STORE_CACHE_CONTROL = 'no-store'
 
 const getQueryParam = (value: string | string[] | undefined): string | undefined =>
 	Array.isArray(value) ? value[0] : value
 
+const setSuccessCacheHeaders = (res: NextApiResponse<ResponseData>) => {
+	res.setHeader('Cache-Control', SUCCESS_CACHE_CONTROL)
+}
+
+const setNoStoreHeaders = (res: NextApiResponse<ResponseData>) => {
+	res.setHeader('Cache-Control', NO_STORE_CACHE_CONTROL)
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ResponseData>) {
 	if (req.method !== 'GET') {
 		res.setHeader('Allow', ['GET'])
+		setNoStoreHeaders(res)
 		return res.status(405).json({ error: 'Method Not Allowed' })
 	}
 
 	const geckoId = getQueryParam(req.query.geckoId)
 	if (!geckoId) {
+		setNoStoreHeaders(res)
 		return res.status(400).json({ error: 'geckoId parameter is required' })
 	}
 
 	const kind = getQueryParam(req.query.kind)
 
 	try {
-		res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600')
-
 		if (kind === 'supply') {
 			const data = await fetchJson<{ data?: { total_supply?: number } }>(`${CACHE_SERVER}/supply/${geckoId}`).catch(
 				() => null
 			)
-			return res.status(200).json({ totalSupply: data?.data?.total_supply ?? null })
+			const totalSupply = data?.data?.total_supply ?? null
+			if (totalSupply === null) {
+				setNoStoreHeaders(res)
+			} else {
+				setSuccessCacheHeaders(res)
+			}
+			return res.status(200).json({ totalSupply })
 		}
 
 		const fullChart = getQueryParam(req.query.fullChart) !== 'false'
 		const chart = await fetchCoinGeckoChartByIdWithCacheFallback(geckoId, { fullChart })
+		if (!chart) {
+			setNoStoreHeaders(res)
+			return res.status(200).json(null)
+		}
+
+		setSuccessCacheHeaders(res)
 		return res.status(200).json(chart)
 	} catch (error) {
+		setNoStoreHeaders(res)
 		console.log('Failed to fetch coingecko chart data', error)
 		return res.status(500).json({ error: 'Failed to load coingecko chart data' })
 	}

--- a/src/pages/api/charts/protocol.ts
+++ b/src/pages/api/charts/protocol.ts
@@ -3,6 +3,7 @@ import { fetchProtocolTokenLiquidityChart } from '~/api'
 import { YIELD_PROJECT_MEDIAN_API } from '~/constants'
 import { fetchBridgeVolumeBySlug } from '~/containers/Bridges/api'
 import { fetchAdapterProtocolChartData } from '~/containers/DimensionAdapters/api'
+import { ADAPTER_DATA_TYPES, ADAPTER_TYPES } from '~/containers/DimensionAdapters/constants'
 import { fetchAndFormatGovernanceData } from '~/containers/Governance/queries.client'
 import { fetchNftMarketplaceVolumes } from '~/containers/Nft/api'
 import { fetchOracleProtocolChart } from '~/containers/Oracles/api'
@@ -13,9 +14,30 @@ import { slug } from '~/utils'
 import { fetchJson } from '~/utils/async'
 
 type ResponseData = unknown[] | Record<string, unknown> | { error: string } | null
+const SUCCESS_CACHE_CONTROL = 'public, s-maxage=3600, stale-while-revalidate=600'
+const NO_STORE_CACHE_CONTROL = 'no-store'
+const VALID_ADAPTER_TYPES = new Set<string>(Object.values(ADAPTER_TYPES))
+const VALID_ADAPTER_DATA_TYPES = new Set<string>(Object.values(ADAPTER_DATA_TYPES))
 
 const getQueryParam = (value: string | string[] | undefined): string | undefined =>
 	Array.isArray(value) ? value[0] : value
+
+const getBodyParam = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined)
+
+const getArrayBodyParam = (value: unknown): string[] | null =>
+	Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : null
+
+const setSuccessCacheHeaders = (res: NextApiResponse<ResponseData>) => {
+	res.setHeader('Cache-Control', SUCCESS_CACHE_CONTROL)
+}
+
+const setNoStoreHeaders = (res: NextApiResponse<ResponseData>) => {
+	res.setHeader('Cache-Control', NO_STORE_CACHE_CONTROL)
+}
+
+const isValidAdapterType = (value: string): value is `${ADAPTER_TYPES}` => VALID_ADAPTER_TYPES.has(value)
+
+const isValidAdapterDataType = (value: string): value is `${ADAPTER_DATA_TYPES}` => VALID_ADAPTER_DATA_TYPES.has(value)
 
 const parseStringArrayParam = (value: string | undefined): string[] | null => {
 	if (!value) return null
@@ -29,33 +51,44 @@ const parseStringArrayParam = (value: string | undefined): string[] | null => {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ResponseData>) {
-	if (req.method !== 'GET') {
-		res.setHeader('Allow', ['GET'])
+	if (req.method !== 'GET' && req.method !== 'POST') {
+		res.setHeader('Allow', ['GET', 'POST'])
+		setNoStoreHeaders(res)
 		return res.status(405).json({ error: 'Method Not Allowed' })
 	}
 
-	const kind = getQueryParam(req.query.kind)
+	const kind = getQueryParam(req.query.kind) ?? getBodyParam(req.body?.kind)
 	if (!kind) {
+		setNoStoreHeaders(res)
 		return res.status(400).json({ error: 'kind parameter is required' })
 	}
 
 	try {
-		res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600')
-
 		if (kind === 'adapter') {
 			const adapterType = getQueryParam(req.query.adapterType)
 			const protocol = getQueryParam(req.query.protocol)
 			const dataType = getQueryParam(req.query.dataType)
 
 			if (!adapterType || !protocol) {
+				setNoStoreHeaders(res)
 				return res.status(400).json({ error: 'adapterType and protocol parameters are required' })
 			}
+			if (!isValidAdapterType(adapterType)) {
+				setNoStoreHeaders(res)
+				return res.status(400).json({ error: `Invalid adapterType: ${adapterType}` })
+			}
+			if (dataType && !isValidAdapterDataType(dataType)) {
+				setNoStoreHeaders(res)
+				return res.status(400).json({ error: `Invalid dataType: ${dataType}` })
+			}
+			const validatedDataType = dataType && isValidAdapterDataType(dataType) ? dataType : undefined
 
 			const data = await fetchAdapterProtocolChartData({
-				adapterType: adapterType as Parameters<typeof fetchAdapterProtocolChartData>[0]['adapterType'],
+				adapterType,
 				protocol,
-				...(dataType ? { dataType: dataType as Parameters<typeof fetchAdapterProtocolChartData>[0]['dataType'] } : {})
+				...(validatedDataType ? { dataType: validatedDataType } : {})
 			})
+			setSuccessCacheHeaders(res)
 			return res.status(200).json(data)
 		}
 
@@ -66,6 +99,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 			const breakdownType = getQueryParam(req.query.breakdownType)
 
 			if (!protocol) {
+				setNoStoreHeaders(res)
 				return res.status(400).json({ error: 'protocol parameter is required' })
 			}
 
@@ -82,22 +116,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
 			const data =
 				kind === 'tvl' ? await fetchProtocolTvlChart(chartParams) : await fetchProtocolTreasuryChart(chartParams)
+			setSuccessCacheHeaders(res)
 			return res.status(200).json(data)
 		}
 
 		if (kind === 'token-liquidity') {
 			const protocolId = getQueryParam(req.query.protocolId)
 			if (!protocolId) {
+				setNoStoreHeaders(res)
 				return res.status(400).json({ error: 'protocolId parameter is required' })
 			}
 
 			const data = await fetchProtocolTokenLiquidityChart(protocolId)
+			setSuccessCacheHeaders(res)
 			return res.status(200).json(data)
 		}
 
 		if (kind === 'median-apy') {
 			const protocol = getQueryParam(req.query.protocol)
 			if (!protocol) {
+				setNoStoreHeaders(res)
 				return res.status(400).json({ error: 'protocol parameter is required' })
 			}
 
@@ -112,14 +150,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 							}))
 						: null
 				)
-				.catch(() => [])
+				.catch(() => null)
 
+			if (data === null) {
+				setNoStoreHeaders(res)
+				return res.status(200).json(null)
+			}
+
+			setSuccessCacheHeaders(res)
 			return res.status(200).json(data)
 		}
 
 		if (kind === 'unlocks') {
 			const protocol = getQueryParam(req.query.protocol)
 			if (!protocol) {
+				setNoStoreHeaders(res)
 				return res.status(400).json({ error: 'protocol parameter is required' })
 			}
 
@@ -139,12 +184,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 					: null
 			}
 
+			setSuccessCacheHeaders(res)
 			return res.status(200).json(data)
 		}
 
 		if (kind === 'bridge-volume') {
 			const protocol = getQueryParam(req.query.protocol)
 			if (!protocol) {
+				setNoStoreHeaders(res)
 				return res.status(400).json({ error: 'protocol parameter is required' })
 			}
 
@@ -152,32 +199,48 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 				.then((response) => normalizeBridgeVolumeToChartMs(response.dailyVolumes))
 				.catch(() => null)
 
+			if (data === null) {
+				setNoStoreHeaders(res)
+				return res.status(200).json(null)
+			}
+
+			setSuccessCacheHeaders(res)
 			return res.status(200).json(data)
 		}
 
 		if (kind === 'oracle-chart') {
 			const protocol = getQueryParam(req.query.protocol)
 			if (!protocol) {
+				setNoStoreHeaders(res)
 				return res.status(400).json({ error: 'protocol parameter is required' })
 			}
 
 			const data = await fetchOracleProtocolChart({ protocol }).catch(() => null)
+			if (data === null) {
+				setNoStoreHeaders(res)
+				return res.status(200).json(null)
+			}
+
+			setSuccessCacheHeaders(res)
 			return res.status(200).json(data)
 		}
 
 		if (kind === 'governance') {
-			const apis = parseStringArrayParam(getQueryParam(req.query.apis))
+			const apis = getArrayBodyParam(req.body?.apis) ?? parseStringArrayParam(getQueryParam(req.query.apis))
 			if (!apis || apis.length === 0) {
+				setNoStoreHeaders(res)
 				return res.status(400).json({ error: 'apis parameter is required' })
 			}
 
 			const data = await fetchAndFormatGovernanceData(apis)
+			setSuccessCacheHeaders(res)
 			return res.status(200).json(data)
 		}
 
 		if (kind === 'nft-volume') {
 			const protocol = getQueryParam(req.query.protocol)
 			if (!protocol) {
+				setNoStoreHeaders(res)
 				return res.status(400).json({ error: 'protocol parameter is required' })
 			}
 
@@ -187,14 +250,22 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 						.filter((item) => slug(item.exchangeName) === slug(protocol))
 						.map(({ day, sumUsd }): [number, number] => [new Date(day).getTime(), sumUsd])
 				)
-				.catch((): Array<[number, number]> => [])
+				.catch((): null => null)
 
+			if (data === null) {
+				setNoStoreHeaders(res)
+				return res.status(200).json(null)
+			}
+
+			setSuccessCacheHeaders(res)
 			return res.status(200).json(data)
 		}
 
+		setNoStoreHeaders(res)
 		return res.status(400).json({ error: `Unsupported kind: ${kind}` })
 	} catch (error) {
-		console.log('Failed to fetch protocol chart data', error)
+		setNoStoreHeaders(res)
+		console.error('Failed to fetch protocol chart data', error)
 		return res.status(500).json({ error: 'Failed to load protocol chart data' })
 	}
 }

--- a/src/pages/api/charts/protocol.ts
+++ b/src/pages/api/charts/protocol.ts
@@ -1,0 +1,200 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { fetchProtocolTokenLiquidityChart } from '~/api'
+import { YIELD_PROJECT_MEDIAN_API } from '~/constants'
+import { fetchBridgeVolumeBySlug } from '~/containers/Bridges/api'
+import { fetchAdapterProtocolChartData } from '~/containers/DimensionAdapters/api'
+import { fetchAndFormatGovernanceData } from '~/containers/Governance/queries.client'
+import { fetchNftMarketplaceVolumes } from '~/containers/Nft/api'
+import { fetchOracleProtocolChart } from '~/containers/Oracles/api'
+import { fetchProtocolTreasuryChart, fetchProtocolTvlChart } from '~/containers/ProtocolOverview/api'
+import { normalizeBridgeVolumeToChartMs } from '~/containers/ProtocolOverview/chartSeries.utils'
+import { getProtocolEmissionsCharts } from '~/containers/Unlocks/queries'
+import { slug } from '~/utils'
+import { fetchJson } from '~/utils/async'
+
+type ResponseData = unknown[] | Record<string, unknown> | { error: string } | null
+
+const getQueryParam = (value: string | string[] | undefined): string | undefined =>
+	Array.isArray(value) ? value[0] : value
+
+const parseStringArrayParam = (value: string | undefined): string[] | null => {
+	if (!value) return null
+
+	try {
+		const parsed = JSON.parse(value) as unknown
+		return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : null
+	} catch {
+		return null
+	}
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<ResponseData>) {
+	if (req.method !== 'GET') {
+		res.setHeader('Allow', ['GET'])
+		return res.status(405).json({ error: 'Method Not Allowed' })
+	}
+
+	const kind = getQueryParam(req.query.kind)
+	if (!kind) {
+		return res.status(400).json({ error: 'kind parameter is required' })
+	}
+
+	try {
+		res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=600')
+
+		if (kind === 'adapter') {
+			const adapterType = getQueryParam(req.query.adapterType)
+			const protocol = getQueryParam(req.query.protocol)
+			const dataType = getQueryParam(req.query.dataType)
+
+			if (!adapterType || !protocol) {
+				return res.status(400).json({ error: 'adapterType and protocol parameters are required' })
+			}
+
+			const data = await fetchAdapterProtocolChartData({
+				adapterType: adapterType as Parameters<typeof fetchAdapterProtocolChartData>[0]['adapterType'],
+				protocol,
+				...(dataType ? { dataType: dataType as Parameters<typeof fetchAdapterProtocolChartData>[0]['dataType'] } : {})
+			})
+			return res.status(200).json(data)
+		}
+
+		if (kind === 'tvl' || kind === 'treasury') {
+			const protocol = getQueryParam(req.query.protocol)
+			const key = getQueryParam(req.query.key)
+			const currency = getQueryParam(req.query.currency)
+			const breakdownType = getQueryParam(req.query.breakdownType)
+
+			if (!protocol) {
+				return res.status(400).json({ error: 'protocol parameter is required' })
+			}
+
+			const chartParams = {
+				protocol,
+				...(key ? { key } : {}),
+				...(currency ? { currency } : {}),
+				...(breakdownType
+					? {
+							breakdownType: breakdownType as NonNullable<Parameters<typeof fetchProtocolTvlChart>[0]['breakdownType']>
+						}
+					: {})
+			}
+
+			const data =
+				kind === 'tvl' ? await fetchProtocolTvlChart(chartParams) : await fetchProtocolTreasuryChart(chartParams)
+			return res.status(200).json(data)
+		}
+
+		if (kind === 'token-liquidity') {
+			const protocolId = getQueryParam(req.query.protocolId)
+			if (!protocolId) {
+				return res.status(400).json({ error: 'protocolId parameter is required' })
+			}
+
+			const data = await fetchProtocolTokenLiquidityChart(protocolId)
+			return res.status(200).json(data)
+		}
+
+		if (kind === 'median-apy') {
+			const protocol = getQueryParam(req.query.protocol)
+			if (!protocol) {
+				return res.status(400).json({ error: 'protocol parameter is required' })
+			}
+
+			const data = await fetchJson<{ data: Array<{ timestamp: string; medianAPY: number; [key: string]: unknown }> }>(
+				`${YIELD_PROJECT_MEDIAN_API}/${protocol}`
+			)
+				.then((values) =>
+					values && values.data.length > 0
+						? values.data.map((item) => ({
+								...item,
+								date: Math.floor(new Date(item.timestamp).getTime() / 1000)
+							}))
+						: null
+				)
+				.catch(() => [])
+
+			return res.status(200).json(data)
+		}
+
+		if (kind === 'unlocks') {
+			const protocol = getQueryParam(req.query.protocol)
+			if (!protocol) {
+				return res.status(400).json({ error: 'protocol parameter is required' })
+			}
+
+			const result = await getProtocolEmissionsCharts(slug(protocol))
+			const data = {
+				...result,
+				unlockUsdChart: Array.isArray(result.unlockUsdChart)
+					? result.unlockUsdChart
+							.filter(
+								(item): item is [string | number, string | number] =>
+									Array.isArray(item) &&
+									item.length >= 2 &&
+									Number.isFinite(Number(item[0])) &&
+									Number.isFinite(Number(item[1]))
+							)
+							.map((item): [number, number] => [Number(item[0]), Number(item[1])])
+					: null
+			}
+
+			return res.status(200).json(data)
+		}
+
+		if (kind === 'bridge-volume') {
+			const protocol = getQueryParam(req.query.protocol)
+			if (!protocol) {
+				return res.status(400).json({ error: 'protocol parameter is required' })
+			}
+
+			const data = await fetchBridgeVolumeBySlug(slug(protocol))
+				.then((response) => normalizeBridgeVolumeToChartMs(response.dailyVolumes))
+				.catch(() => null)
+
+			return res.status(200).json(data)
+		}
+
+		if (kind === 'oracle-chart') {
+			const protocol = getQueryParam(req.query.protocol)
+			if (!protocol) {
+				return res.status(400).json({ error: 'protocol parameter is required' })
+			}
+
+			const data = await fetchOracleProtocolChart({ protocol }).catch(() => null)
+			return res.status(200).json(data)
+		}
+
+		if (kind === 'governance') {
+			const apis = parseStringArrayParam(getQueryParam(req.query.apis))
+			if (!apis || apis.length === 0) {
+				return res.status(400).json({ error: 'apis parameter is required' })
+			}
+
+			const data = await fetchAndFormatGovernanceData(apis)
+			return res.status(200).json(data)
+		}
+
+		if (kind === 'nft-volume') {
+			const protocol = getQueryParam(req.query.protocol)
+			if (!protocol) {
+				return res.status(400).json({ error: 'protocol parameter is required' })
+			}
+
+			const data = await fetchNftMarketplaceVolumes()
+				.then((response) =>
+					response
+						.filter((item) => slug(item.exchangeName) === slug(protocol))
+						.map(({ day, sumUsd }): [number, number] => [new Date(day).getTime(), sumUsd])
+				)
+				.catch((): Array<[number, number]> => [])
+
+			return res.status(200).json(data)
+		}
+
+		return res.status(400).json({ error: `Unsupported kind: ${kind}` })
+	} catch (error) {
+		console.log('Failed to fetch protocol chart data', error)
+		return res.status(500).json({ error: 'Failed to load protocol chart data' })
+	}
+}

--- a/src/pages/protocol/treasury/[protocol].tsx
+++ b/src/pages/protocol/treasury/[protocol].tsx
@@ -9,10 +9,7 @@ import { SelectWithCombobox } from '~/components/Select/SelectWithCombobox'
 import { Switch } from '~/components/Switch'
 import { TokenLogo } from '~/components/TokenLogo'
 import { SKIP_BUILD_STATIC_GENERATION } from '~/constants'
-import {
-	fetchProtocolOverviewMetrics,
-	fetchProtocolTreasuryTokenBreakdownChart
-} from '~/containers/ProtocolOverview/api'
+import { fetchProtocolOverviewMetrics } from '~/containers/ProtocolOverview/api'
 import { ProtocolOverviewLayout } from '~/containers/ProtocolOverview/Layout'
 import { getProtocolMetricFlags } from '~/containers/ProtocolOverview/queries'
 import type { IProtocolPageMetrics } from '~/containers/ProtocolOverview/types'
@@ -20,6 +17,7 @@ import { useProtocolBreakdownCharts } from '~/containers/ProtocolOverview/usePro
 import { getProtocolWarningBanners } from '~/containers/ProtocolOverview/utils'
 import { useGetChartInstance } from '~/hooks/useGetChartInstance'
 import { slug } from '~/utils'
+import { fetchJson } from '~/utils/async'
 import { maxAgeForNext } from '~/utils/maxAgeForNext'
 import type { IProtocolMetadata } from '~/utils/metadata/types'
 import { withPerformanceLogging } from '~/utils/perf'
@@ -284,7 +282,10 @@ export default function Protocols(props: TreasuryPageProps) {
 
 	const { data: ownTokensBreakdown } = useQuery({
 		queryKey: ['protocol-overview', 'treasury-own-tokens', protocol],
-		queryFn: () => fetchProtocolTreasuryTokenBreakdownChart({ protocol, key: 'OwnTokens' }),
+		queryFn: () =>
+			fetchJson(
+				`/api/charts/protocol?kind=treasury&protocol=${encodeURIComponent(protocol)}&key=${encodeURIComponent('OwnTokens')}&breakdownType=${encodeURIComponent('token-breakdown')}`
+			),
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 0,


### PR DESCRIPTION
## Summary
- add Next API chart endpoints for chain, protocol, and CoinGecko-backed client chart requests
- switch home, `/chain/:chain`, and protocol chart fetchers to same-origin `/api/*` routes, including the chain stablecoin chart path
- include the formatter-only cleanup in `src/containers/Downloads/MultiMetricModal.tsx` produced by `bun run format`

## Testing
- bun run format
- bun run lint
- bun run ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified chart data backend into centralized endpoints for protocol, chain, and coingecko charts; client queries updated to use these endpoints for consistent charting across bridges, protocols, governance, stablecoins, and token pages.

* **Bug Fixes**
  * More consistent error handling and caching behavior for chart requests; some chart fallbacks now return null instead of empty arrays for clearer UI handling.

* **Chores**
  * Minor formatting and test tweaks; no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->