### PR TITLE
Refactor protocol category metric configs

### DIFF
--- a/public/pages.json
+++ b/public/pages.json
@@ -494,6 +494,12 @@
       ]
     },
     {
+      "name": "RWA by Chain",
+      "route": "/rwa/chains",
+      "category": "RWA",
+      "description": "Overview of all Real World Assets (RWAs) by chain"
+    },
+    {
       "name": "RWA: Perps",
       "route": "/rwa/perps",
       "category": "RWA",
@@ -501,12 +507,6 @@
       "tags": [
         "New"
       ]
-    },
-    {
-      "name": "RWA by Chain",
-      "route": "/rwa/chains",
-      "category": "RWA",
-      "description": "Overview of all Real World Assets (RWAs) by chain"
     },
     {
       "name": "RWA by Category",

--- a/src/containers/Downloads/MultiMetricModal.tsx
+++ b/src/containers/Downloads/MultiMetricModal.tsx
@@ -1,6 +1,6 @@
-import Link from 'next/link'
 import * as Ariakit from '@ariakit/react'
 import { useQueries } from '@tanstack/react-query'
+import Link from 'next/link'
 import { lazy, Suspense, useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react'
 import { toast } from 'react-hot-toast'
 import { Icon, type IIcon } from '~/components/Icon'
@@ -654,12 +654,20 @@ function CenteredHint({ icon, text }: { icon: IIcon['name']; text: string }) {
 	)
 }
 
-function PreviewTable({ parsed, isPreview }: { parsed: { headers: string[]; rows: ParsedCsvRow[] }; isPreview: boolean }) {
+function PreviewTable({
+	parsed,
+	isPreview
+}: {
+	parsed: { headers: string[]; rows: ParsedCsvRow[] }
+	isPreview: boolean
+}) {
 	const { headers, rows } = parsed
 	const display = rows.slice(0, PREVIEW_ROWS)
 	const filler = isPreview && display.length > 0 ? [...display, ...display] : []
 	return (
-		<div className={`relative thin-scrollbar min-h-0 flex-1 ${isPreview ? 'overflow-x-auto overflow-y-hidden' : 'overflow-auto'}`}>
+		<div
+			className={`relative thin-scrollbar min-h-0 flex-1 ${isPreview ? 'overflow-x-auto overflow-y-hidden' : 'overflow-auto'}`}
+		>
 			<table className="w-full text-xs">
 				<thead className="sticky top-0 z-10 bg-(--cards-bg)">
 					<tr>

--- a/src/containers/ProtocolsByCategoryOrTag/constants.test.ts
+++ b/src/containers/ProtocolsByCategoryOrTag/constants.test.ts
@@ -1,35 +1,211 @@
 import { describe, expect, it } from 'vitest'
+import type { ICategoriesAndTags } from '~/utils/metadata/types'
 import {
+	getProtocolCategoryCapabilities,
 	getProtocolCategoryChartMetricLabel,
 	getProtocolCategoryChartMetrics,
 	getProtocolCategoryColumns,
 	getProtocolCategoryDefaultSort,
 	getProtocolCategoryDexVolumeLabel,
-	protocolCategoryConfig
+	protocolCategoryConfig,
+	resolveProtocolCategoryDataConfig
 } from './constants'
 
+const categoriesAndTags: ICategoriesAndTags = {
+	categories: ['Dexs', 'RWA'],
+	tags: ['StableSwap', 'Carbon Credits'],
+	tagCategoryMap: {
+		StableSwap: 'Dexs',
+		'Carbon Credits': 'RWA'
+	},
+	configs: {
+		Dexs: {
+			category: 'Dexs',
+			chains: ['ethereum'],
+			slug: 'dexs',
+			fees: true,
+			revenue: true,
+			dexs: true
+		},
+		StableSwap: {
+			category: 'StableSwap',
+			chains: ['ethereum'],
+			slug: 'stableswap',
+			fees: true,
+			revenue: true
+		},
+		RWA: {
+			category: 'RWA',
+			chains: ['ethereum'],
+			slug: 'rwa',
+			fees: true
+		},
+		Interface: {
+			category: 'Interface',
+			chains: ['ethereum'],
+			slug: 'interface',
+			fees: true,
+			revenue: true,
+			dexs: true,
+			dexAggregators: true,
+			perps: true,
+			perpsAggregators: true,
+			bridgeAggregators: true,
+			normalizedVolume: true,
+			openInterest: true
+		},
+		Options: {
+			category: 'Options',
+			chains: ['ethereum'],
+			slug: 'options',
+			optionsPremiumVolume: true,
+			optionsNotionalVolume: true
+		},
+		'Partially Algorithmic Stablecoin': {
+			category: 'Partially Algorithmic Stablecoin',
+			chains: ['ethereum'],
+			slug: 'partially-algorithmic-stablecoin',
+			dimAgg: {
+				'aggregator-derivatives': {
+					dv: { '24h': 1, '7d': 2, '30d': 3 }
+				}
+			}
+		}
+	}
+}
+
 describe('ProtocolsByCategoryOrTag constants', () => {
-	it('keeps Interface perp-first while enabling dex volume columns and metrics', () => {
+	it('resolves direct tag config before parent category config', () => {
+		const dataConfig = resolveProtocolCategoryDataConfig({
+			categoriesAndTags,
+			tag: 'StableSwap',
+			tagCategory: 'Dexs'
+		})
+
+		expect(dataConfig?.category).toBe('StableSwap')
+
+		const capabilities = getProtocolCategoryCapabilities({
+			dataConfig,
+			effectiveCategory: 'Dexs'
+		})
+
+		expect(capabilities.dexVolume).toBe(false)
+		expect(capabilities.fees).toBe(true)
+		expect(capabilities.revenue).toBe(true)
+	})
+
+	it('falls back to the parent category config when the tag has no direct config', () => {
+		const dataConfig = resolveProtocolCategoryDataConfig({
+			categoriesAndTags,
+			tag: 'Carbon Credits',
+			tagCategory: 'RWA'
+		})
+
+		expect(dataConfig?.category).toBe('RWA')
+	})
+
+	it('derives columns and chart metrics from resolved capabilities', () => {
 		expect(protocolCategoryConfig.Interface?.defaultChart).toBe('perpVolume')
-		expect(getProtocolCategoryChartMetrics('Interface')).toEqual(['tvl', 'dexVolume', 'perpVolume'])
-		expect(getProtocolCategoryColumns('Interface')).toEqual([
-			'name',
-			'perp_volume_24h',
-			'spot_volume_24h',
-			'perp_volume_7d',
-			'spot_volume_7d',
-			'perp_volume_30d',
-			'spot_volume_30d',
+
+		const capabilities = getProtocolCategoryCapabilities({
+			dataConfig: categoriesAndTags.configs.Interface,
+			effectiveCategory: 'Interface'
+		})
+
+		expect(getProtocolCategoryChartMetrics(capabilities)).toEqual([
 			'tvl',
-			'fees_7d',
-			'revenue_7d',
-			'mcap/tvl',
+			'dexVolume',
+			'dexAggregatorsVolume',
+			'perpVolume',
+			'perpsAggregatorsVolume',
+			'bridgeAggregatorsVolume',
+			'normalizedVolume',
+			'openInterest'
+		])
+		expect(
+			getProtocolCategoryColumns({
+				effectiveCategory: 'Interface',
+				metrics: capabilities
+			})
+		).toEqual([
+			'name',
+			'tvl',
+			'perp_volume_30d',
+			'perp_aggregator_volume_30d',
+			'bridge_aggregator_volume_30d',
+			'normalized_volume_30d',
+			'dex_aggregator_volume_30d',
+			'spot_volume_30d',
 			'fees_30d',
 			'revenue_30d',
+			'openInterest',
+			'perp_volume_7d',
+			'perp_aggregator_volume_7d',
+			'bridge_aggregator_volume_7d',
+			'normalized_volume_7d',
+			'dex_aggregator_volume_7d',
+			'spot_volume_7d',
+			'fees_7d',
+			'revenue_7d',
+			'perp_volume_24h',
+			'perp_aggregator_volume_24h',
+			'bridge_aggregator_volume_24h',
+			'normalized_volume_24h',
+			'dex_aggregator_volume_24h',
+			'spot_volume_24h',
 			'fees_24h',
-			'revenue_24h'
+			'revenue_24h',
+			'mcap/tvl'
 		])
-		expect(getProtocolCategoryDefaultSort('Interface')).toBe('perp_volume_24h')
+		expect(
+			getProtocolCategoryDefaultSort({
+				effectiveCategory: 'Interface',
+				metrics: capabilities
+			})
+		).toBe('perp_volume_24h')
+	})
+
+	it('falls back to the first visible derived metric column when no sort override exists', () => {
+		const capabilities = getProtocolCategoryCapabilities({
+			dataConfig: categoriesAndTags.configs.Dexs,
+			effectiveCategory: 'Dexs'
+		})
+
+		expect(
+			getProtocolCategoryDefaultSort({
+				effectiveCategory: 'Dexs',
+				metrics: capabilities
+			})
+		).toBe('dex_volume_7d')
+	})
+
+	it('prefers cache-driven options capabilities before legacy category fallback', () => {
+		const capabilities = getProtocolCategoryCapabilities({
+			dataConfig: categoriesAndTags.configs.Options,
+			effectiveCategory: 'Options'
+		})
+
+		expect(capabilities.optionsPremiumVolume).toBe(true)
+		expect(capabilities.optionsNotionalVolume).toBe(true)
+	})
+
+	it('detects perp aggregators from dimAgg when the top-level flag is absent', () => {
+		const capabilities = getProtocolCategoryCapabilities({
+			dataConfig: categoriesAndTags.configs['Partially Algorithmic Stablecoin'],
+			effectiveCategory: 'Partially Algorithmic Stablecoin'
+		})
+
+		expect(capabilities.perpsAggregatorsVolume).toBe(true)
+	})
+
+	it('keeps legacy-only options capabilities without reading config dimAgg', () => {
+		const capabilities = getProtocolCategoryCapabilities({
+			dataConfig: null,
+			effectiveCategory: 'Options'
+		})
+
+		expect(capabilities.optionsPremiumVolume).toBe(true)
+		expect(capabilities.optionsNotionalVolume).toBe(true)
 	})
 
 	it('resolves category-aware dex volume labels for chart and table surfaces', () => {
@@ -39,5 +215,8 @@ describe('ProtocolsByCategoryOrTag constants', () => {
 		expect(getProtocolCategoryDexVolumeLabel('Crypto Card Issuer')).toBe('Payment Volume')
 		expect(getProtocolCategoryDexVolumeLabel('Interface')).toBe('Spot Volume')
 		expect(getProtocolCategoryChartMetricLabel('dexVolume', 'Interface')).toBe('Spot Volume')
+		expect(getProtocolCategoryChartMetricLabel('perpsAggregatorsVolume', 'Interface')).toBe('Perp Aggregator Volume')
+		expect(getProtocolCategoryChartMetricLabel('bridgeAggregatorsVolume', 'Interface')).toBe('Bridge Aggregator Volume')
+		expect(getProtocolCategoryChartMetricLabel('normalizedVolume', 'Interface')).toBe('Normalized Volume')
 	})
 })

--- a/src/containers/ProtocolsByCategoryOrTag/constants.tsx
+++ b/src/containers/ProtocolsByCategoryOrTag/constants.tsx
@@ -1,11 +1,15 @@
 import type { ProtocolChartsQueryParams } from '~/containers/ProtocolOverview/constants'
 import { capitalizeFirstLetter } from '~/utils'
+import type { ICategoriesAndTags, ICategoriesAndTagsConfig } from '~/utils/metadata/types'
 
 export type ProtocolCategoryChartMetric =
 	| 'tvl'
 	| 'dexVolume'
 	| 'dexAggregatorsVolume'
 	| 'perpVolume'
+	| 'perpsAggregatorsVolume'
+	| 'bridgeAggregatorsVolume'
+	| 'normalizedVolume'
 	| 'openInterest'
 	| 'optionsPremiumVolume'
 	| 'optionsNotionalVolume'
@@ -14,9 +18,14 @@ export type ProtocolCategoryChartMetric =
 
 export interface ProtocolCategoryMetrics {
 	tvl?: boolean
+	fees?: boolean
+	revenue?: boolean
 	dexVolume?: boolean
 	dexAggregatorsVolume?: boolean
 	perpVolume?: boolean
+	perpsAggregatorsVolume?: boolean
+	bridgeAggregatorsVolume?: boolean
+	normalizedVolume?: boolean
 	openInterest?: boolean
 	optionsPremiumVolume?: boolean
 	optionsNotionalVolume?: boolean
@@ -33,22 +42,8 @@ export interface ProtocolCategoryConfig {
 	seoTitleSuffix?: string
 	tableHeader?: string
 	searchPlaceholder?: string
-	metrics?: ProtocolCategoryMetrics
-	columns?: string[]
 	defaultSort?: string
 }
-
-const DEFAULT_COLUMNS = [
-	'name',
-	'tvl',
-	'fees_7d',
-	'revenue_7d',
-	'mcap/tvl',
-	'fees_30d',
-	'revenue_30d',
-	'fees_24h',
-	'revenue_24h'
-]
 
 const DEFAULT_DEX_VOLUME_LABEL = 'DEX Volume'
 
@@ -64,23 +59,7 @@ export const protocolCategoryConfig: Record<string, ProtocolCategoryConfig> = {
 	Dexs: {
 		description: 'Protocols where you can swap/trade cryptocurrency',
 		defaultChart: 'dexVolume',
-		seoBaseTitle: 'Crypto DEX Protocols - Volume, TVL, Fees, & Revenue',
-		metrics: { dexVolume: true },
-		columns: [
-			'name',
-			'tvl',
-			'dex_volume_7d',
-			'fees_7d',
-			'revenue_7d',
-			'mcap/tvl',
-			'dex_volume_30d',
-			'fees_30d',
-			'revenue_30d',
-			'dex_volume_24h',
-			'fees_24h',
-			'revenue_24h'
-		],
-		defaultSort: 'prediction_volume_7d'
+		seoBaseTitle: 'Crypto DEX Protocols - Volume, TVL, Fees, & Revenue'
 	},
 	Yield: {
 		description: 'Protocols that pay you a reward for your staking/LP on their platform',
@@ -88,22 +67,7 @@ export const protocolCategoryConfig: Record<string, ProtocolCategoryConfig> = {
 	},
 	Lending: {
 		description: 'Protocols that allow users to borrow and lend assets',
-		seoBaseTitle: 'DeFi Lending Protocols - TVL, Fees, & Revenue',
-		metrics: { borrowed: true },
-		columns: [
-			'name',
-			'tvl',
-			'fees_7d',
-			'revenue_7d',
-			'mcap/tvl',
-			'fees_30d',
-			'revenue_30d',
-			'fees_24h',
-			'revenue_24h',
-			'borrowed',
-			'supplied',
-			'supplied/tvl'
-		]
+		seoBaseTitle: 'DeFi Lending Protocols - TVL, Fees, & Revenue'
 	},
 	'Cross Chain Bridge': {
 		description:
@@ -133,22 +97,6 @@ export const protocolCategoryConfig: Record<string, ProtocolCategoryConfig> = {
 		description: 'Protocols for betting with leverage',
 		defaultChart: 'perpVolume',
 		seoBaseTitle: 'Crypto Derivatives Protocols - Volume, Fees, & Revenue',
-		metrics: { perpVolume: true, openInterest: true },
-		columns: [
-			'name',
-			'perp_volume_24h',
-			'openInterest',
-			'perp_volume_7d',
-			'perp_volume_30d',
-			'tvl',
-			'fees_7d',
-			'revenue_7d',
-			'mcap/tvl',
-			'fees_30d',
-			'revenue_30d',
-			'fees_24h',
-			'revenue_24h'
-		],
 		defaultSort: 'perp_volume_24h'
 	},
 	Payments: {
@@ -192,24 +140,6 @@ export const protocolCategoryConfig: Record<string, ProtocolCategoryConfig> = {
 		description: 'Protocols that give you the right to buy an asset at a fixed price',
 		defaultChart: 'optionsPremiumVolume',
 		seoBaseTitle: 'DeFi Options Protocols - TVL, Volume, Fees, & Revenue',
-		metrics: { optionsPremiumVolume: true, optionsNotionalVolume: true },
-		columns: [
-			'name',
-			'tvl',
-			'options_premium_7d',
-			'options_notional_7d',
-			'fees_7d',
-			'revenue_7d',
-			'mcap/tvl',
-			'options_premium_30d',
-			'options_notional_30d',
-			'fees_30d',
-			'revenue_30d',
-			'options_premium_24h',
-			'options_notional_24h',
-			'fees_24h',
-			'revenue_24h'
-		],
 		defaultSort: 'options_premium_7d'
 	},
 	Launchpad: {
@@ -226,27 +156,12 @@ export const protocolCategoryConfig: Record<string, ProtocolCategoryConfig> = {
 	'Prediction Market': {
 		description: 'Protocols that allow you to wager/bet/buy in future results',
 		defaultChart: 'dexVolume',
-		metrics: { dexVolume: true },
 		headingLabel: 'Prediction Markets',
 		seoLabel: 'Prediction Markets',
 		seoBaseTitle: 'Top Crypto Prediction Markets - TVL, Volume, & Revenue',
 		seoTitleSuffix: 'Rankings',
 		tableHeader: 'Market Rankings',
 		searchPlaceholder: 'Search markets...',
-		columns: [
-			'name',
-			'tvl',
-			'prediction_volume_7d',
-			'fees_7d',
-			'revenue_7d',
-			'mcap/tvl',
-			'prediction_volume_30d',
-			'fees_30d',
-			'revenue_30d',
-			'prediction_volume_24h',
-			'fees_24h',
-			'revenue_24h'
-		],
 		defaultSort: 'prediction_volume_7d'
 	},
 	'Algo-Stables': { description: 'Protocols that provide algorithmic coins to stablecoins' },
@@ -282,8 +197,7 @@ export const protocolCategoryConfig: Record<string, ProtocolCategoryConfig> = {
 	'Liquid Staking': {
 		description:
 			'Protocols that enable you to earn staking rewards on your tokens while also providing a tradeable and liquid receipt for your staked position',
-		seoBaseTitle: 'Liquid Staking Protocols - TVL, Fees, & Revenue',
-		metrics: { staking: true }
+		seoBaseTitle: 'Liquid Staking Protocols - TVL, Fees, & Revenue'
 	},
 	Oracle: {
 		description: 'Protocols that connect data from the outside world (off-chain) with the blockchain world (Onchain)',
@@ -335,21 +249,6 @@ export const protocolCategoryConfig: Record<string, ProtocolCategoryConfig> = {
 		seoLabel: 'DEX Aggregators',
 		seoBaseTitle: 'Crypto DEX Aggregator Protocols - Volume, TVL, & Fees',
 		searchPlaceholder: 'Search DEX aggregators...',
-		metrics: { dexAggregatorsVolume: true },
-		columns: [
-			'name',
-			'tvl',
-			'dex_aggregator_volume_7d',
-			'fees_7d',
-			'revenue_7d',
-			'mcap/tvl',
-			'dex_aggregator_volume_30d',
-			'fees_30d',
-			'revenue_30d',
-			'dex_aggregator_volume_24h',
-			'fees_24h',
-			'revenue_24h'
-		],
 		defaultSort: 'dex_aggregator_volume_7d'
 	},
 	Restaking: {
@@ -593,24 +492,6 @@ export const protocolCategoryConfig: Record<string, ProtocolCategoryConfig> = {
 	Interface: {
 		description: 'Projects that provide a user interface to interact with external protocols',
 		defaultChart: 'perpVolume',
-		metrics: { perpVolume: true, dexVolume: true },
-		columns: [
-			'name',
-			'perp_volume_24h',
-			'spot_volume_24h',
-			'perp_volume_7d',
-			'spot_volume_7d',
-			'perp_volume_30d',
-			'spot_volume_30d',
-			'tvl',
-			'fees_7d',
-			'revenue_7d',
-			'mcap/tvl',
-			'fees_30d',
-			'revenue_30d',
-			'fees_24h',
-			'revenue_24h'
-		],
 		defaultSort: 'perp_volume_24h'
 	},
 	'Video Infrastructure': {
@@ -666,26 +547,11 @@ export const protocolCategoryConfig: Record<string, ProtocolCategoryConfig> = {
 	'Crypto Card Issuer': {
 		description:
 			'Protocols that issue crypto-linked debit or credit cards for spending through traditional payment networks',
-		metrics: { dexVolume: true },
 		headingLabel: 'Crypto Card Issuers',
 		seoLabel: 'Crypto Card Issuers',
 		seoTitleSuffix: 'Rankings',
 		tableHeader: 'Issuer Rankings',
 		searchPlaceholder: 'Search Issuers...',
-		columns: [
-			'name',
-			'tvl',
-			'payment_volume_7d',
-			'fees_7d',
-			'revenue_7d',
-			'mcap/tvl',
-			'payment_volume_30d',
-			'fees_30d',
-			'revenue_30d',
-			'payment_volume_24h',
-			'fees_24h',
-			'revenue_24h'
-		],
 		defaultSort: 'payment_volume_7d'
 	}
 }
@@ -715,6 +581,12 @@ export function getProtocolCategoryChartMetricLabel(
 			return 'DEX Aggregator Volume'
 		case 'perpVolume':
 			return 'Perp Volume'
+		case 'perpsAggregatorsVolume':
+			return 'Perp Aggregator Volume'
+		case 'bridgeAggregatorsVolume':
+			return 'Bridge Aggregator Volume'
+		case 'normalizedVolume':
+			return 'Normalized Volume'
 		case 'openInterest':
 			return 'Open Interest'
 		case 'optionsPremiumVolume':
@@ -729,6 +601,112 @@ export function getProtocolCategoryChartMetricLabel(
 }
 
 export const categoriesPageExcludedExtraTvls = new Set<string>(['doublecounted', 'liquidstaking'])
+
+const LEGACY_CATEGORY_CAPABILITIES: Record<string, Partial<ProtocolCategoryMetrics>> = {
+	Lending: { borrowed: true },
+	'Liquid Staking': { staking: true },
+	Options: { optionsPremiumVolume: true, optionsNotionalVolume: true }
+}
+
+const DEFAULT_DEX_COLUMN_IDS = ['dex_volume_7d', 'dex_volume_30d', 'dex_volume_24h']
+
+const DEX_COLUMN_IDS_BY_CATEGORY: Record<string, string[]> = {
+	'DEX Aggregator': ['dex_aggregator_volume_7d', 'dex_aggregator_volume_30d', 'dex_aggregator_volume_24h'],
+	'Prediction Market': ['prediction_volume_7d', 'prediction_volume_30d', 'prediction_volume_24h'],
+	'Crypto Card Issuer': ['payment_volume_7d', 'payment_volume_30d', 'payment_volume_24h'],
+	Interface: ['spot_volume_7d', 'spot_volume_30d', 'spot_volume_24h']
+}
+
+type TimedMetricColumnGroups = {
+	'30d': string[]
+	'7d': string[]
+	'24h': string[]
+}
+
+const EMPTY_TIMED_METRIC_COLUMN_GROUPS: TimedMetricColumnGroups = {
+	'30d': [],
+	'7d': [],
+	'24h': []
+}
+
+const groupTimedColumns = (columns: string[]): TimedMetricColumnGroups => {
+	return columns.reduce<TimedMetricColumnGroups>(
+		(acc, columnId) => {
+			if (columnId.endsWith('_30d')) acc['30d'].push(columnId)
+			if (columnId.endsWith('_7d')) acc['7d'].push(columnId)
+			if (columnId.endsWith('_24h')) acc['24h'].push(columnId)
+			return acc
+		},
+		{
+			'30d': [],
+			'7d': [],
+			'24h': []
+		}
+	)
+}
+
+const DEFAULT_SORT_PRIORITY = [
+	'perp_aggregator_volume_7d',
+	'perp_volume_7d',
+	'bridge_aggregator_volume_7d',
+	'normalized_volume_7d',
+	'dex_aggregator_volume_7d',
+	'spot_volume_7d',
+	'payment_volume_7d',
+	'prediction_volume_7d',
+	'dex_volume_7d',
+	'options_premium_7d',
+	'options_notional_7d',
+	'openInterest',
+	'borrowed',
+	'fees_7d',
+	'revenue_7d',
+	'tvl'
+]
+
+export function resolveProtocolCategoryDataConfig({
+	categoriesAndTags,
+	category,
+	tag,
+	tagCategory
+}: {
+	categoriesAndTags: ICategoriesAndTags
+	category?: string | null
+	tag?: string | null
+	tagCategory?: string | null
+}): ICategoriesAndTagsConfig | null {
+	if (category) return categoriesAndTags.configs[category] ?? null
+	if (!tag) return null
+	return categoriesAndTags.configs[tag] ?? (tagCategory ? (categoriesAndTags.configs[tagCategory] ?? null) : null)
+}
+
+export function getProtocolCategoryCapabilities({
+	dataConfig,
+	effectiveCategory
+}: {
+	dataConfig: ICategoriesAndTagsConfig | null
+	effectiveCategory: string | null
+}): ProtocolCategoryMetrics {
+	const legacyCapabilities = effectiveCategory ? LEGACY_CATEGORY_CAPABILITIES[effectiveCategory] : null
+	const hasPerpsAggregatorsDimAgg = Boolean(dataConfig?.dimAgg?.['aggregator-derivatives'])
+
+	return {
+		tvl: true,
+		fees: dataConfig?.fees ?? false,
+		revenue: dataConfig?.revenue ?? false,
+		dexVolume: dataConfig?.dexs ?? false,
+		dexAggregatorsVolume: dataConfig?.dexAggregators ?? false,
+		perpVolume: dataConfig?.perps ?? false,
+		perpsAggregatorsVolume: dataConfig?.perpsAggregators ?? hasPerpsAggregatorsDimAgg,
+		bridgeAggregatorsVolume: dataConfig?.bridgeAggregators ?? false,
+		normalizedVolume: dataConfig?.normalizedVolume ?? false,
+		openInterest: dataConfig?.openInterest ?? legacyCapabilities?.openInterest ?? false,
+		optionsPremiumVolume: dataConfig?.optionsPremiumVolume ?? legacyCapabilities?.optionsPremiumVolume ?? false,
+		optionsNotionalVolume: dataConfig?.optionsNotionalVolume ?? legacyCapabilities?.optionsNotionalVolume ?? false,
+		borrowed: legacyCapabilities?.borrowed ?? false,
+		staking: legacyCapabilities?.staking ?? false
+	}
+}
 
 export function getProtocolCategoryPresentation({
 	label,
@@ -790,15 +768,18 @@ export function getProtocolCategoryPresentation({
 	}
 }
 
-export function getProtocolCategoryChartMetrics(effectiveCategory: string | null): ProtocolCategoryChartMetric[] {
-	if (!effectiveCategory) return ['tvl']
-	const m = protocolCategoryConfig[effectiveCategory]?.metrics
-	if (!m) return ['tvl']
+export function getProtocolCategoryChartMetrics(
+	metrics?: ProtocolCategoryMetrics | null
+): ProtocolCategoryChartMetric[] {
+	const m = metrics ?? { tvl: true }
 	const result: ProtocolCategoryChartMetric[] = []
 	if (m.tvl !== false) result.push('tvl')
 	if (m.dexVolume) result.push('dexVolume')
 	if (m.dexAggregatorsVolume) result.push('dexAggregatorsVolume')
 	if (m.perpVolume) result.push('perpVolume')
+	if (m.perpsAggregatorsVolume) result.push('perpsAggregatorsVolume')
+	if (m.bridgeAggregatorsVolume) result.push('bridgeAggregatorsVolume')
+	if (m.normalizedVolume) result.push('normalizedVolume')
 	if (m.openInterest) result.push('openInterest')
 	if (m.optionsPremiumVolume) result.push('optionsPremiumVolume')
 	if (m.optionsNotionalVolume) result.push('optionsNotionalVolume')
@@ -807,12 +788,105 @@ export function getProtocolCategoryChartMetrics(effectiveCategory: string | null
 	return result.length > 0 ? result : ['tvl']
 }
 
-export function getProtocolCategoryColumns(effectiveCategory: string | null): string[] {
-	if (!effectiveCategory) return DEFAULT_COLUMNS
-	return protocolCategoryConfig[effectiveCategory]?.columns ?? DEFAULT_COLUMNS
+export function getProtocolCategoryColumns({
+	effectiveCategory,
+	metrics
+}: {
+	effectiveCategory: string | null
+	metrics: ProtocolCategoryMetrics
+}): string[] {
+	const timedMetricGroups: TimedMetricColumnGroups[] = []
+
+	if (metrics.perpVolume) {
+		timedMetricGroups.push(groupTimedColumns(['perp_volume_7d', 'perp_volume_30d', 'perp_volume_24h']))
+	}
+
+	if (metrics.perpsAggregatorsVolume) {
+		timedMetricGroups.push(
+			groupTimedColumns(['perp_aggregator_volume_7d', 'perp_aggregator_volume_30d', 'perp_aggregator_volume_24h'])
+		)
+	}
+
+	if (metrics.bridgeAggregatorsVolume) {
+		timedMetricGroups.push(
+			groupTimedColumns(['bridge_aggregator_volume_7d', 'bridge_aggregator_volume_30d', 'bridge_aggregator_volume_24h'])
+		)
+	}
+
+	if (metrics.normalizedVolume) {
+		timedMetricGroups.push(
+			groupTimedColumns(['normalized_volume_7d', 'normalized_volume_30d', 'normalized_volume_24h'])
+		)
+	}
+
+	if (metrics.dexAggregatorsVolume) {
+		timedMetricGroups.push(
+			groupTimedColumns(['dex_aggregator_volume_7d', 'dex_aggregator_volume_30d', 'dex_aggregator_volume_24h'])
+		)
+	}
+
+	if (metrics.dexVolume) {
+		timedMetricGroups.push(
+			groupTimedColumns(
+				effectiveCategory
+					? (DEX_COLUMN_IDS_BY_CATEGORY[effectiveCategory] ?? DEFAULT_DEX_COLUMN_IDS)
+					: DEFAULT_DEX_COLUMN_IDS
+			)
+		)
+	}
+
+	if (metrics.optionsPremiumVolume) {
+		timedMetricGroups.push(groupTimedColumns(['options_premium_7d', 'options_premium_30d', 'options_premium_24h']))
+	}
+
+	if (metrics.optionsNotionalVolume) {
+		timedMetricGroups.push(groupTimedColumns(['options_notional_7d', 'options_notional_30d', 'options_notional_24h']))
+	}
+
+	if (metrics.fees) {
+		timedMetricGroups.push(groupTimedColumns(['fees_7d', 'fees_30d', 'fees_24h']))
+	}
+
+	if (metrics.revenue) {
+		timedMetricGroups.push(groupTimedColumns(['revenue_7d', 'revenue_30d', 'revenue_24h']))
+	}
+
+	const groupedTimedColumns = timedMetricGroups.reduce<TimedMetricColumnGroups>(
+		(acc, group) => ({
+			'30d': [...acc['30d'], ...group['30d']],
+			'7d': [...acc['7d'], ...group['7d']],
+			'24h': [...acc['24h'], ...group['24h']]
+		}),
+		{ ...EMPTY_TIMED_METRIC_COLUMN_GROUPS }
+	)
+
+	const columnIds = ['name', 'tvl']
+
+	if (metrics.borrowed) {
+		columnIds.push('borrowed', 'supplied', 'supplied/tvl')
+	}
+
+	columnIds.push(...groupedTimedColumns['30d'])
+
+	if (metrics.openInterest) {
+		columnIds.push('openInterest')
+	}
+
+	columnIds.push(...groupedTimedColumns['7d'], ...groupedTimedColumns['24h'], 'mcap/tvl')
+
+	return Array.from(new Set(columnIds))
 }
 
-export function getProtocolCategoryDefaultSort(effectiveCategory: string | null): string {
-	if (!effectiveCategory) return 'tvl'
-	return protocolCategoryConfig[effectiveCategory]?.defaultSort ?? 'tvl'
+export function getProtocolCategoryDefaultSort({
+	effectiveCategory,
+	metrics
+}: {
+	effectiveCategory: string | null
+	metrics: ProtocolCategoryMetrics
+}): string {
+	const defaultSort = effectiveCategory ? protocolCategoryConfig[effectiveCategory]?.defaultSort : null
+	if (defaultSort) return defaultSort
+
+	const visibleColumns = new Set(getProtocolCategoryColumns({ effectiveCategory, metrics }))
+	return DEFAULT_SORT_PRIORITY.find((columnId) => visibleColumns.has(columnId)) ?? 'tvl'
 }

--- a/src/containers/ProtocolsByCategoryOrTag/index.test.ts
+++ b/src/containers/ProtocolsByCategoryOrTag/index.test.ts
@@ -3,6 +3,8 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
 import type { IProtocolByCategoryOrTagPageData } from './types'
 
+let lastTableWithSearchProps: any = null
+
 vi.mock('~/components/ButtonStyled/ChartExportButtons', () => ({
 	ChartExportButtons: () => null
 }))
@@ -18,7 +20,10 @@ vi.mock('~/components/RowLinksWithDropdown', () => ({
 }))
 
 vi.mock('~/components/Table/TableWithSearch', () => ({
-	TableWithSearch: () => null
+	TableWithSearch: (props: any) => {
+		lastTableWithSearchProps = props
+		return null
+	}
 }))
 
 vi.mock('~/hooks/useGetChartInstance', () => ({
@@ -89,7 +94,7 @@ vi.mock('../../../public/definitions', () => ({
 import { ProtocolsByCategoryOrTag, getColumnsForCategory } from './index'
 
 describe('ProtocolsByCategoryOrTag', () => {
-	it('uses derived spot-volume headers for Interface pages', () => {
+	it('uses the fixed widths for resized ranking columns', () => {
 		const columns = getColumnsForCategory({
 			effectiveCategory: 'Interface',
 			metrics: {
@@ -98,50 +103,20 @@ describe('ProtocolsByCategoryOrTag', () => {
 				revenue: true,
 				dexVolume: true,
 				dexAggregatorsVolume: true,
-				perpVolume: true,
 				perpsAggregatorsVolume: true,
-				bridgeAggregatorsVolume: true,
-				normalizedVolume: true,
-				openInterest: true
+				bridgeAggregatorsVolume: true
 			}
 		})
-		const headers = columns.map((column) => column.header)
 
-		expect(headers).toEqual([
-			'Name',
-			'TVL',
-			'Perp Volume 30d',
-			'Perp Aggregator Volume 30d',
-			'Bridge Aggregator Volume 30d',
-			'Normalized Volume 30d',
-			'DEX Aggregator Volume 30d',
-			'Spot Volume 30d',
-			'Fees 30d',
-			'Revenue 30d',
-			'Open Interest',
-			'Perp Volume 7d',
-			'Perp Aggregator Volume 7d',
-			'Bridge Aggregator Volume 7d',
-			'Normalized Volume 7d',
-			'DEX Aggregator Volume 7d',
-			'Spot Volume 7d',
-			'Fees 7d',
-			'Revenue 7d',
-			'Perp Volume 24h',
-			'Perp Aggregator Volume 24h',
-			'Bridge Aggregator Volume 24h',
-			'Normalized Volume 24h',
-			'DEX Aggregator Volume 24h',
-			'Spot Volume 24h',
-			'Fees 24h',
-			'Revenue 24h',
-			'Mcap/TVL'
-		])
-		expect(columns.find((column) => column.id === 'spot_volume_7d')?.meta?.headerHelperText).toBeUndefined()
-		expect(columns.find((column) => column.id === 'dex_aggregator_volume_7d')?.meta?.headerHelperText).toBe('7d')
+		expect(columns.find((column) => column.id === 'dex_aggregator_volume_7d')?.size).toBe(230)
+		expect(columns.find((column) => column.id === 'perp_aggregator_volume_7d')?.size).toBe(230)
+		expect(columns.find((column) => column.id === 'bridge_aggregator_volume_7d')?.size).toBe(230)
+		expect(columns.find((column) => column.id === 'fees_7d')?.size).toBe(100)
+		expect(columns.find((column) => column.id === 'revenue_7d')?.size).toBe(125)
 	})
 
 	it('renders metric sections with nested 24h and 30d rows', () => {
+		lastTableWithSearchProps = null
 		const props: IProtocolByCategoryOrTagPageData = {
 			protocols: [],
 			category: 'Dexs',
@@ -188,6 +163,7 @@ describe('ProtocolsByCategoryOrTag', () => {
 	})
 
 	it('sorts summary metrics by their primary dollar value', () => {
+		lastTableWithSearchProps = null
 		const props: IProtocolByCategoryOrTagPageData = {
 			protocols: [],
 			category: 'Prediction Market',
@@ -227,6 +203,7 @@ describe('ProtocolsByCategoryOrTag', () => {
 	})
 
 	it('does not attach a generic dex tooltip to relabeled dex metrics', () => {
+		lastTableWithSearchProps = null
 		const props: IProtocolByCategoryOrTagPageData = {
 			protocols: [],
 			category: 'Interface',
@@ -255,5 +232,118 @@ describe('ProtocolsByCategoryOrTag', () => {
 
 		expect(html).toContain('Spot Volume (7d)')
 		expect(html).not.toContain('title="7d"')
+	})
+
+	it('orders ranking columns to match the summary metric order', () => {
+		lastTableWithSearchProps = null
+
+		const props: IProtocolByCategoryOrTagPageData = {
+			protocols: [],
+			category: 'Interface',
+			tag: null,
+			effectiveCategory: 'Interface',
+			capabilities: {
+				tvl: true,
+				fees: true,
+				revenue: true,
+				dexVolume: true,
+				dexAggregatorsVolume: true,
+				perpsAggregatorsVolume: true,
+				bridgeAggregatorsVolume: true
+			},
+			chains: [],
+			chain: 'All',
+			charts: {
+				dataset: {
+					source: [{ timestamp: 1710000000000, TVL: 5_850_000 }],
+					dimensions: ['timestamp', 'TVL']
+				},
+				charts: []
+			},
+			summaryMetrics: {
+				fees: { total24h: 100_000, total7d: 1_060_000, total30d: 4_400_000 },
+				revenue: { total24h: 80_000, total7d: 1_000_000, total30d: 4_000_000 },
+				dexVolume: { total24h: 7_000_000, total7d: 56_270_000, total30d: 210_000_000 },
+				dexAggregatorsVolume: { total24h: 900_000_000, total7d: 10_490_000_000, total30d: 38_000_000_000 },
+				perpsAggregatorsVolume: { total24h: 75_000_000, total7d: 869_250_000, total30d: 3_200_000_000 },
+				bridgeAggregatorsVolume: { total24h: 21_000_000, total7d: 233_550_000, total30d: 940_000_000 }
+			},
+			extraTvlCharts: {}
+		}
+
+		renderToStaticMarkup(React.createElement(ProtocolsByCategoryOrTag, props))
+
+		expect(lastTableWithSearchProps?.columns.map((column: { header: string }) => column.header)).toEqual([
+			'Name',
+			'DEX Aggregator Volume 30d',
+			'Perp Aggregator Volume 30d',
+			'Bridge Aggregator Volume 30d',
+			'Spot Volume 30d',
+			'TVL',
+			'Fees 30d',
+			'Revenue 30d',
+			'Perp Aggregator Volume 7d',
+			'Bridge Aggregator Volume 7d',
+			'DEX Aggregator Volume 7d',
+			'Spot Volume 7d',
+			'Fees 7d',
+			'Revenue 7d',
+			'Perp Aggregator Volume 24h',
+			'Bridge Aggregator Volume 24h',
+			'DEX Aggregator Volume 24h',
+			'Spot Volume 24h',
+			'Fees 24h',
+			'Revenue 24h',
+			'Mcap/TVL'
+		])
+	})
+
+	it('keeps ranked summary metrics ahead of unranked visible metrics on Dexs pages', () => {
+		lastTableWithSearchProps = null
+
+		const props: IProtocolByCategoryOrTagPageData = {
+			protocols: [],
+			category: 'Dexs',
+			tag: null,
+			effectiveCategory: 'Dexs',
+			capabilities: {
+				tvl: true,
+				fees: true,
+				revenue: true,
+				dexVolume: true,
+				dexAggregatorsVolume: true,
+				perpVolume: true
+			},
+			chains: [],
+			chain: 'All',
+			charts: {
+				dataset: {
+					source: [{ timestamp: 1710000000000, TVL: 13_138_000_000 }],
+					dimensions: ['timestamp', 'TVL']
+				},
+				charts: []
+			},
+			summaryMetrics: {
+				fees: { total24h: 1_000_000, total7d: 29_870_000, total30d: 120_000_000 },
+				revenue: { total24h: 200_000, total7d: 7_100_000, total30d: 31_000_000 },
+				dexVolume: { total24h: 5_300_000_000, total7d: 37_446_000_000, total30d: 145_000_000_000 },
+				dexAggregatorsVolume: { total24h: 201, total7d: 201, total30d: 201 },
+				perpVolume: { total24h: null, total7d: null, total30d: null }
+			},
+			extraTvlCharts: {}
+		}
+
+		renderToStaticMarkup(React.createElement(ProtocolsByCategoryOrTag, props))
+
+		expect(lastTableWithSearchProps?.sortingState).toEqual([{ id: 'dex_volume_30d', desc: true }])
+		expect(lastTableWithSearchProps?.columns.slice(0, 7).map((column: { header: string }) => column.header)).toEqual([
+			'Name',
+			'DEX Volume 30d',
+			'TVL',
+			'Fees 30d',
+			'Revenue 30d',
+			'DEX Aggregator Volume 30d',
+			'Perp Volume 30d'
+		])
 	})
 })

--- a/src/containers/ProtocolsByCategoryOrTag/index.test.ts
+++ b/src/containers/ProtocolsByCategoryOrTag/index.test.ts
@@ -1,13 +1,55 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
+import type { IProtocolByCategoryOrTagPageData } from './types'
 
-vi.mock('../../public/definitions', () => ({
+vi.mock('~/components/ButtonStyled/ChartExportButtons', () => ({
+	ChartExportButtons: () => null
+}))
+
+vi.mock('~/components/ECharts/ChartGroupingSelector', () => ({
+	ChartGroupingSelector: () => null,
+	DWMC_GROUPING_OPTIONS_LOWERCASE: [],
+	type: {}
+}))
+
+vi.mock('~/components/RowLinksWithDropdown', () => ({
+	RowLinksWithDropdown: () => null
+}))
+
+vi.mock('~/components/Table/TableWithSearch', () => ({
+	TableWithSearch: () => null
+}))
+
+vi.mock('~/hooks/useGetChartInstance', () => ({
+	useGetChartInstance: () => ({
+		chartInstance: null,
+		handleChartReady: () => null
+	})
+}))
+
+vi.mock('~/contexts/LocalStorage', () => ({
+	TVL_SETTINGS_KEYS: ['borrowed'],
+	useLocalStorageSettingsManager: () => [{ borrowed: false }]
+}))
+
+vi.mock('../../../public/definitions', () => ({
 	definitions: {
 		dexs: {
 			protocol: {
 				'24h': '24h',
 				'7d': '7d',
 				'30d': '30d'
+			},
+			chain: {
+				'24h': '24h',
+				'7d': '7d',
+				'30d': '30d'
 			}
+		},
+		dexAggregators: {
+			protocol: { '24h': '24h', '7d': '7d', '30d': '30d' },
+			chain: { '24h': '24h', '7d': '7d', '30d': '30d' }
 		},
 		perps: {
 			protocol: {
@@ -16,36 +58,202 @@ vi.mock('../../public/definitions', () => ({
 				'30d': '30d'
 			}
 		},
-		openInterest: { protocol: 'oi' },
-		optionsPremium: { protocol: { '24h': '24h', '7d': '7d', '30d': '30d' } },
-		optionsNotional: { protocol: { '24h': '24h', '7d': '7d', '30d': '30d' } },
-		fees: { protocol: { '24h': '24h', '7d': '7d', '30d': '30d' }, chain: { '7d': '7d' } },
-		revenue: { protocol: { '24h': '24h', '7d': '7d', '30d': '30d' }, chain: { '7d': '7d' } }
+		perpsAggregators: {
+			protocol: { '24h': '24h', '7d': '7d', '30d': '30d' }
+		},
+		bridgeAggregators: {
+			protocol: { '24h': '24h', '7d': '7d', '30d': '30d' },
+			chain: { '24h': '24h', '7d': '7d', '30d': '30d' }
+		},
+		normalizedVolume: {
+			protocol: { '24h': '24h', '7d': '7d', '30d': '30d' }
+		},
+		openInterest: { protocol: 'oi', common: 'oi' },
+		optionsPremium: {
+			protocol: { '24h': '24h', '7d': '7d', '30d': '30d' }
+		},
+		optionsNotional: {
+			protocol: { '24h': '24h', '7d': '7d', '30d': '30d' }
+		},
+		fees: {
+			protocol: { '24h': '24h', '7d': '7d', '30d': '30d' },
+			chain: { '24h': '24h', '7d': '7d', '30d': '30d' }
+		},
+		revenue: {
+			protocol: { '24h': '24h', '7d': '7d', '30d': '30d' },
+			chain: { '24h': '24h', '7d': '7d', '30d': '30d' }
+		}
 	}
 }))
 
-import { getColumnsForCategory } from './index'
+import { ProtocolsByCategoryOrTag, getColumnsForCategory } from './index'
 
-const getHeader = (column: { header?: unknown }) => column.header
+describe('ProtocolsByCategoryOrTag', () => {
+	it('uses derived spot-volume headers for Interface pages', () => {
+		const columns = getColumnsForCategory({
+			effectiveCategory: 'Interface',
+			metrics: {
+				tvl: true,
+				fees: true,
+				revenue: true,
+				dexVolume: true,
+				dexAggregatorsVolume: true,
+				perpVolume: true,
+				perpsAggregatorsVolume: true,
+				bridgeAggregatorsVolume: true,
+				normalizedVolume: true,
+				openInterest: true
+			}
+		})
+		const headers = columns.map((column) => column.header)
 
-describe('getColumnsForCategory', () => {
-	it('uses Spot Volume headers for Interface dex columns', () => {
-		const headers = getColumnsForCategory('Interface').map(getHeader)
-		expect(headers).toContain('Spot Volume 24h')
-		expect(headers).toContain('Spot Volume 7d')
-		expect(headers).toContain('Spot Volume 30d')
-		expect(headers).toContain('Perp Volume 24h')
+		expect(headers).toEqual([
+			'Name',
+			'TVL',
+			'Perp Volume 30d',
+			'Perp Aggregator Volume 30d',
+			'Bridge Aggregator Volume 30d',
+			'Normalized Volume 30d',
+			'DEX Aggregator Volume 30d',
+			'Spot Volume 30d',
+			'Fees 30d',
+			'Revenue 30d',
+			'Open Interest',
+			'Perp Volume 7d',
+			'Perp Aggregator Volume 7d',
+			'Bridge Aggregator Volume 7d',
+			'Normalized Volume 7d',
+			'DEX Aggregator Volume 7d',
+			'Spot Volume 7d',
+			'Fees 7d',
+			'Revenue 7d',
+			'Perp Volume 24h',
+			'Perp Aggregator Volume 24h',
+			'Bridge Aggregator Volume 24h',
+			'Normalized Volume 24h',
+			'DEX Aggregator Volume 24h',
+			'Spot Volume 24h',
+			'Fees 24h',
+			'Revenue 24h',
+			'Mcap/TVL'
+		])
+		expect(columns.find((column) => column.id === 'spot_volume_7d')?.meta?.headerHelperText).toBeUndefined()
+		expect(columns.find((column) => column.id === 'dex_aggregator_volume_7d')?.meta?.headerHelperText).toBe('7d')
 	})
 
-	it('uses category-aware dex headers for prediction markets and crypto card issuers', () => {
-		const predictionHeaders = getColumnsForCategory('Prediction Market').map(getHeader)
-		expect(predictionHeaders).toContain('Prediction Volume 24h')
-		expect(predictionHeaders).toContain('Prediction Volume 7d')
-		expect(predictionHeaders).toContain('Prediction Volume 30d')
+	it('renders metric sections with nested 24h and 30d rows', () => {
+		const props: IProtocolByCategoryOrTagPageData = {
+			protocols: [],
+			category: 'Dexs',
+			tag: null,
+			effectiveCategory: 'Dexs',
+			capabilities: {
+				tvl: true,
+				fees: true,
+				revenue: true,
+				dexVolume: true
+			},
+			chains: [],
+			chain: 'All',
+			charts: {
+				dataset: {
+					source: [{ timestamp: 1710000000000, TVL: 123 }],
+					dimensions: ['timestamp', 'TVL']
+				},
+				charts: []
+			},
+			summaryMetrics: {
+				fees: { total24h: 10, total7d: 70, total30d: 300 },
+				dexVolume: { total24h: 20, total7d: 140, total30d: 600 },
+				dexAggregatorsVolume: { total24h: 5, total7d: 30, total30d: 120 },
+				perpsAggregatorsVolume: { total24h: 7, total7d: 40, total30d: 160 },
+				bridgeAggregatorsVolume: { total24h: 9, total7d: 50, total30d: 180 },
+				normalizedVolume: { total24h: 11, total7d: 60, total30d: 240 }
+			},
+			extraTvlCharts: {}
+		}
 
-		const paymentHeaders = getColumnsForCategory('Crypto Card Issuer').map(getHeader)
-		expect(paymentHeaders).toContain('Payment Volume 24h')
-		expect(paymentHeaders).toContain('Payment Volume 7d')
-		expect(paymentHeaders).toContain('Payment Volume 30d')
+		const html = renderToStaticMarkup(React.createElement(ProtocolsByCategoryOrTag, props))
+
+		expect(html).toContain('Fees (7d)')
+		expect(html).toContain('DEX Volume (7d)')
+		expect(html).toContain('Fees (24h)')
+		expect(html).toContain('Fees (30d)')
+		expect(html).toContain('DEX Volume (24h)')
+		expect(html).toContain('DEX Volume (30d)')
+		expect(html).toContain('DEX Aggregator Volume (7d)')
+		expect(html).toContain('Perp Aggregator Volume (30d)')
+		expect(html).toContain('Bridge Aggregator Volume (24h)')
+		expect(html).toContain('Normalized Volume (30d)')
+	})
+
+	it('sorts summary metrics by their primary dollar value', () => {
+		const props: IProtocolByCategoryOrTagPageData = {
+			protocols: [],
+			category: 'Prediction Market',
+			tag: null,
+			effectiveCategory: 'Prediction Market',
+			capabilities: {
+				tvl: true,
+				fees: true,
+				revenue: true,
+				dexVolume: true,
+				openInterest: true
+			},
+			chains: [],
+			chain: 'All',
+			charts: {
+				dataset: {
+					source: [{ timestamp: 1710000000000, TVL: 495_570_000 }],
+					dimensions: ['timestamp', 'TVL']
+				},
+				charts: []
+			},
+			summaryMetrics: {
+				fees: { total24h: 0, total7d: 10_030_000, total30d: 0 },
+				revenue: { total24h: 0, total7d: 6_110_000, total30d: 0 },
+				dexVolume: { total24h: 0, total7d: 2_643_000_000, total30d: 0 },
+				openInterest: { total24h: 924_760_000, total7d: 0, total30d: 0 }
+			},
+			extraTvlCharts: {}
+		}
+
+		const html = renderToStaticMarkup(React.createElement(ProtocolsByCategoryOrTag, props))
+
+		expect(html.indexOf('Prediction Volume (7d)')).toBeLessThan(html.indexOf('Open Interest'))
+		expect(html.indexOf('Open Interest')).toBeLessThan(html.indexOf('Total Value Locked'))
+		expect(html.indexOf('Total Value Locked')).toBeLessThan(html.indexOf('Fees (7d)'))
+		expect(html.indexOf('Fees (7d)')).toBeLessThan(html.indexOf('Revenue (7d)'))
+	})
+
+	it('does not attach a generic dex tooltip to relabeled dex metrics', () => {
+		const props: IProtocolByCategoryOrTagPageData = {
+			protocols: [],
+			category: 'Interface',
+			tag: null,
+			effectiveCategory: 'Interface',
+			capabilities: {
+				tvl: true,
+				dexVolume: true
+			},
+			chains: [],
+			chain: 'All',
+			charts: {
+				dataset: {
+					source: [{ timestamp: 1710000000000, TVL: 123 }],
+					dimensions: ['timestamp', 'TVL']
+				},
+				charts: []
+			},
+			summaryMetrics: {
+				dexVolume: { total24h: 20, total7d: 140, total30d: 600 }
+			},
+			extraTvlCharts: {}
+		}
+
+		const html = renderToStaticMarkup(React.createElement(ProtocolsByCategoryOrTag, props))
+
+		expect(html).toContain('Spot Volume (7d)')
+		expect(html).not.toContain('title="7d"')
 	})
 })

--- a/src/containers/ProtocolsByCategoryOrTag/index.tsx
+++ b/src/containers/ProtocolsByCategoryOrTag/index.tsx
@@ -22,7 +22,6 @@ import { definitions } from '../../../public/definitions'
 import {
 	getProtocolCategoryDexVolumeLabel,
 	getProtocolCategoryColumns,
-	getProtocolCategoryDefaultSort,
 	getProtocolCategoryPresentation
 } from './constants'
 import type { IProtocolByCategoryOrTagPageData } from './types'
@@ -33,14 +32,50 @@ type SummaryMetricEntry = {
 	key: string
 	sortValue: number
 	content: ReactNode
+	leadingColumnId: string
 }
 
-const getSectionSortValue = (
+type SummaryMetricPeriod = '7d' | '24h' | '30d'
+type TimedColumnIds = Record<SummaryMetricPeriod, string>
+type TimedSummaryMetricKey = Exclude<keyof IProtocolByCategoryOrTagPageData['summaryMetrics'], 'openInterest'>
+type TimedSummaryMetricDescriptor = {
+	type: 'timed'
+	key: TimedSummaryMetricKey
+	label: string
+	metric: IProtocolByCategoryOrTagPageData['summaryMetrics'][TimedSummaryMetricKey]
+	tooltips?: Partial<Record<SummaryMetricPeriod, string>>
+	columns: TimedColumnIds
+}
+type StaticSummaryMetricDescriptor = {
+	type: 'static'
+	key: 'openInterest'
+	label: 'Open Interest'
+	value: number | null
+	tooltip: string
+	columnId: 'openInterest'
+}
+type SummaryMetricDescriptor = TimedSummaryMetricDescriptor | StaticSummaryMetricDescriptor
+
+const NON_SUMMARY_LEADING_COLUMN_IDS = ['borrowed', 'supplied', 'supplied/tvl'] as const
+const getDexVolumeColumnIds = (effectiveCategory: string | null): TimedColumnIds => {
+	switch (effectiveCategory) {
+		case 'Interface':
+			return { '30d': 'spot_volume_30d', '7d': 'spot_volume_7d', '24h': 'spot_volume_24h' }
+		case 'Prediction Market':
+			return { '30d': 'prediction_volume_30d', '7d': 'prediction_volume_7d', '24h': 'prediction_volume_24h' }
+		case 'Crypto Card Issuer':
+			return { '30d': 'payment_volume_30d', '7d': 'payment_volume_7d', '24h': 'payment_volume_24h' }
+		default:
+			return { '30d': 'dex_volume_30d', '7d': 'dex_volume_7d', '24h': 'dex_volume_24h' }
+	}
+}
+
+const getPrimarySectionMetric = (
 	metric: IProtocolByCategoryOrTagPageData['summaryMetrics'][keyof IProtocolByCategoryOrTagPageData['summaryMetrics']]
 ) => {
-	if (metric?.total7d != null) return metric.total7d
-	if (metric?.total24h != null) return metric.total24h
-	if (metric?.total30d != null) return metric.total30d
+	if (metric?.total7d != null) return { period: '7d' as const, value: metric.total7d }
+	if (metric?.total24h != null) return { period: '24h' as const, value: metric.total24h }
+	if (metric?.total30d != null) return { period: '30d' as const, value: metric.total30d }
 	return null
 }
 
@@ -117,21 +152,6 @@ export function ProtocolsByCategoryOrTag(props: IProtocolByCategoryOrTagPageData
 	}, [tvlSettings, props.protocols, props.charts, props.extraTvlCharts, props.effectiveCategory])
 
 	const chartSeries = useMemo(() => charts.charts ?? [], [charts.charts])
-
-	const categoryColumns = useMemo(() => {
-		return getColumnsForCategory({
-			effectiveCategory: props.effectiveCategory,
-			metrics: props.capabilities
-		})
-	}, [props.effectiveCategory, props.capabilities])
-
-	const sortingState = useMemo(() => {
-		const sortId = getProtocolCategoryDefaultSort({
-			effectiveCategory: props.effectiveCategory,
-			metrics: props.capabilities
-		})
-		return [{ id: sortId, desc: true }]
-	}, [props.effectiveCategory, props.capabilities])
 
 	const hasBarCharts = useMemo(() => {
 		return chartSeries.some((series) => {
@@ -224,165 +244,281 @@ export function ProtocolsByCategoryOrTag(props: IProtocolByCategoryOrTagPageData
 	const deferredGroupedCharts = useDeferredValue(groupedCharts)
 
 	const chartGroupBy = groupBy
-	const sortedSummaryEntries = useMemo(() => {
-		const entries: SummaryMetricEntry[] = []
+	const latestTvlValue = useMemo(() => {
 		const latestTvl = charts.dataset?.source[charts.dataset?.source.length - 1]?.TVL
 		const tvlValue = typeof latestTvl === 'number' ? latestTvl : Number(latestTvl ?? NaN)
+		return Number.isFinite(tvlValue) ? tvlValue : null
+	}, [charts.dataset])
+	const summaryMetricDescriptors = useMemo<SummaryMetricDescriptor[]>(() => {
+		return [
+			{
+				type: 'timed',
+				key: 'dexAggregatorsVolume',
+				label: 'DEX Aggregator Volume',
+				metric: props.summaryMetrics.dexAggregatorsVolume,
+				tooltips: {
+					'7d': definitions.dexAggregators.chain['7d'],
+					'24h': definitions.dexAggregators.chain['24h'],
+					'30d': definitions.dexAggregators.chain['30d']
+				},
+				columns: {
+					'30d': 'dex_aggregator_volume_30d',
+					'7d': 'dex_aggregator_volume_7d',
+					'24h': 'dex_aggregator_volume_24h'
+				}
+			},
+			{
+				type: 'timed',
+				key: 'perpsAggregatorsVolume',
+				label: 'Perp Aggregator Volume',
+				metric: props.summaryMetrics.perpsAggregatorsVolume,
+				tooltips: {
+					'7d': definitions.perpsAggregators.protocol['7d'],
+					'24h': definitions.perpsAggregators.protocol['24h'],
+					'30d': definitions.perpsAggregators.protocol['30d']
+				},
+				columns: {
+					'30d': 'perp_aggregator_volume_30d',
+					'7d': 'perp_aggregator_volume_7d',
+					'24h': 'perp_aggregator_volume_24h'
+				}
+			},
+			{
+				type: 'timed',
+				key: 'bridgeAggregatorsVolume',
+				label: 'Bridge Aggregator Volume',
+				metric: props.summaryMetrics.bridgeAggregatorsVolume,
+				tooltips: {
+					'7d': definitions.bridgeAggregators.chain['7d'],
+					'24h': definitions.bridgeAggregators.chain['24h'],
+					'30d': definitions.bridgeAggregators.chain['30d']
+				},
+				columns: {
+					'30d': 'bridge_aggregator_volume_30d',
+					'7d': 'bridge_aggregator_volume_7d',
+					'24h': 'bridge_aggregator_volume_24h'
+				}
+			},
+			{
+				type: 'timed',
+				key: 'normalizedVolume',
+				label: 'Normalized Volume',
+				metric: props.summaryMetrics.normalizedVolume,
+				tooltips: {
+					'7d': definitions.normalizedVolume.protocol['7d'],
+					'24h': definitions.normalizedVolume.protocol['24h'],
+					'30d': definitions.normalizedVolume.protocol['30d']
+				},
+				columns: {
+					'30d': 'normalized_volume_30d',
+					'7d': 'normalized_volume_7d',
+					'24h': 'normalized_volume_24h'
+				}
+			},
+			{
+				type: 'timed',
+				key: 'dexVolume',
+				label: dexVolumeLabel,
+				metric: props.summaryMetrics.dexVolume,
+				tooltips: showDexVolumeTooltip
+					? {
+							'7d': definitions.dexs.chain['7d'],
+							'24h': definitions.dexs.chain['24h'],
+							'30d': definitions.dexs.chain['30d']
+						}
+					: undefined,
+				columns: getDexVolumeColumnIds(props.effectiveCategory)
+			},
+			{
+				type: 'timed',
+				key: 'perpVolume',
+				label: 'Perp Volume',
+				metric: props.summaryMetrics.perpVolume,
+				tooltips: {
+					'7d': definitions.perps.protocol['7d'],
+					'24h': definitions.perps.protocol['24h'],
+					'30d': definitions.perps.protocol['30d']
+				},
+				columns: {
+					'30d': 'perp_volume_30d',
+					'7d': 'perp_volume_7d',
+					'24h': 'perp_volume_24h'
+				}
+			},
+			{
+				type: 'timed',
+				key: 'optionsPremiumVolume',
+				label: 'Premium Volume',
+				metric: props.summaryMetrics.optionsPremiumVolume,
+				tooltips: {
+					'7d': definitions.optionsPremium.protocol['7d'],
+					'24h': definitions.optionsPremium.protocol['24h'],
+					'30d': definitions.optionsPremium.protocol['30d']
+				},
+				columns: {
+					'30d': 'options_premium_30d',
+					'7d': 'options_premium_7d',
+					'24h': 'options_premium_24h'
+				}
+			},
+			{
+				type: 'timed',
+				key: 'optionsNotionalVolume',
+				label: 'Notional Volume',
+				metric: props.summaryMetrics.optionsNotionalVolume,
+				tooltips: {
+					'7d': definitions.optionsNotional.protocol['7d'],
+					'24h': definitions.optionsNotional.protocol['24h'],
+					'30d': definitions.optionsNotional.protocol['30d']
+				},
+				columns: {
+					'30d': 'options_notional_30d',
+					'7d': 'options_notional_7d',
+					'24h': 'options_notional_24h'
+				}
+			},
+			{
+				type: 'timed',
+				key: 'fees',
+				label: 'Fees',
+				metric: props.summaryMetrics.fees,
+				tooltips: {
+					'7d': definitions.fees.chain['7d'],
+					'24h': definitions.fees.chain['24h'],
+					'30d': definitions.fees.chain['30d']
+				},
+				columns: { '30d': 'fees_30d', '7d': 'fees_7d', '24h': 'fees_24h' }
+			},
+			{
+				type: 'timed',
+				key: 'revenue',
+				label: 'Revenue',
+				metric: props.summaryMetrics.revenue,
+				tooltips: {
+					'7d': definitions.revenue.chain['7d'],
+					'24h': definitions.revenue.chain['24h'],
+					'30d': definitions.revenue.chain['30d']
+				},
+				columns: { '30d': 'revenue_30d', '7d': 'revenue_7d', '24h': 'revenue_24h' }
+			},
+			{
+				type: 'static',
+				key: 'openInterest',
+				label: 'Open Interest',
+				value: props.summaryMetrics.openInterest?.total24h ?? null,
+				tooltip: definitions.openInterest.common,
+				columnId: 'openInterest'
+			}
+		]
+	}, [dexVolumeLabel, props.effectiveCategory, props.summaryMetrics, showDexVolumeTooltip])
+	const rankedSummaryEntries = useMemo<SummaryMetricEntry[]>(() => {
+		const entries: SummaryMetricEntry[] = []
 
-		if (Number.isFinite(tvlValue)) {
+		if (latestTvlValue != null) {
 			entries.push({
 				key: 'tvl',
-				sortValue: tvlValue,
+				sortValue: latestTvlValue,
+				leadingColumnId: 'tvl',
 				content: (
 					<MetricRow
 						label="Total Value Locked"
 						tooltip="Sum of value of all coins held in smart contracts of all the protocols on the chain"
-						value={formattedNum(tvlValue, true)}
+						value={formattedNum(latestTvlValue, true)}
 					/>
 				)
 			})
 		}
 
-		const pushSection = ({
-			key,
-			label,
-			metric,
-			primaryTooltip,
-			subtooltips
-		}: {
-			key: string
-			label: string
-			metric: IProtocolByCategoryOrTagPageData['summaryMetrics'][keyof IProtocolByCategoryOrTagPageData['summaryMetrics']]
-			primaryTooltip?: string
-			subtooltips?: Partial<Record<'24h' | '30d', string>>
-		}) => {
-			const sortValue = getSectionSortValue(metric)
-			if (sortValue == null) return
+		for (const descriptor of summaryMetricDescriptors) {
+			if (descriptor.type === 'timed') {
+				const primaryMetric = getPrimarySectionMetric(descriptor.metric)
+				if (primaryMetric == null) continue
+
+				entries.push({
+					key: descriptor.key,
+					sortValue: primaryMetric.value,
+					leadingColumnId: descriptor.columns['30d'],
+					content: (
+						<SummaryMetricSection label={descriptor.label} metric={descriptor.metric} tooltips={descriptor.tooltips} />
+					)
+				})
+				continue
+			}
+
+			if (descriptor.value == null) continue
 
 			entries.push({
-				key,
-				sortValue,
-				content: (
-					<SummaryMetricSection
-						label={label}
-						metric={metric}
-						primaryTooltip={primaryTooltip}
-						subtooltips={subtooltips}
-					/>
-				)
-			})
-		}
-
-		pushSection({
-			key: 'fees',
-			label: 'Fees',
-			metric: props.summaryMetrics.fees,
-			primaryTooltip: definitions.fees.chain['7d'],
-			subtooltips: { '24h': definitions.fees.chain['24h'], '30d': definitions.fees.chain['30d'] }
-		})
-		pushSection({
-			key: 'revenue',
-			label: 'Revenue',
-			metric: props.summaryMetrics.revenue,
-			primaryTooltip: definitions.revenue.chain['7d'],
-			subtooltips: { '24h': definitions.revenue.chain['24h'], '30d': definitions.revenue.chain['30d'] }
-		})
-		pushSection({
-			key: 'dexVolume',
-			label: dexVolumeLabel,
-			metric: props.summaryMetrics.dexVolume,
-			primaryTooltip: showDexVolumeTooltip ? definitions.dexs.chain['7d'] : undefined,
-			subtooltips: showDexVolumeTooltip
-				? { '24h': definitions.dexs.chain['24h'], '30d': definitions.dexs.chain['30d'] }
-				: undefined
-		})
-		pushSection({
-			key: 'dexAggregatorsVolume',
-			label: 'DEX Aggregator Volume',
-			metric: props.summaryMetrics.dexAggregatorsVolume,
-			primaryTooltip: definitions.dexAggregators.chain['7d'],
-			subtooltips: {
-				'24h': definitions.dexAggregators.chain['24h'],
-				'30d': definitions.dexAggregators.chain['30d']
-			}
-		})
-		pushSection({
-			key: 'perpVolume',
-			label: 'Perp Volume',
-			metric: props.summaryMetrics.perpVolume,
-			primaryTooltip: definitions.perps.protocol['7d'],
-			subtooltips: { '24h': definitions.perps.protocol['24h'], '30d': definitions.perps.protocol['30d'] }
-		})
-		pushSection({
-			key: 'perpsAggregatorsVolume',
-			label: 'Perp Aggregator Volume',
-			metric: props.summaryMetrics.perpsAggregatorsVolume,
-			primaryTooltip: definitions.perpsAggregators.protocol['7d'],
-			subtooltips: {
-				'24h': definitions.perpsAggregators.protocol['24h'],
-				'30d': definitions.perpsAggregators.protocol['30d']
-			}
-		})
-		pushSection({
-			key: 'bridgeAggregatorsVolume',
-			label: 'Bridge Aggregator Volume',
-			metric: props.summaryMetrics.bridgeAggregatorsVolume,
-			primaryTooltip: definitions.bridgeAggregators.chain['7d'],
-			subtooltips: {
-				'24h': definitions.bridgeAggregators.chain['24h'],
-				'30d': definitions.bridgeAggregators.chain['30d']
-			}
-		})
-		pushSection({
-			key: 'normalizedVolume',
-			label: 'Normalized Volume',
-			metric: props.summaryMetrics.normalizedVolume,
-			primaryTooltip: definitions.normalizedVolume.protocol['7d'],
-			subtooltips: {
-				'24h': definitions.normalizedVolume.protocol['24h'],
-				'30d': definitions.normalizedVolume.protocol['30d']
-			}
-		})
-
-		if (props.summaryMetrics.openInterest?.total24h != null) {
-			entries.push({
-				key: 'openInterest',
-				sortValue: props.summaryMetrics.openInterest.total24h,
+				key: descriptor.key,
+				sortValue: descriptor.value,
+				leadingColumnId: descriptor.columnId,
 				content: (
 					<MetricRow
-						label="Open Interest"
-						tooltip={definitions.openInterest.common}
-						value={formattedNum(props.summaryMetrics.openInterest.total24h, true)}
+						label={descriptor.label}
+						tooltip={descriptor.tooltip}
+						value={formattedNum(descriptor.value, true)}
 					/>
 				)
 			})
 		}
 
-		pushSection({
-			key: 'optionsPremiumVolume',
-			label: 'Premium Volume',
-			metric: props.summaryMetrics.optionsPremiumVolume,
-			primaryTooltip: definitions.optionsPremium.protocol['7d'],
-			subtooltips: {
-				'24h': definitions.optionsPremium.protocol['24h'],
-				'30d': definitions.optionsPremium.protocol['30d']
-			}
+		return entries.sort((a, b) => b.sortValue - a.sortValue)
+	}, [latestTvlValue, summaryMetricDescriptors])
+	const categoryColumns = useMemo(() => {
+		const baseColumnIds = getProtocolCategoryColumns({
+			effectiveCategory: props.effectiveCategory,
+			metrics: props.capabilities
 		})
-		pushSection({
-			key: 'optionsNotionalVolume',
-			label: 'Notional Volume',
-			metric: props.summaryMetrics.optionsNotionalVolume,
-			primaryTooltip: definitions.optionsNotional.protocol['7d'],
-			subtooltips: {
-				'24h': definitions.optionsNotional.protocol['24h'],
-				'30d': definitions.optionsNotional.protocol['30d']
-			}
-		})
+		const visibleColumnIds = new Set(baseColumnIds)
+		const usedColumnIds = new Set<string>()
+		const orderedColumnIds: string[] = []
 
-		return entries
-			.sort((a, b) => b.sortValue - a.sortValue)
-			.map((entry) => <Fragment key={entry.key}>{entry.content}</Fragment>)
-	}, [charts.dataset, dexVolumeLabel, props.summaryMetrics, showDexVolumeTooltip])
+		const pushColumnId = (columnId: string) => {
+			if (!visibleColumnIds.has(columnId) || usedColumnIds.has(columnId)) return
+			usedColumnIds.add(columnId)
+			orderedColumnIds.push(columnId)
+		}
+
+		pushColumnId('name')
+		for (const columnId of NON_SUMMARY_LEADING_COLUMN_IDS) {
+			pushColumnId(columnId)
+		}
+		for (const entry of rankedSummaryEntries) {
+			pushColumnId(entry.leadingColumnId)
+		}
+		for (const columnId of baseColumnIds) {
+			if (!columnId.endsWith('_30d')) continue
+			pushColumnId(columnId)
+		}
+		for (const columnId of baseColumnIds) {
+			if (
+				columnId.endsWith('_30d') ||
+				columnId.endsWith('_7d') ||
+				columnId.endsWith('_24h') ||
+				columnId === 'mcap/tvl'
+			) {
+				continue
+			}
+			pushColumnId(columnId)
+		}
+		for (const columnId of baseColumnIds) {
+			if (!columnId.endsWith('_7d')) continue
+			pushColumnId(columnId)
+		}
+		for (const columnId of baseColumnIds) {
+			if (!columnId.endsWith('_24h')) continue
+			pushColumnId(columnId)
+		}
+		pushColumnId('mcap/tvl')
+
+		return orderedColumnIds.flatMap((id) => (COLUMN_REGISTRY[id] ? [COLUMN_REGISTRY[id]] : []))
+	}, [props.effectiveCategory, props.capabilities, rankedSummaryEntries])
+	const sortingState = useMemo(() => {
+		const firstSortableColumn = categoryColumns.find((column) => {
+			return column.id !== 'name' && column.enableSorting !== false
+		})
+		const sortId = firstSortableColumn?.id ?? 'tvl'
+		return [{ id: sortId, desc: true }]
+	}, [categoryColumns])
 
 	return (
 		<>
@@ -394,7 +530,11 @@ export function ProtocolsByCategoryOrTag(props: IProtocolByCategoryOrTagPageData
 					) : (
 						<h1 className="text-lg font-semibold">{`${categoryPresentation.headingLabel} on ${props.chain}`}</h1>
 					)}
-					<div className="mb-auto flex flex-1 flex-col">{sortedSummaryEntries}</div>
+					<div className="mb-auto flex flex-1 flex-col">
+						{rankedSummaryEntries.map((entry) => (
+							<Fragment key={entry.key}>{entry.content}</Fragment>
+						))}
+					</div>
 				</div>
 				<div className="col-span-2 rounded-md border border-(--cards-border) bg-(--cards-bg)">
 					<div className="flex items-center justify-end gap-2 p-2 pb-0">
@@ -440,33 +580,32 @@ export function ProtocolsByCategoryOrTag(props: IProtocolByCategoryOrTagPageData
 function SummaryMetricSection({
 	label,
 	metric,
-	primaryTooltip,
-	subtooltips
+	tooltips
 }: {
 	label: string
 	metric: IProtocolByCategoryOrTagPageData['summaryMetrics'][keyof IProtocolByCategoryOrTagPageData['summaryMetrics']]
-	primaryTooltip?: string
-	subtooltips?: Partial<Record<'24h' | '30d', string>>
+	tooltips?: Partial<Record<SummaryMetricPeriod, string>>
 }) {
-	if (!metric?.total7d && !metric?.total24h && !metric?.total30d) return null
+	const primaryMetric = getPrimarySectionMetric(metric)
+	if (primaryMetric == null) return null
 
 	return (
 		<MetricSection
-			label={`${label} (7d)`}
-			tooltip={primaryTooltip ?? null}
-			value={metric.total7d != null ? formattedNum(metric.total7d, true) : '—'}
+			label={`${label} (${primaryMetric.period})`}
+			tooltip={tooltips?.[primaryMetric.period] ?? null}
+			value={formattedNum(primaryMetric.value, true)}
 		>
-			{metric.total24h != null ? (
+			{primaryMetric.period !== '24h' && metric.total24h != null ? (
 				<SubMetricRow
 					label={`${label} (24h)`}
-					tooltip={subtooltips?.['24h']}
+					tooltip={tooltips?.['24h']}
 					value={formattedNum(metric.total24h, true)}
 				/>
 			) : null}
-			{metric.total30d != null ? (
+			{primaryMetric.period !== '30d' && metric.total30d != null ? (
 				<SubMetricRow
 					label={`${label} (30d)`}
-					tooltip={subtooltips?.['30d']}
+					tooltip={tooltips?.['30d']}
 					value={formattedNum(metric.total30d, true)}
 				/>
 			) : null}
@@ -567,7 +706,7 @@ const COLUMN_REGISTRY: Record<string, ColumnDef<ProtocolRow, any>> = {
 		header: 'Mcap/TVL',
 		cell: (info) => (info.getValue() != null ? info.getValue() : null),
 		meta: { align: 'end', headerHelperText: 'Market cap / TVL ratio' },
-		size: 110
+		size: 120
 	}),
 	fees_7d: columnHelper.accessor((p) => p.fees?.total7d, {
 		id: 'fees_7d',
@@ -581,35 +720,35 @@ const COLUMN_REGISTRY: Record<string, ColumnDef<ProtocolRow, any>> = {
 		header: 'Revenue 7d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
 		meta: { align: 'end', headerHelperText: definitions.revenue.protocol['7d'] },
-		size: 128
+		size: 125
 	}),
 	fees_30d: columnHelper.accessor((p) => p.fees?.total30d, {
 		id: 'fees_30d',
 		header: 'Fees 30d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
 		meta: { align: 'end', headerHelperText: definitions.fees.protocol['30d'] },
-		size: 100
+		size: 110
 	}),
 	revenue_30d: columnHelper.accessor((p) => p.revenue?.total30d, {
 		id: 'revenue_30d',
 		header: 'Revenue 30d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
 		meta: { align: 'end', headerHelperText: definitions.revenue.protocol['30d'] },
-		size: 128
+		size: 135
 	}),
 	fees_24h: columnHelper.accessor((p) => p.fees?.total24h, {
 		id: 'fees_24h',
 		header: 'Fees 24h',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
 		meta: { align: 'end', headerHelperText: definitions.fees.protocol['24h'] },
-		size: 100
+		size: 110
 	}),
 	revenue_24h: columnHelper.accessor((p) => p.revenue?.total24h, {
 		id: 'revenue_24h',
 		header: 'Revenue 24h',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
 		meta: { align: 'end', headerHelperText: definitions.revenue.protocol['24h'] },
-		size: 128
+		size: 135
 	}),
 	perp_volume_24h: columnHelper.accessor((p) => p.perpVolume?.total24h, {
 		id: 'perp_volume_24h',
@@ -637,42 +776,42 @@ const COLUMN_REGISTRY: Record<string, ColumnDef<ProtocolRow, any>> = {
 		header: 'Perp Aggregator Volume 24h',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
 		meta: { align: 'end', headerHelperText: definitions.perpsAggregators.protocol['24h'] },
-		size: 220
+		size: 250
 	}),
 	perp_aggregator_volume_7d: columnHelper.accessor((p) => p.perpsAggregatorsVolume?.total7d, {
 		id: 'perp_aggregator_volume_7d',
 		header: 'Perp Aggregator Volume 7d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
 		meta: { align: 'end', headerHelperText: definitions.perpsAggregators.protocol['7d'] },
-		size: 220
+		size: 230
 	}),
 	perp_aggregator_volume_30d: columnHelper.accessor((p) => p.perpsAggregatorsVolume?.total30d, {
 		id: 'perp_aggregator_volume_30d',
 		header: 'Perp Aggregator Volume 30d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
 		meta: { align: 'end', headerHelperText: definitions.perpsAggregators.protocol['30d'] },
-		size: 220
+		size: 250
 	}),
 	bridge_aggregator_volume_24h: columnHelper.accessor((p) => p.bridgeAggregatorsVolume?.total24h, {
 		id: 'bridge_aggregator_volume_24h',
 		header: 'Bridge Aggregator Volume 24h',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
 		meta: { align: 'end', headerHelperText: definitions.bridgeAggregators.protocol['24h'] },
-		size: 220
+		size: 250
 	}),
 	bridge_aggregator_volume_7d: columnHelper.accessor((p) => p.bridgeAggregatorsVolume?.total7d, {
 		id: 'bridge_aggregator_volume_7d',
 		header: 'Bridge Aggregator Volume 7d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
 		meta: { align: 'end', headerHelperText: definitions.bridgeAggregators.protocol['7d'] },
-		size: 220
+		size: 230
 	}),
 	bridge_aggregator_volume_30d: columnHelper.accessor((p) => p.bridgeAggregatorsVolume?.total30d, {
 		id: 'bridge_aggregator_volume_30d',
 		header: 'Bridge Aggregator Volume 30d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
 		meta: { align: 'end', headerHelperText: definitions.bridgeAggregators.protocol['30d'] },
-		size: 220
+		size: 250
 	}),
 	normalized_volume_24h: columnHelper.accessor((p) => p.normalizedVolume?.total24h, {
 		id: 'normalized_volume_24h',
@@ -728,21 +867,21 @@ const COLUMN_REGISTRY: Record<string, ColumnDef<ProtocolRow, any>> = {
 		header: 'DEX Aggregator Volume 7d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
 		meta: { align: 'end', headerHelperText: definitions.dexAggregators.protocol['7d'] },
-		size: 220
+		size: 230
 	}),
 	dex_aggregator_volume_30d: columnHelper.accessor((p) => p.dexAggregatorsVolume?.total30d, {
 		id: 'dex_aggregator_volume_30d',
 		header: 'DEX Aggregator Volume 30d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
 		meta: { align: 'end', headerHelperText: definitions.dexAggregators.protocol['30d'] },
-		size: 220
+		size: 250
 	}),
 	dex_aggregator_volume_24h: columnHelper.accessor((p) => p.dexAggregatorsVolume?.total24h, {
 		id: 'dex_aggregator_volume_24h',
 		header: 'DEX Aggregator Volume 24h',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
 		meta: { align: 'end', headerHelperText: definitions.dexAggregators.protocol['24h'] },
-		size: 220
+		size: 250
 	}),
 	prediction_volume_7d: columnHelper.accessor((p) => p.dexVolume?.total7d, {
 		id: 'prediction_volume_7d',
@@ -880,5 +1019,5 @@ export function getColumnsForCategory({
 	metrics: IProtocolByCategoryOrTagPageData['capabilities']
 }) {
 	const columnIds = getProtocolCategoryColumns({ effectiveCategory, metrics })
-	return columnIds.map((id) => COLUMN_REGISTRY[id]).filter(Boolean)
+	return columnIds.flatMap((id) => (COLUMN_REGISTRY[id] ? [COLUMN_REGISTRY[id]] : []))
 }

--- a/src/containers/ProtocolsByCategoryOrTag/index.tsx
+++ b/src/containers/ProtocolsByCategoryOrTag/index.tsx
@@ -1,5 +1,5 @@
 import { type ColumnDef, createColumnHelper } from '@tanstack/react-table'
-import { lazy, Suspense, useDeferredValue, useMemo, useState } from 'react'
+import { Fragment, lazy, Suspense, useDeferredValue, useMemo, useState, type ReactNode } from 'react'
 import { ChartExportButtons } from '~/components/ButtonStyled/ChartExportButtons'
 import {
 	ChartGroupingSelector,
@@ -9,6 +9,7 @@ import {
 import { formatBarChart, formatLineChart } from '~/components/ECharts/utils'
 import { Icon } from '~/components/Icon'
 import { BasicLink } from '~/components/Link'
+import { MetricRow, MetricSection, SubMetricRow } from '~/components/MetricPrimitives'
 import { QuestionHelper } from '~/components/QuestionHelper'
 import { RowLinksWithDropdown } from '~/components/RowLinksWithDropdown'
 import { TableWithSearch } from '~/components/Table/TableWithSearch'
@@ -16,8 +17,8 @@ import { TokenLogo } from '~/components/TokenLogo'
 import { Tooltip } from '~/components/Tooltip'
 import { TVL_SETTINGS_KEYS, useLocalStorageSettingsManager } from '~/contexts/LocalStorage'
 import { useGetChartInstance } from '~/hooks/useGetChartInstance'
-import { definitions } from '~/public/definitions'
 import { formatNum, formattedNum } from '~/utils'
+import { definitions } from '../../../public/definitions'
 import {
 	getProtocolCategoryDexVolumeLabel,
 	getProtocolCategoryColumns,
@@ -28,9 +29,26 @@ import type { IProtocolByCategoryOrTagPageData } from './types'
 
 const MultiSeriesChart2 = lazy(() => import('~/components/ECharts/MultiSeriesChart2'))
 
+type SummaryMetricEntry = {
+	key: string
+	sortValue: number
+	content: ReactNode
+}
+
+const getSectionSortValue = (
+	metric: IProtocolByCategoryOrTagPageData['summaryMetrics'][keyof IProtocolByCategoryOrTagPageData['summaryMetrics']]
+) => {
+	if (metric?.total7d != null) return metric.total7d
+	if (metric?.total24h != null) return metric.total24h
+	if (metric?.total30d != null) return metric.total30d
+	return null
+}
+
 export function ProtocolsByCategoryOrTag(props: IProtocolByCategoryOrTagPageData) {
 	const name = props.category ?? props.tag ?? ''
 	const namePrefix = name ? `${name}-` : ''
+	const dexVolumeLabel = getProtocolCategoryDexVolumeLabel(props.effectiveCategory)
+	const showDexVolumeTooltip = dexVolumeLabel === 'DEX Volume'
 	const [groupBy, setGroupBy] = useState<LowercaseDwmcGrouping>('daily')
 	const { chartInstance, handleChartReady } = useGetChartInstance()
 	const categoryPresentation = useMemo(
@@ -101,13 +119,19 @@ export function ProtocolsByCategoryOrTag(props: IProtocolByCategoryOrTagPageData
 	const chartSeries = useMemo(() => charts.charts ?? [], [charts.charts])
 
 	const categoryColumns = useMemo(() => {
-		return getColumnsForCategory(props.effectiveCategory)
-	}, [props.effectiveCategory])
+		return getColumnsForCategory({
+			effectiveCategory: props.effectiveCategory,
+			metrics: props.capabilities
+		})
+	}, [props.effectiveCategory, props.capabilities])
 
 	const sortingState = useMemo(() => {
-		const sortId = getProtocolCategoryDefaultSort(props.effectiveCategory)
+		const sortId = getProtocolCategoryDefaultSort({
+			effectiveCategory: props.effectiveCategory,
+			metrics: props.capabilities
+		})
 		return [{ id: sortId, desc: true }]
-	}, [props.effectiveCategory])
+	}, [props.effectiveCategory, props.capabilities])
 
 	const hasBarCharts = useMemo(() => {
 		return chartSeries.some((series) => {
@@ -200,6 +224,165 @@ export function ProtocolsByCategoryOrTag(props: IProtocolByCategoryOrTagPageData
 	const deferredGroupedCharts = useDeferredValue(groupedCharts)
 
 	const chartGroupBy = groupBy
+	const sortedSummaryEntries = useMemo(() => {
+		const entries: SummaryMetricEntry[] = []
+		const latestTvl = charts.dataset?.source[charts.dataset?.source.length - 1]?.TVL
+		const tvlValue = typeof latestTvl === 'number' ? latestTvl : Number(latestTvl ?? NaN)
+
+		if (Number.isFinite(tvlValue)) {
+			entries.push({
+				key: 'tvl',
+				sortValue: tvlValue,
+				content: (
+					<MetricRow
+						label="Total Value Locked"
+						tooltip="Sum of value of all coins held in smart contracts of all the protocols on the chain"
+						value={formattedNum(tvlValue, true)}
+					/>
+				)
+			})
+		}
+
+		const pushSection = ({
+			key,
+			label,
+			metric,
+			primaryTooltip,
+			subtooltips
+		}: {
+			key: string
+			label: string
+			metric: IProtocolByCategoryOrTagPageData['summaryMetrics'][keyof IProtocolByCategoryOrTagPageData['summaryMetrics']]
+			primaryTooltip?: string
+			subtooltips?: Partial<Record<'24h' | '30d', string>>
+		}) => {
+			const sortValue = getSectionSortValue(metric)
+			if (sortValue == null) return
+
+			entries.push({
+				key,
+				sortValue,
+				content: (
+					<SummaryMetricSection
+						label={label}
+						metric={metric}
+						primaryTooltip={primaryTooltip}
+						subtooltips={subtooltips}
+					/>
+				)
+			})
+		}
+
+		pushSection({
+			key: 'fees',
+			label: 'Fees',
+			metric: props.summaryMetrics.fees,
+			primaryTooltip: definitions.fees.chain['7d'],
+			subtooltips: { '24h': definitions.fees.chain['24h'], '30d': definitions.fees.chain['30d'] }
+		})
+		pushSection({
+			key: 'revenue',
+			label: 'Revenue',
+			metric: props.summaryMetrics.revenue,
+			primaryTooltip: definitions.revenue.chain['7d'],
+			subtooltips: { '24h': definitions.revenue.chain['24h'], '30d': definitions.revenue.chain['30d'] }
+		})
+		pushSection({
+			key: 'dexVolume',
+			label: dexVolumeLabel,
+			metric: props.summaryMetrics.dexVolume,
+			primaryTooltip: showDexVolumeTooltip ? definitions.dexs.chain['7d'] : undefined,
+			subtooltips: showDexVolumeTooltip
+				? { '24h': definitions.dexs.chain['24h'], '30d': definitions.dexs.chain['30d'] }
+				: undefined
+		})
+		pushSection({
+			key: 'dexAggregatorsVolume',
+			label: 'DEX Aggregator Volume',
+			metric: props.summaryMetrics.dexAggregatorsVolume,
+			primaryTooltip: definitions.dexAggregators.chain['7d'],
+			subtooltips: {
+				'24h': definitions.dexAggregators.chain['24h'],
+				'30d': definitions.dexAggregators.chain['30d']
+			}
+		})
+		pushSection({
+			key: 'perpVolume',
+			label: 'Perp Volume',
+			metric: props.summaryMetrics.perpVolume,
+			primaryTooltip: definitions.perps.protocol['7d'],
+			subtooltips: { '24h': definitions.perps.protocol['24h'], '30d': definitions.perps.protocol['30d'] }
+		})
+		pushSection({
+			key: 'perpsAggregatorsVolume',
+			label: 'Perp Aggregator Volume',
+			metric: props.summaryMetrics.perpsAggregatorsVolume,
+			primaryTooltip: definitions.perpsAggregators.protocol['7d'],
+			subtooltips: {
+				'24h': definitions.perpsAggregators.protocol['24h'],
+				'30d': definitions.perpsAggregators.protocol['30d']
+			}
+		})
+		pushSection({
+			key: 'bridgeAggregatorsVolume',
+			label: 'Bridge Aggregator Volume',
+			metric: props.summaryMetrics.bridgeAggregatorsVolume,
+			primaryTooltip: definitions.bridgeAggregators.chain['7d'],
+			subtooltips: {
+				'24h': definitions.bridgeAggregators.chain['24h'],
+				'30d': definitions.bridgeAggregators.chain['30d']
+			}
+		})
+		pushSection({
+			key: 'normalizedVolume',
+			label: 'Normalized Volume',
+			metric: props.summaryMetrics.normalizedVolume,
+			primaryTooltip: definitions.normalizedVolume.protocol['7d'],
+			subtooltips: {
+				'24h': definitions.normalizedVolume.protocol['24h'],
+				'30d': definitions.normalizedVolume.protocol['30d']
+			}
+		})
+
+		if (props.summaryMetrics.openInterest?.total24h != null) {
+			entries.push({
+				key: 'openInterest',
+				sortValue: props.summaryMetrics.openInterest.total24h,
+				content: (
+					<MetricRow
+						label="Open Interest"
+						tooltip={definitions.openInterest.common}
+						value={formattedNum(props.summaryMetrics.openInterest.total24h, true)}
+					/>
+				)
+			})
+		}
+
+		pushSection({
+			key: 'optionsPremiumVolume',
+			label: 'Premium Volume',
+			metric: props.summaryMetrics.optionsPremiumVolume,
+			primaryTooltip: definitions.optionsPremium.protocol['7d'],
+			subtooltips: {
+				'24h': definitions.optionsPremium.protocol['24h'],
+				'30d': definitions.optionsPremium.protocol['30d']
+			}
+		})
+		pushSection({
+			key: 'optionsNotionalVolume',
+			label: 'Notional Volume',
+			metric: props.summaryMetrics.optionsNotionalVolume,
+			primaryTooltip: definitions.optionsNotional.protocol['7d'],
+			subtooltips: {
+				'24h': definitions.optionsNotional.protocol['24h'],
+				'30d': definitions.optionsNotional.protocol['30d']
+			}
+		})
+
+		return entries
+			.sort((a, b) => b.sortValue - a.sortValue)
+			.map((entry) => <Fragment key={entry.key}>{entry.content}</Fragment>)
+	}, [charts.dataset, dexVolumeLabel, props.summaryMetrics, showDexVolumeTooltip])
 
 	return (
 		<>
@@ -211,96 +394,7 @@ export function ProtocolsByCategoryOrTag(props: IProtocolByCategoryOrTagPageData
 					) : (
 						<h1 className="text-lg font-semibold">{`${categoryPresentation.headingLabel} on ${props.chain}`}</h1>
 					)}
-					<div className="mb-auto flex flex-1 flex-col gap-2">
-						{props.charts.dataset?.source.length > 0 ? (
-							<p className="flex flex-wrap items-center justify-between gap-4 text-base">
-								<Tooltip
-									content="Sum of value of all coins held in smart contracts of all the protocols on the chain"
-									className="font-normal text-(--text-label) underline decoration-dotted"
-								>
-									Total Value Locked
-								</Tooltip>
-
-								<span className="text-right font-jetbrains">
-									{formattedNum(charts.dataset?.source[charts.dataset?.source.length - 1]?.TVL, true)}
-								</span>
-							</p>
-						) : null}
-						{props.optionsPremium7d != null ? (
-							<p className="flex flex-wrap items-center justify-between gap-4 text-base">
-								<Tooltip
-									content={definitions.optionsPremium.chain['7d']}
-									className="font-normal text-(--text-label) underline decoration-dotted"
-								>
-									Premium Volume (7d)
-								</Tooltip>
-								<span className="text-right font-jetbrains">{formattedNum(props.optionsPremium7d, true)}</span>
-							</p>
-						) : null}
-						{props.optionsNotional7d != null ? (
-							<p className="flex flex-wrap items-center justify-between gap-4 text-base">
-								<Tooltip
-									content={definitions.optionsNotional.chain['7d']}
-									className="font-normal text-(--text-label) underline decoration-dotted"
-								>
-									Notional Volume (7d)
-								</Tooltip>
-								<span className="text-right font-jetbrains">{formattedNum(props.optionsNotional7d, true)}</span>
-							</p>
-						) : null}
-						{props.fees7d != null ? (
-							<p className="flex flex-wrap items-center justify-between gap-4 text-base">
-								<Tooltip
-									content={definitions.fees.chain['7d']}
-									className="font-normal text-(--text-label) underline decoration-dotted"
-								>
-									Fees (7d)
-								</Tooltip>
-								<span className="text-right font-jetbrains">{formattedNum(props.fees7d, true)}</span>
-							</p>
-						) : null}
-						{props.revenue7d != null ? (
-							<p className="flex flex-wrap items-center justify-between gap-4 text-base">
-								<Tooltip
-									content={definitions.revenue.chain['7d']}
-									className="font-normal text-(--text-label) underline decoration-dotted"
-								>
-									Revenue (7d)
-								</Tooltip>
-								<span className="text-right font-jetbrains">{formattedNum(props.revenue7d, true)}</span>
-							</p>
-						) : null}
-						{props.perpVolume7d != null ? (
-							<p className="flex flex-wrap items-center justify-between gap-4 text-base">
-								<Tooltip
-									content={definitions.perps.protocol['7d']}
-									className="font-normal text-(--text-label) underline decoration-dotted"
-								>
-									Perp Volume (7d)
-								</Tooltip>
-								<span className="text-right font-jetbrains">{formattedNum(props.perpVolume7d, true)}</span>
-							</p>
-						) : null}
-						{props.dexVolume7d != null ? (
-							<p className="flex flex-wrap items-center justify-between gap-4 text-base">
-								<span className="font-normal text-(--text-label)">
-									{getProtocolCategoryDexVolumeLabel(props.effectiveCategory)} (7d)
-								</span>
-								<span className="text-right font-jetbrains">{formattedNum(props.dexVolume7d, true)}</span>
-							</p>
-						) : null}
-						{props.openInterest != null ? (
-							<p className="flex flex-wrap items-center justify-between gap-4 text-base">
-								<Tooltip
-									content={definitions.openInterest.common}
-									className="font-normal text-(--text-label) underline decoration-dotted"
-								>
-									Open Interest
-								</Tooltip>
-								<span className="text-right font-jetbrains">{formattedNum(props.openInterest, true)}</span>
-							</p>
-						) : null}
-					</div>
+					<div className="mb-auto flex flex-1 flex-col">{sortedSummaryEntries}</div>
 				</div>
 				<div className="col-span-2 rounded-md border border-(--cards-border) bg-(--cards-bg)">
 					<div className="flex items-center justify-end gap-2 p-2 pb-0">
@@ -340,6 +434,43 @@ export function ProtocolsByCategoryOrTag(props: IProtocolByCategoryOrTagPageData
 				csvFileName={`defillama-${namePrefix}${props.chain || 'all'}-protocols`}
 			/>
 		</>
+	)
+}
+
+function SummaryMetricSection({
+	label,
+	metric,
+	primaryTooltip,
+	subtooltips
+}: {
+	label: string
+	metric: IProtocolByCategoryOrTagPageData['summaryMetrics'][keyof IProtocolByCategoryOrTagPageData['summaryMetrics']]
+	primaryTooltip?: string
+	subtooltips?: Partial<Record<'24h' | '30d', string>>
+}) {
+	if (!metric?.total7d && !metric?.total24h && !metric?.total30d) return null
+
+	return (
+		<MetricSection
+			label={`${label} (7d)`}
+			tooltip={primaryTooltip ?? null}
+			value={metric.total7d != null ? formattedNum(metric.total7d, true) : '—'}
+		>
+			{metric.total24h != null ? (
+				<SubMetricRow
+					label={`${label} (24h)`}
+					tooltip={subtooltips?.['24h']}
+					value={formattedNum(metric.total24h, true)}
+				/>
+			) : null}
+			{metric.total30d != null ? (
+				<SubMetricRow
+					label={`${label} (30d)`}
+					tooltip={subtooltips?.['30d']}
+					value={formattedNum(metric.total30d, true)}
+				/>
+			) : null}
+		</MetricSection>
 	)
 }
 
@@ -501,6 +632,69 @@ const COLUMN_REGISTRY: Record<string, ColumnDef<ProtocolRow, any>> = {
 		meta: { align: 'end', headerHelperText: definitions.perps.protocol['30d'] },
 		size: 160
 	}),
+	perp_aggregator_volume_24h: columnHelper.accessor((p) => p.perpsAggregatorsVolume?.total24h, {
+		id: 'perp_aggregator_volume_24h',
+		header: 'Perp Aggregator Volume 24h',
+		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
+		meta: { align: 'end', headerHelperText: definitions.perpsAggregators.protocol['24h'] },
+		size: 220
+	}),
+	perp_aggregator_volume_7d: columnHelper.accessor((p) => p.perpsAggregatorsVolume?.total7d, {
+		id: 'perp_aggregator_volume_7d',
+		header: 'Perp Aggregator Volume 7d',
+		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
+		meta: { align: 'end', headerHelperText: definitions.perpsAggregators.protocol['7d'] },
+		size: 220
+	}),
+	perp_aggregator_volume_30d: columnHelper.accessor((p) => p.perpsAggregatorsVolume?.total30d, {
+		id: 'perp_aggregator_volume_30d',
+		header: 'Perp Aggregator Volume 30d',
+		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
+		meta: { align: 'end', headerHelperText: definitions.perpsAggregators.protocol['30d'] },
+		size: 220
+	}),
+	bridge_aggregator_volume_24h: columnHelper.accessor((p) => p.bridgeAggregatorsVolume?.total24h, {
+		id: 'bridge_aggregator_volume_24h',
+		header: 'Bridge Aggregator Volume 24h',
+		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
+		meta: { align: 'end', headerHelperText: definitions.bridgeAggregators.protocol['24h'] },
+		size: 220
+	}),
+	bridge_aggregator_volume_7d: columnHelper.accessor((p) => p.bridgeAggregatorsVolume?.total7d, {
+		id: 'bridge_aggregator_volume_7d',
+		header: 'Bridge Aggregator Volume 7d',
+		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
+		meta: { align: 'end', headerHelperText: definitions.bridgeAggregators.protocol['7d'] },
+		size: 220
+	}),
+	bridge_aggregator_volume_30d: columnHelper.accessor((p) => p.bridgeAggregatorsVolume?.total30d, {
+		id: 'bridge_aggregator_volume_30d',
+		header: 'Bridge Aggregator Volume 30d',
+		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
+		meta: { align: 'end', headerHelperText: definitions.bridgeAggregators.protocol['30d'] },
+		size: 220
+	}),
+	normalized_volume_24h: columnHelper.accessor((p) => p.normalizedVolume?.total24h, {
+		id: 'normalized_volume_24h',
+		header: 'Normalized Volume 24h',
+		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
+		meta: { align: 'end', headerHelperText: definitions.normalizedVolume.protocol['24h'] },
+		size: 190
+	}),
+	normalized_volume_7d: columnHelper.accessor((p) => p.normalizedVolume?.total7d, {
+		id: 'normalized_volume_7d',
+		header: 'Normalized Volume 7d',
+		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
+		meta: { align: 'end', headerHelperText: definitions.normalizedVolume.protocol['7d'] },
+		size: 190
+	}),
+	normalized_volume_30d: columnHelper.accessor((p) => p.normalizedVolume?.total30d, {
+		id: 'normalized_volume_30d',
+		header: 'Normalized Volume 30d',
+		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
+		meta: { align: 'end', headerHelperText: definitions.normalizedVolume.protocol['30d'] },
+		size: 190
+	}),
 	openInterest: columnHelper.accessor((p) => p.openInterest?.total24h, {
 		id: 'openInterest',
 		header: 'Open Interest',
@@ -529,88 +723,88 @@ const COLUMN_REGISTRY: Record<string, ColumnDef<ProtocolRow, any>> = {
 		meta: { align: 'end', headerHelperText: definitions.dexs.protocol['24h'] },
 		size: 148
 	}),
-	dex_aggregator_volume_7d: columnHelper.accessor((p) => p.dexVolume?.total7d, {
+	dex_aggregator_volume_7d: columnHelper.accessor((p) => p.dexAggregatorsVolume?.total7d, {
 		id: 'dex_aggregator_volume_7d',
 		header: 'DEX Aggregator Volume 7d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
-		meta: { align: 'end', headerHelperText: definitions.dexs.protocol['7d'] },
+		meta: { align: 'end', headerHelperText: definitions.dexAggregators.protocol['7d'] },
 		size: 220
 	}),
-	dex_aggregator_volume_30d: columnHelper.accessor((p) => p.dexVolume?.total30d, {
+	dex_aggregator_volume_30d: columnHelper.accessor((p) => p.dexAggregatorsVolume?.total30d, {
 		id: 'dex_aggregator_volume_30d',
 		header: 'DEX Aggregator Volume 30d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
-		meta: { align: 'end', headerHelperText: definitions.dexs.protocol['30d'] },
+		meta: { align: 'end', headerHelperText: definitions.dexAggregators.protocol['30d'] },
 		size: 220
 	}),
-	dex_aggregator_volume_24h: columnHelper.accessor((p) => p.dexVolume?.total24h, {
+	dex_aggregator_volume_24h: columnHelper.accessor((p) => p.dexAggregatorsVolume?.total24h, {
 		id: 'dex_aggregator_volume_24h',
 		header: 'DEX Aggregator Volume 24h',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
-		meta: { align: 'end', headerHelperText: definitions.dexs.protocol['24h'] },
+		meta: { align: 'end', headerHelperText: definitions.dexAggregators.protocol['24h'] },
 		size: 220
 	}),
 	prediction_volume_7d: columnHelper.accessor((p) => p.dexVolume?.total7d, {
 		id: 'prediction_volume_7d',
 		header: 'Prediction Volume 7d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
-		meta: { align: 'end', headerHelperText: definitions.dexs.protocol['7d'] },
+		meta: { align: 'end' },
 		size: 180
 	}),
 	prediction_volume_30d: columnHelper.accessor((p) => p.dexVolume?.total30d, {
 		id: 'prediction_volume_30d',
 		header: 'Prediction Volume 30d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
-		meta: { align: 'end', headerHelperText: definitions.dexs.protocol['30d'] },
+		meta: { align: 'end' },
 		size: 195
 	}),
 	prediction_volume_24h: columnHelper.accessor((p) => p.dexVolume?.total24h, {
 		id: 'prediction_volume_24h',
 		header: 'Prediction Volume 24h',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
-		meta: { align: 'end', headerHelperText: definitions.dexs.protocol['24h'] },
+		meta: { align: 'end' },
 		size: 195
 	}),
 	payment_volume_7d: columnHelper.accessor((p) => p.dexVolume?.total7d, {
 		id: 'payment_volume_7d',
 		header: 'Payment Volume 7d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
-		meta: { align: 'end', headerHelperText: definitions.dexs.protocol['7d'] },
+		meta: { align: 'end' },
 		size: 180
 	}),
 	payment_volume_30d: columnHelper.accessor((p) => p.dexVolume?.total30d, {
 		id: 'payment_volume_30d',
 		header: 'Payment Volume 30d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
-		meta: { align: 'end', headerHelperText: definitions.dexs.protocol['30d'] },
+		meta: { align: 'end' },
 		size: 180
 	}),
 	payment_volume_24h: columnHelper.accessor((p) => p.dexVolume?.total24h, {
 		id: 'payment_volume_24h',
 		header: 'Payment Volume 24h',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
-		meta: { align: 'end', headerHelperText: definitions.dexs.protocol['24h'] },
+		meta: { align: 'end' },
 		size: 180
 	}),
 	spot_volume_7d: columnHelper.accessor((p) => p.dexVolume?.total7d, {
 		id: 'spot_volume_7d',
 		header: 'Spot Volume 7d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
-		meta: { align: 'end', headerHelperText: definitions.dexs.protocol['7d'] },
+		meta: { align: 'end' },
 		size: 160
 	}),
 	spot_volume_30d: columnHelper.accessor((p) => p.dexVolume?.total30d, {
 		id: 'spot_volume_30d',
 		header: 'Spot Volume 30d',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
-		meta: { align: 'end', headerHelperText: definitions.dexs.protocol['30d'] },
+		meta: { align: 'end' },
 		size: 160
 	}),
 	spot_volume_24h: columnHelper.accessor((p) => p.dexVolume?.total24h, {
 		id: 'spot_volume_24h',
 		header: 'Spot Volume 24h',
 		cell: (info) => (info.getValue() != null ? formattedNum(info.getValue(), true) : null),
-		meta: { align: 'end', headerHelperText: definitions.dexs.protocol['24h'] },
+		meta: { align: 'end' },
 		size: 160
 	}),
 	options_premium_7d: columnHelper.accessor((p) => p.optionsPremium?.total7d, {
@@ -678,7 +872,13 @@ const COLUMN_REGISTRY: Record<string, ColumnDef<ProtocolRow, any>> = {
 	})
 }
 
-export function getColumnsForCategory(effectiveCategory: string | null) {
-	const columnIds = getProtocolCategoryColumns(effectiveCategory)
+export function getColumnsForCategory({
+	effectiveCategory,
+	metrics
+}: {
+	effectiveCategory: string | null
+	metrics: IProtocolByCategoryOrTagPageData['capabilities']
+}) {
+	const columnIds = getProtocolCategoryColumns({ effectiveCategory, metrics })
 	return columnIds.map((id) => COLUMN_REGISTRY[id]).filter(Boolean)
 }

--- a/src/containers/ProtocolsByCategoryOrTag/queries.test.ts
+++ b/src/containers/ProtocolsByCategoryOrTag/queries.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { IAdapterChainMetrics } from '~/containers/DimensionAdapters/api.types'
 import type { ParentProtocolLite, ProtocolLite } from '~/containers/Protocols/api.types'
+import type { ICategoriesAndTags } from '~/utils/metadata/types'
 
 const {
 	fetchProtocolsMock,
@@ -114,6 +115,44 @@ const makeAdapterProtocol = ({
 		linkedProtocols: []
 	}) as IAdapterChainMetrics['protocols'][number]
 
+const categoriesAndTags: ICategoriesAndTags = {
+	categories: ['Interface', 'Dexs'],
+	tags: ['StableSwap'],
+	tagCategoryMap: {
+		StableSwap: 'Dexs'
+	},
+	configs: {
+		Interface: {
+			category: 'Interface',
+			chains: ['ethereum'],
+			slug: 'interface',
+			fees: true,
+			revenue: true,
+			dexs: true,
+			dexAggregators: true,
+			perps: true,
+			perpsAggregators: true,
+			bridgeAggregators: true,
+			normalizedVolume: true,
+			openInterest: true,
+			optionsPremiumVolume: true,
+			optionsNotionalVolume: true
+		},
+		Dexs: {
+			category: 'Dexs',
+			chains: ['ethereum'],
+			slug: 'dexs',
+			dexs: true
+		},
+		StableSwap: {
+			category: 'StableSwap',
+			chains: ['ethereum'],
+			slug: 'stableswap',
+			fees: true
+		}
+	}
+}
+
 describe('ProtocolsByCategoryOrTag queries', () => {
 	beforeEach(() => {
 		const liteProtocols: ProtocolLite[] = []
@@ -131,9 +170,9 @@ describe('ProtocolsByCategoryOrTag queries', () => {
 		fetchTagChartMock.mockResolvedValue({
 			tvl: { 1710000000: 100 }
 		})
-		fetchJsonMock.mockResolvedValue({ Interface: ['Ethereum'] })
+		fetchJsonMock.mockResolvedValue({ Interface: ['Ethereum'], StableSwap: ['Ethereum'] })
 
-		fetchAdapterChainMetricsMock.mockImplementation(async ({ adapterType, dataType }) => {
+		fetchAdapterChainMetricsMock.mockImplementation(async ({ adapterType, dataType, category }) => {
 			if (adapterType === 'dexs') {
 				return makeAdapterMetrics([
 					makeAdapterProtocol({
@@ -182,12 +221,164 @@ describe('ProtocolsByCategoryOrTag queries', () => {
 				])
 			}
 
+			if (adapterType === 'aggregators') {
+				return makeAdapterMetrics([
+					makeAdapterProtocol({
+						defillamaId: 'hybrid',
+						name: 'Hybrid UI',
+						total24h: 60,
+						total7d: 420,
+						total30d: 1800
+					}),
+					makeAdapterProtocol({
+						defillamaId: 'child-a',
+						name: 'Interface Child A',
+						parentProtocol: 'parent#Interface Suite',
+						total24h: 6,
+						total7d: 42,
+						total30d: 180
+					})
+				])
+			}
+
+			if (adapterType === 'aggregator-derivatives') {
+				return makeAdapterMetrics([
+					makeAdapterProtocol({
+						defillamaId: 'hybrid',
+						name: 'Hybrid UI',
+						total24h: 12,
+						total7d: 84,
+						total30d: 360
+					}),
+					makeAdapterProtocol({
+						defillamaId: 'child-b',
+						name: 'Interface Child B',
+						parentProtocol: 'parent#Interface Suite',
+						total24h: 3,
+						total7d: 21,
+						total30d: 90
+					})
+				])
+			}
+
+			if (adapterType === 'bridge-aggregators') {
+				return makeAdapterMetrics([
+					makeAdapterProtocol({
+						defillamaId: 'hybrid',
+						name: 'Hybrid UI',
+						total24h: 7,
+						total7d: 49,
+						total30d: 210
+					})
+				])
+			}
+
+			if (adapterType === 'normalized-volume') {
+				return makeAdapterMetrics([
+					makeAdapterProtocol({
+						defillamaId: 'hybrid',
+						name: 'Hybrid UI',
+						total24h: 50,
+						total7d: 350,
+						total30d: 1500
+					})
+				])
+			}
+
+			if (adapterType === 'open-interest') {
+				return makeAdapterMetrics([
+					makeAdapterProtocol({
+						defillamaId: 'hybrid',
+						name: 'Hybrid UI',
+						total24h: 15,
+						total7d: 105,
+						total30d: 450
+					}),
+					makeAdapterProtocol({
+						defillamaId: 'child-b',
+						name: 'Interface Child B',
+						parentProtocol: 'parent#Interface Suite',
+						total24h: 5,
+						total7d: 35,
+						total30d: 150
+					})
+				])
+			}
+
 			if (adapterType === 'fees' && dataType === 'dailyRevenue') {
+				if (category === 'interface') {
+					return makeAdapterMetrics([
+						makeAdapterProtocol({
+							defillamaId: 'hybrid',
+							name: 'Hybrid UI',
+							total24h: 2,
+							total7d: 14,
+							total30d: 60
+						})
+					])
+				}
+
 				return makeAdapterMetrics([])
 			}
 
 			if (adapterType === 'fees') {
+				if (category === 'interface') {
+					return makeAdapterMetrics([
+						makeAdapterProtocol({
+							defillamaId: 'hybrid',
+							name: 'Hybrid UI',
+							total24h: 8,
+							total7d: 56,
+							total30d: 240
+						}),
+						makeAdapterProtocol({
+							defillamaId: 'child-a',
+							name: 'Interface Child A',
+							parentProtocol: 'parent#Interface Suite',
+							total24h: 3,
+							total7d: 21,
+							total30d: 90
+						})
+					])
+				}
+
+				if (category === 'stableswap') {
+					return makeAdapterMetrics([
+						makeAdapterProtocol({
+							defillamaId: 'stable-fees',
+							name: 'Stable Fees',
+							total24h: 5,
+							total7d: 50,
+							total30d: 500
+						})
+					])
+				}
+
 				return makeAdapterMetrics([])
+			}
+
+			if (adapterType === 'options' && dataType === 'dailyPremiumVolume') {
+				return makeAdapterMetrics([
+					makeAdapterProtocol({
+						defillamaId: 'hybrid',
+						name: 'Hybrid UI',
+						total24h: 4,
+						total7d: 28,
+						total30d: 120
+					})
+				])
+			}
+
+			if (adapterType === 'options' && dataType === 'dailyNotionalVolume') {
+				return makeAdapterMetrics([
+					makeAdapterProtocol({
+						defillamaId: 'hybrid',
+						name: 'Hybrid UI',
+						total24h: 9,
+						total7d: 63,
+						total30d: 270
+					})
+				])
 			}
 
 			return makeAdapterMetrics([])
@@ -208,6 +399,41 @@ describe('ProtocolsByCategoryOrTag queries', () => {
 				]
 			}
 
+			if (adapterType === 'aggregators') {
+				return [
+					[1710000000, 3],
+					[1710086400, 6]
+				]
+			}
+
+			if (adapterType === 'aggregator-derivatives') {
+				return [
+					[1710000000, 2],
+					[1710086400, 4]
+				]
+			}
+
+			if (adapterType === 'bridge-aggregators') {
+				return [
+					[1710000000, 1],
+					[1710086400, 2]
+				]
+			}
+
+			if (adapterType === 'normalized-volume') {
+				return [
+					[1710000000, 5],
+					[1710086400, 10]
+				]
+			}
+
+			if (adapterType === 'options') {
+				return [
+					[1710000000, 8],
+					[1710086400, 16]
+				]
+			}
+
 			return []
 		})
 	})
@@ -224,6 +450,9 @@ describe('ProtocolsByCategoryOrTag queries', () => {
 			dexVolumeChartData: [[1710000000, 10]],
 			dexAggregatorsVolumeChartData: null,
 			perpVolumeChartData: [[1710000000, 4]],
+			perpsAggregatorsVolumeChartData: null,
+			bridgeAggregatorsVolumeChartData: null,
+			normalizedVolumeChartData: null,
 			openInterestChartData: null,
 			optionsPremiumVolumeChartData: null,
 			optionsNotionalVolumeChartData: null,
@@ -236,10 +465,11 @@ describe('ProtocolsByCategoryOrTag queries', () => {
 		expect(chart.charts.map((series) => series.name)).toEqual(['TVL', 'Spot Volume', 'Perp Volume'])
 	})
 
-	it('merges adapter-only interface protocols and preserves both dex and perp metrics', async () => {
+	it('merges adapter-only interface protocols and preserves independent metric families', async () => {
 		const result = await getProtocolsByCategoryOrTag({
 			kind: 'category',
 			category: 'Interface',
+			categoriesAndTags,
 			chainMetadata: {}
 		})
 
@@ -250,11 +480,80 @@ describe('ProtocolsByCategoryOrTag queries', () => {
 		expect(hybrid).toBeDefined()
 		expect(hybrid?.tvl).toBeNull()
 		expect(hybrid?.dexVolume?.total24h).toBe(100)
+		expect(hybrid?.dexAggregatorsVolume?.total24h).toBe(60)
 		expect(hybrid?.perpVolume?.total24h).toBe(40)
+		expect(hybrid?.perpsAggregatorsVolume?.total24h).toBe(12)
+		expect(hybrid?.bridgeAggregatorsVolume?.total24h).toBe(7)
+		expect(hybrid?.normalizedVolume?.total24h).toBe(50)
+		expect(hybrid?.optionsPremium?.total24h).toBe(4)
+		expect(hybrid?.optionsNotional?.total24h).toBe(9)
 
 		const parent = result.protocols.find((protocol) => protocol.name === 'Interface Suite')
 		expect(parent?.subRows?.map((row) => row.name)).toEqual(['Interface Child A', 'Interface Child B'])
 		expect(parent?.dexVolume?.total24h).toBe(50)
+		expect(parent?.dexAggregatorsVolume?.total24h).toBe(6)
 		expect(parent?.perpVolume?.total24h).toBe(10)
+		expect(parent?.perpsAggregatorsVolume?.total24h).toBe(3)
+		expect(result.summaryMetrics.fees?.total7d).toBe(77)
+		expect(result.summaryMetrics.revenue?.total7d).toBe(14)
+		expect(result.summaryMetrics.dexVolume?.total7d).toBe(1050)
+		expect(result.summaryMetrics.dexAggregatorsVolume?.total7d).toBe(462)
+		expect(result.summaryMetrics.perpVolume?.total7d).toBe(350)
+		expect(result.summaryMetrics.perpsAggregatorsVolume?.total7d).toBe(105)
+		expect(result.summaryMetrics.bridgeAggregatorsVolume?.total7d).toBe(49)
+		expect(result.summaryMetrics.normalizedVolume?.total7d).toBe(350)
+		expect(result.summaryMetrics.optionsPremiumVolume?.total7d).toBe(28)
+		expect(result.summaryMetrics.optionsNotionalVolume?.total7d).toBe(63)
+		expect(result.summaryMetrics.openInterest?.total30d).toBe(600)
+		expect(result.summaryMetrics.dexAggregatorsVolume?.total7d).not.toBe(result.summaryMetrics.dexVolume?.total7d)
+		expect(fetchAdapterChainMetricsMock).toHaveBeenCalledWith(
+			expect.objectContaining({ adapterType: 'aggregators', category: 'interface' })
+		)
+		expect(fetchAdapterChainMetricsMock).toHaveBeenCalledWith(
+			expect.objectContaining({ adapterType: 'aggregator-derivatives', category: 'interface' })
+		)
+		expect(fetchAdapterChainMetricsMock).toHaveBeenCalledWith(
+			expect.objectContaining({ adapterType: 'bridge-aggregators', category: 'interface' })
+		)
+		expect(fetchAdapterChainMetricsMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				adapterType: 'normalized-volume',
+				dataType: 'dailyNormalizedVolume',
+				category: 'interface'
+			})
+		)
+		expect(fetchAdapterChainMetricsMock).toHaveBeenCalledWith(
+			expect.objectContaining({ adapterType: 'options', dataType: 'dailyPremiumVolume', category: 'interface' })
+		)
+		expect(fetchAdapterChainMetricsMock).toHaveBeenCalledWith(
+			expect.objectContaining({ adapterType: 'options', dataType: 'dailyNotionalVolume', category: 'interface' })
+		)
+		expect(result.chains).toEqual([
+			{ label: 'All', to: '/protocols/interface' },
+			{ label: 'Ethereum', to: '/protocols/interface/ethereum' }
+		])
+	})
+
+	it('uses direct tag config capabilities instead of inheriting parent dex capabilities', async () => {
+		const result = await getProtocolsByCategoryOrTag({
+			kind: 'tag',
+			tag: 'StableSwap',
+			tagCategory: 'Dexs',
+			categoriesAndTags,
+			chainMetadata: {}
+		})
+
+		expect(result).not.toBeNull()
+		if (!result) return
+
+		expect(result.capabilities.dexVolume).toBe(false)
+		expect(result.capabilities.fees).toBe(true)
+		expect(fetchAdapterChainMetricsMock).not.toHaveBeenCalledWith(
+			expect.objectContaining({
+				adapterType: 'dexs',
+				category: 'stableswap'
+			})
+		)
+		expect(result.summaryMetrics.fees?.total7d).toBe(50)
 	})
 })

--- a/src/containers/ProtocolsByCategoryOrTag/queries.tsx
+++ b/src/containers/ProtocolsByCategoryOrTag/queries.tsx
@@ -8,17 +8,20 @@ import { TVL_SETTINGS_KEYS, TVL_SETTINGS_KEYS_SET } from '~/contexts/LocalStorag
 import { getNDistinctColors, getPercentChange, slug } from '~/utils'
 import { fetchJson } from '~/utils/async'
 import { tokenIconUrl } from '~/utils/icons'
-import type { IChainMetadata } from '~/utils/metadata/types'
+import type { ICategoriesAndTags, IChainMetadata } from '~/utils/metadata/types'
 import { fetchCategoriesSummary, fetchCategoryChart, fetchTagChart } from './api'
 import {
 	categoriesPageExcludedExtraTvls,
+	getProtocolCategoryCapabilities,
 	getProtocolCategoryChartMetricLabel,
 	getProtocolCategoryChartMetrics,
 	protocolCategoryConfig,
+	resolveProtocolCategoryDataConfig,
 	type ProtocolCategoryChartMetric,
 	type ProtocolCategoryMetrics
 } from './constants'
 import type {
+	IProtocolMetricTotals,
 	IProtocolByCategoryOrTagPageData,
 	IProtocolsCategoriesExtraTvlPoint,
 	IProtocolsCategoriesPageData,
@@ -27,6 +30,7 @@ import type {
 
 type GetProtocolsByCategoryOrTagParams = {
 	chain?: string
+	categoriesAndTags: ICategoriesAndTags
 	chainMetadata: Record<string, IChainMetadata>
 } & (
 	| {
@@ -48,6 +52,9 @@ const CHART_METRIC_SERIES_TYPE: Record<ProtocolCategoryChartMetric, 'line' | 'ba
 	dexVolume: 'bar',
 	dexAggregatorsVolume: 'bar',
 	perpVolume: 'bar',
+	perpsAggregatorsVolume: 'bar',
+	bridgeAggregatorsVolume: 'bar',
+	normalizedVolume: 'bar',
 	openInterest: 'line',
 	optionsPremiumVolume: 'bar',
 	optionsNotionalVolume: 'bar',
@@ -60,6 +67,9 @@ const CHART_METRIC_Y_AXIS_INDEX: Record<ProtocolCategoryChartMetric, number> = {
 	dexVolume: 1,
 	dexAggregatorsVolume: 1,
 	perpVolume: 1,
+	perpsAggregatorsVolume: 1,
+	bridgeAggregatorsVolume: 1,
+	normalizedVolume: 1,
 	openInterest: 1,
 	optionsPremiumVolume: 1,
 	optionsNotionalVolume: 1,
@@ -181,6 +191,9 @@ export const buildCategoryCharts = ({
 	dexVolumeChartData,
 	dexAggregatorsVolumeChartData,
 	perpVolumeChartData,
+	perpsAggregatorsVolumeChartData,
+	bridgeAggregatorsVolumeChartData,
+	normalizedVolumeChartData,
 	openInterestChartData,
 	optionsPremiumVolumeChartData,
 	optionsNotionalVolumeChartData,
@@ -193,6 +206,9 @@ export const buildCategoryCharts = ({
 	dexVolumeChartData: Array<[number, number]> | null
 	dexAggregatorsVolumeChartData: Array<[number, number]> | null
 	perpVolumeChartData: Array<[number, number]> | null
+	perpsAggregatorsVolumeChartData: Array<[number, number]> | null
+	bridgeAggregatorsVolumeChartData: Array<[number, number]> | null
+	normalizedVolumeChartData: Array<[number, number]> | null
 	openInterestChartData: Array<[number, number]> | null
 	optionsPremiumVolumeChartData: Array<[number, number]> | null
 	optionsNotionalVolumeChartData: Array<[number, number]> | null
@@ -204,6 +220,9 @@ export const buildCategoryCharts = ({
 		dexVolume: createTimeSeriesMap(dexVolumeChartData),
 		dexAggregatorsVolume: createTimeSeriesMap(dexAggregatorsVolumeChartData),
 		perpVolume: createTimeSeriesMap(perpVolumeChartData),
+		perpsAggregatorsVolume: createTimeSeriesMap(perpsAggregatorsVolumeChartData),
+		bridgeAggregatorsVolume: createTimeSeriesMap(bridgeAggregatorsVolumeChartData),
+		normalizedVolume: createTimeSeriesMap(normalizedVolumeChartData),
 		openInterest: createTimeSeriesMap(openInterestChartData),
 		optionsPremiumVolume: createTimeSeriesMap(optionsPremiumVolumeChartData),
 		optionsNotionalVolume: createTimeSeriesMap(optionsNotionalVolumeChartData),
@@ -268,16 +287,18 @@ type PerpMetricTotals = ProtocolMetricTotals & {
 	zeroFeePerp?: boolean
 }
 
-type OpenInterestTotals = {
-	total24h: number | null
-}
+type OpenInterestTotals = ProtocolMetricTotals
 
 type AdapterProtocolData = {
 	chains: Array<string>
 	fees?: ProtocolMetricTotals
 	revenue?: ProtocolMetricTotals
 	dexVolume?: ProtocolMetricTotals
+	dexAggregatorsVolume?: ProtocolMetricTotals
 	perpVolume?: PerpMetricTotals
+	perpsAggregatorsVolume?: ProtocolMetricTotals
+	bridgeAggregatorsVolume?: ProtocolMetricTotals
+	normalizedVolume?: ProtocolMetricTotals
 	openInterest?: OpenInterestTotals
 	optionsPremium?: ProtocolMetricTotals
 	optionsNotional?: ProtocolMetricTotals
@@ -293,24 +314,36 @@ type ChainTvlPoint = {
 export async function getProtocolsByCategoryOrTag(
 	params: GetProtocolsByCategoryOrTagParams
 ): Promise<IProtocolByCategoryOrTagPageData | null> {
-	const { chain, chainMetadata } = params
+	const { chain, chainMetadata, categoriesAndTags } = params
 	const category = params.kind === 'category' ? params.category : undefined
 	const tag = params.kind === 'tag' ? params.tag : undefined
 	// For tag pages, we use the tag's parent category for category-specific logic.
 	const effectiveCategory = params.kind === 'category' ? params.category : params.tagCategory
 	const dimensionCategory = slug(category ?? tag ?? '')
-	const config = effectiveCategory ? protocolCategoryConfig[effectiveCategory] : null
-	const categoryMetrics: ProtocolCategoryMetrics | undefined = config?.metrics
-	const chartMetrics = getProtocolCategoryChartMetrics(effectiveCategory)
+	const dataConfig = resolveProtocolCategoryDataConfig({
+		categoriesAndTags,
+		category,
+		tag,
+		tagCategory: params.kind === 'tag' ? params.tagCategory : null
+	})
+	const capabilities: ProtocolCategoryMetrics = getProtocolCategoryCapabilities({
+		dataConfig,
+		effectiveCategory
+	})
+	const chartMetrics = getProtocolCategoryChartMetrics(capabilities)
 
 	const currentChainMetadata: IChainMetadata = chain
 		? chainMetadata[slug(chain)]
 		: {
 				name: 'All',
 				fees: true,
+				revenue: true,
 				dexs: true,
 				dexAggregators: true,
 				perps: true,
+				perpsAggregators: true,
+				bridgeAggregators: true,
+				normalizedVolume: true,
 				openInterest: true,
 				optionsPremiumVolume: true,
 				optionsNotionalVolume: true,
@@ -326,7 +359,11 @@ export async function getProtocolsByCategoryOrTag(
 		feesData,
 		revenueData,
 		dexVolumeData,
+		dexAggregatorsVolumeData,
 		perpVolumeData,
+		perpsAggregatorsVolumeData,
+		bridgeAggregatorsVolumeData,
+		normalizedVolumeData,
 		openInterestData,
 		optionsPremiumData,
 		optionsNotionalData,
@@ -334,12 +371,19 @@ export async function getProtocolsByCategoryOrTag(
 		dexVolumeChartData,
 		dexAggregatorsVolumeChartData,
 		perpVolumeChartData,
+		perpsAggregatorsVolumeChartData,
+		bridgeAggregatorsVolumeChartData,
+		normalizedVolumeChartData,
 		openInterestChartData,
 		optionsPremiumVolumeChartData,
 		optionsNotionalVolumeChartData,
 		chainsByCategoriesOrTags
 	]: [
 		{ protocols: Array<ProtocolLite>; parentProtocols: Array<ParentProtocolLite> },
+		IAdapterChainMetrics | null,
+		IAdapterChainMetrics | null,
+		IAdapterChainMetrics | null,
+		IAdapterChainMetrics | null,
 		IAdapterChainMetrics | null,
 		IAdapterChainMetrics | null,
 		IAdapterChainMetrics | null,
@@ -354,17 +398,20 @@ export async function getProtocolsByCategoryOrTag(
 		Array<[number, number]> | null,
 		Array<[number, number]> | null,
 		Array<[number, number]> | null,
+		Array<[number, number]> | null,
+		Array<[number, number]> | null,
+		Array<[number, number]> | null,
 		Record<string, Array<string>> | null
 	] = await Promise.all([
 		fetchProtocols(),
-		currentChainMetadata?.fees
+		capabilities.fees && currentChainMetadata?.fees
 			? fetchAdapterChainMetrics({
 					chain: chain ?? 'All',
 					adapterType: 'fees',
 					category: dimensionCategory
 				})
 			: null,
-		currentChainMetadata?.fees
+		capabilities.revenue && (currentChainMetadata?.revenue ?? currentChainMetadata?.fees)
 			? fetchAdapterChainMetrics({
 					chain: chain ?? 'All',
 					adapterType: 'fees',
@@ -372,27 +419,50 @@ export async function getProtocolsByCategoryOrTag(
 					category: dimensionCategory
 				})
 			: null,
-		categoryMetrics?.dexVolume && currentChainMetadata?.dexs
+		capabilities.dexVolume && currentChainMetadata?.dexs
 			? fetchAdapterChainMetrics({
 					chain: chain ?? 'All',
 					adapterType: 'dexs',
 					category: dimensionCategory
 				})
-			: categoryMetrics?.dexAggregatorsVolume && currentChainMetadata?.dexAggregators
-				? fetchAdapterChainMetrics({
-						chain: chain ?? 'All',
-						adapterType: 'aggregators',
-						category: dimensionCategory
-					})
-				: null,
-		categoryMetrics?.perpVolume && currentChainMetadata?.perps
+			: null,
+		capabilities.dexAggregatorsVolume && currentChainMetadata?.dexAggregators
+			? fetchAdapterChainMetrics({
+					chain: chain ?? 'All',
+					adapterType: 'aggregators',
+					category: dimensionCategory
+				})
+			: null,
+		capabilities.perpVolume && currentChainMetadata?.perps
 			? fetchAdapterChainMetrics({
 					chain: chain ?? 'All',
 					adapterType: 'derivatives',
 					category: dimensionCategory
 				})
 			: null,
-		categoryMetrics?.openInterest && currentChainMetadata?.openInterest
+		capabilities.perpsAggregatorsVolume && currentChainMetadata?.perpsAggregators
+			? fetchAdapterChainMetrics({
+					chain: chain ?? 'All',
+					adapterType: 'aggregator-derivatives',
+					category: dimensionCategory
+				})
+			: null,
+		capabilities.bridgeAggregatorsVolume && currentChainMetadata?.bridgeAggregators
+			? fetchAdapterChainMetrics({
+					chain: chain ?? 'All',
+					adapterType: 'bridge-aggregators',
+					category: dimensionCategory
+				})
+			: null,
+		capabilities.normalizedVolume && currentChainMetadata?.normalizedVolume
+			? fetchAdapterChainMetrics({
+					chain: chain ?? 'All',
+					adapterType: 'normalized-volume',
+					dataType: 'dailyNormalizedVolume',
+					category: dimensionCategory
+				})
+			: null,
+		capabilities.openInterest && currentChainMetadata?.openInterest
 			? fetchAdapterChainMetrics({
 					chain: chain ?? 'All',
 					adapterType: 'open-interest',
@@ -403,7 +473,7 @@ export async function getProtocolsByCategoryOrTag(
 					return null
 				})
 			: null,
-		categoryMetrics?.optionsPremiumVolume && currentChainMetadata?.optionsPremiumVolume
+		capabilities.optionsPremiumVolume && currentChainMetadata?.optionsPremiumVolume
 			? fetchAdapterChainMetrics({
 					chain: chain ?? 'All',
 					adapterType: 'options',
@@ -411,7 +481,7 @@ export async function getProtocolsByCategoryOrTag(
 					category: dimensionCategory
 				})
 			: null,
-		categoryMetrics?.optionsNotionalVolume && currentChainMetadata?.optionsNotionalVolume
+		capabilities.optionsNotionalVolume && currentChainMetadata?.optionsNotionalVolume
 			? fetchAdapterChainMetrics({
 					chain: chain ?? 'All',
 					adapterType: 'options',
@@ -420,28 +490,50 @@ export async function getProtocolsByCategoryOrTag(
 				})
 			: null,
 		tag ? fetchTagChart({ tag, chain }) : fetchCategoryChart({ category: category ?? '', chain }),
-		categoryMetrics?.dexVolume && currentChainMetadata?.dexs
+		capabilities.dexVolume && currentChainMetadata?.dexs
 			? fetchAdapterChainChartData({
 					chain: chain ?? 'All',
 					adapterType: 'dexs',
 					category: dimensionCategory
 				}).catch(() => null)
 			: null,
-		categoryMetrics?.dexAggregatorsVolume && currentChainMetadata?.dexAggregators
+		capabilities.dexAggregatorsVolume && currentChainMetadata?.dexAggregators
 			? fetchAdapterChainChartData({
 					chain: chain ?? 'All',
 					adapterType: 'aggregators',
 					category: dimensionCategory
 				}).catch(() => null)
 			: null,
-		categoryMetrics?.perpVolume && currentChainMetadata?.perps
+		capabilities.perpVolume && currentChainMetadata?.perps
 			? fetchAdapterChainChartData({
 					chain: chain ?? 'All',
 					adapterType: 'derivatives',
 					category: dimensionCategory
 				}).catch(() => null)
 			: null,
-		categoryMetrics?.openInterest && currentChainMetadata?.openInterest
+		capabilities.perpsAggregatorsVolume && currentChainMetadata?.perpsAggregators
+			? fetchAdapterChainChartData({
+					chain: chain ?? 'All',
+					adapterType: 'aggregator-derivatives',
+					category: dimensionCategory
+				}).catch(() => null)
+			: null,
+		capabilities.bridgeAggregatorsVolume && currentChainMetadata?.bridgeAggregators
+			? fetchAdapterChainChartData({
+					chain: chain ?? 'All',
+					adapterType: 'bridge-aggregators',
+					category: dimensionCategory
+				}).catch(() => null)
+			: null,
+		capabilities.normalizedVolume && currentChainMetadata?.normalizedVolume
+			? fetchAdapterChainChartData({
+					chain: chain ?? 'All',
+					adapterType: 'normalized-volume',
+					dataType: 'dailyNormalizedVolume',
+					category: dimensionCategory
+				}).catch(() => null)
+			: null,
+		capabilities.openInterest && currentChainMetadata?.openInterest
 			? fetchAdapterChainChartData({
 					chain: chain ?? 'All',
 					adapterType: 'open-interest',
@@ -449,7 +541,7 @@ export async function getProtocolsByCategoryOrTag(
 					category: dimensionCategory
 				}).catch(() => null)
 			: null,
-		categoryMetrics?.optionsPremiumVolume && currentChainMetadata?.optionsPremiumVolume
+		capabilities.optionsPremiumVolume && currentChainMetadata?.optionsPremiumVolume
 			? fetchAdapterChainChartData({
 					chain: chain ?? 'All',
 					adapterType: 'options',
@@ -457,7 +549,7 @@ export async function getProtocolsByCategoryOrTag(
 					category: dimensionCategory
 				}).catch(() => null)
 			: null,
-		categoryMetrics?.optionsNotionalVolume && currentChainMetadata?.optionsNotionalVolume
+		capabilities.optionsNotionalVolume && currentChainMetadata?.optionsNotionalVolume
 			? fetchAdapterChainChartData({
 					chain: chain ?? 'All',
 					adapterType: 'options',
@@ -476,7 +568,11 @@ export async function getProtocolsByCategoryOrTag(
 		...(feesData?.protocols ?? []),
 		...(revenueData?.protocols ?? []),
 		...(dexVolumeData?.protocols ?? []),
+		...(dexAggregatorsVolumeData?.protocols ?? []),
 		...(perpVolumeData?.protocols ?? []),
+		...(perpsAggregatorsVolumeData?.protocols ?? []),
+		...(bridgeAggregatorsVolumeData?.protocols ?? []),
+		...(normalizedVolumeData?.protocols ?? []),
 		...(openInterestData?.protocols ?? []),
 		...(optionsPremiumData?.protocols ?? []),
 		...(optionsNotionalData?.protocols ?? [])
@@ -510,16 +606,18 @@ export async function getProtocolsByCategoryOrTag(
 		return newData
 	}
 
+	const toProtocolMetricTotals = (protocol: AdapterMetricProtocol): ProtocolMetricTotals => ({
+		total24h: protocol.total24h ?? null,
+		total7d: protocol.total7d ?? null,
+		total30d: protocol.total30d ?? null
+	})
+
 	for (const protocol of feesData?.protocols ?? []) {
 		const adapterData = getOrCreateAdapterProtocolData({
 			protocolId: protocol.defillamaId,
 			protocolChains: protocol.chains
 		})
-		adapterData.fees = {
-			total24h: protocol.total24h ?? null,
-			total7d: protocol.total7d ?? null,
-			total30d: protocol.total30d ?? null
-		}
+		adapterData.fees = toProtocolMetricTotals(protocol)
 	}
 
 	for (const protocol of revenueData?.protocols ?? []) {
@@ -527,11 +625,7 @@ export async function getProtocolsByCategoryOrTag(
 			protocolId: protocol.defillamaId,
 			protocolChains: protocol.chains
 		})
-		adapterData.revenue = {
-			total24h: protocol.total24h ?? null,
-			total7d: protocol.total7d ?? null,
-			total30d: protocol.total30d ?? null
-		}
+		adapterData.revenue = toProtocolMetricTotals(protocol)
 	}
 
 	for (const protocol of dexVolumeData?.protocols ?? []) {
@@ -539,11 +633,15 @@ export async function getProtocolsByCategoryOrTag(
 			protocolId: protocol.defillamaId,
 			protocolChains: protocol.chains
 		})
-		adapterData.dexVolume = {
-			total24h: protocol.total24h ?? null,
-			total7d: protocol.total7d ?? null,
-			total30d: protocol.total30d ?? null
-		}
+		adapterData.dexVolume = toProtocolMetricTotals(protocol)
+	}
+
+	for (const protocol of dexAggregatorsVolumeData?.protocols ?? []) {
+		const adapterData = getOrCreateAdapterProtocolData({
+			protocolId: protocol.defillamaId,
+			protocolChains: protocol.chains
+		})
+		adapterData.dexAggregatorsVolume = toProtocolMetricTotals(protocol)
 	}
 
 	for (const protocol of perpVolumeData?.protocols ?? []) {
@@ -560,14 +658,36 @@ export async function getProtocolsByCategoryOrTag(
 		}
 	}
 
+	for (const protocol of perpsAggregatorsVolumeData?.protocols ?? []) {
+		const adapterData = getOrCreateAdapterProtocolData({
+			protocolId: protocol.defillamaId,
+			protocolChains: protocol.chains
+		})
+		adapterData.perpsAggregatorsVolume = toProtocolMetricTotals(protocol)
+	}
+
+	for (const protocol of bridgeAggregatorsVolumeData?.protocols ?? []) {
+		const adapterData = getOrCreateAdapterProtocolData({
+			protocolId: protocol.defillamaId,
+			protocolChains: protocol.chains
+		})
+		adapterData.bridgeAggregatorsVolume = toProtocolMetricTotals(protocol)
+	}
+
+	for (const protocol of normalizedVolumeData?.protocols ?? []) {
+		const adapterData = getOrCreateAdapterProtocolData({
+			protocolId: protocol.defillamaId,
+			protocolChains: protocol.chains
+		})
+		adapterData.normalizedVolume = toProtocolMetricTotals(protocol)
+	}
+
 	for (const protocol of openInterestData?.protocols ?? []) {
 		const adapterData = getOrCreateAdapterProtocolData({
 			protocolId: protocol.defillamaId,
 			protocolChains: protocol.chains
 		})
-		adapterData.openInterest = {
-			total24h: protocol.total24h ?? null
-		}
+		adapterData.openInterest = toProtocolMetricTotals(protocol)
 	}
 
 	for (const protocol of optionsPremiumData?.protocols ?? []) {
@@ -575,11 +695,7 @@ export async function getProtocolsByCategoryOrTag(
 			protocolId: protocol.defillamaId,
 			protocolChains: protocol.chains
 		})
-		adapterData.optionsPremium = {
-			total24h: protocol.total24h ?? null,
-			total7d: protocol.total7d ?? null,
-			total30d: protocol.total30d ?? null
-		}
+		adapterData.optionsPremium = toProtocolMetricTotals(protocol)
 	}
 
 	for (const protocol of optionsNotionalData?.protocols ?? []) {
@@ -587,11 +703,7 @@ export async function getProtocolsByCategoryOrTag(
 			protocolId: protocol.defillamaId,
 			protocolChains: protocol.chains
 		})
-		adapterData.optionsNotional = {
-			total24h: protocol.total24h ?? null,
-			total7d: protocol.total7d ?? null,
-			total30d: protocol.total30d ?? null
-		}
+		adapterData.optionsNotional = toProtocolMetricTotals(protocol)
 	}
 
 	const protocolsStore: Record<string, ProtocolTableRow> = {}
@@ -677,7 +789,11 @@ export async function getProtocolsByCategoryOrTag(
 			fees: adapterProtocolData?.fees ?? null,
 			revenue: adapterProtocolData?.revenue ?? null,
 			dexVolume: adapterProtocolData?.dexVolume ?? null,
+			dexAggregatorsVolume: adapterProtocolData?.dexAggregatorsVolume ?? null,
 			perpVolume: adapterProtocolData?.perpVolume ?? null,
+			perpsAggregatorsVolume: adapterProtocolData?.perpsAggregatorsVolume ?? null,
+			bridgeAggregatorsVolume: adapterProtocolData?.bridgeAggregatorsVolume ?? null,
+			normalizedVolume: adapterProtocolData?.normalizedVolume ?? null,
 			openInterest: adapterProtocolData?.openInterest ?? null,
 			optionsPremium: adapterProtocolData?.optionsPremium ?? null,
 			optionsNotional: adapterProtocolData?.optionsNotional ?? null,
@@ -715,6 +831,54 @@ export async function getProtocolsByCategoryOrTag(
 		)
 	}
 
+	const getSummaryMetricsFromRows = (
+		rows: Array<ProtocolTableRow>
+	): IProtocolByCategoryOrTagPageData['summaryMetrics'] => {
+		const fees = sumMetricTotals({ rows, selector: (row) => row.fees })
+		const revenue = sumMetricTotals({ rows, selector: (row) => row.revenue })
+		const dexVolume = sumMetricTotals({ rows, selector: (row) => row.dexVolume })
+		const dexAggregatorsVolume = sumMetricTotals({ rows, selector: (row) => row.dexAggregatorsVolume })
+		const perpVolume = sumMetricTotals({ rows, selector: (row) => row.perpVolume })
+		const perpsAggregatorsVolume = sumMetricTotals({ rows, selector: (row) => row.perpsAggregatorsVolume })
+		const bridgeAggregatorsVolume = sumMetricTotals({ rows, selector: (row) => row.bridgeAggregatorsVolume })
+		const normalizedVolume = sumMetricTotals({ rows, selector: (row) => row.normalizedVolume })
+		const optionsPremiumVolume = sumMetricTotals({ rows, selector: (row) => row.optionsPremium })
+		const optionsNotionalVolume = sumMetricTotals({ rows, selector: (row) => row.optionsNotional })
+		const openInterest = rows.reduce<OpenInterestTotals>(
+			(acc, row) => ({
+				total24h: (acc.total24h ?? 0) + (row.openInterest?.total24h ?? 0),
+				total7d: (acc.total7d ?? 0) + (row.openInterest?.total7d ?? 0),
+				total30d: (acc.total30d ?? 0) + (row.openInterest?.total30d ?? 0)
+			}),
+			{
+				total24h: 0,
+				total7d: 0,
+				total30d: 0
+			}
+		)
+
+		const toNullableTotals = (totals: IProtocolMetricTotals) =>
+			totals.total24h === 0 && totals.total7d === 0 && totals.total30d === 0 ? null : totals
+
+		return {
+			fees: capabilities.fees ? toNullableTotals(fees) : null,
+			revenue: capabilities.revenue ? toNullableTotals(revenue) : null,
+			dexVolume: capabilities.dexVolume ? toNullableTotals(dexVolume) : null,
+			dexAggregatorsVolume: capabilities.dexAggregatorsVolume ? toNullableTotals(dexAggregatorsVolume) : null,
+			perpVolume: capabilities.perpVolume ? toNullableTotals(perpVolume) : null,
+			perpsAggregatorsVolume: capabilities.perpsAggregatorsVolume ? toNullableTotals(perpsAggregatorsVolume) : null,
+			bridgeAggregatorsVolume: capabilities.bridgeAggregatorsVolume ? toNullableTotals(bridgeAggregatorsVolume) : null,
+			normalizedVolume: capabilities.normalizedVolume ? toNullableTotals(normalizedVolume) : null,
+			openInterest:
+				capabilities.openInterest &&
+				!(openInterest.total24h === 0 && openInterest.total7d === 0 && openInterest.total30d === 0)
+					? openInterest
+					: null,
+			optionsPremiumVolume: capabilities.optionsPremiumVolume ? toNullableTotals(optionsPremiumVolume) : null,
+			optionsNotionalVolume: capabilities.optionsNotionalVolume ? toNullableTotals(optionsNotionalVolume) : null
+		}
+	}
+
 	const finalProtocols: Array<ProtocolTableRow> = Object.values(protocolsStore)
 	for (const parentProtocol of mergedParentProtocols) {
 		const childProtocols = parentProtocolsStore[parentProtocol.id]
@@ -745,13 +909,27 @@ export async function getProtocolsByCategoryOrTag(
 		const fees = sumMetricTotals({ rows: childProtocols, selector: (row) => row.fees })
 		const revenue = sumMetricTotals({ rows: childProtocols, selector: (row) => row.revenue })
 		const dexVolume = sumMetricTotals({ rows: childProtocols, selector: (row) => row.dexVolume })
+		const dexAggregatorsVolume = sumMetricTotals({ rows: childProtocols, selector: (row) => row.dexAggregatorsVolume })
 		const perpVolume = sumMetricTotals({ rows: childProtocols, selector: (row) => row.perpVolume })
+		const perpsAggregatorsVolume = sumMetricTotals({
+			rows: childProtocols,
+			selector: (row) => row.perpsAggregatorsVolume
+		})
+		const bridgeAggregatorsVolume = sumMetricTotals({
+			rows: childProtocols,
+			selector: (row) => row.bridgeAggregatorsVolume
+		})
+		const normalizedVolume = sumMetricTotals({ rows: childProtocols, selector: (row) => row.normalizedVolume })
 		const openInterest = childProtocols.reduce<OpenInterestTotals>(
 			(acc, row) => ({
-				total24h: (acc.total24h ?? 0) + (row.openInterest?.total24h ?? 0)
+				total24h: (acc.total24h ?? 0) + (row.openInterest?.total24h ?? 0),
+				total7d: (acc.total7d ?? 0) + (row.openInterest?.total7d ?? 0),
+				total30d: (acc.total30d ?? 0) + (row.openInterest?.total30d ?? 0)
 			}),
 			{
-				total24h: 0
+				total24h: 0,
+				total7d: 0,
+				total30d: 0
 			}
 		)
 		const optionsPremium = sumMetricTotals({ rows: childProtocols, selector: (row) => row.optionsPremium })
@@ -769,9 +947,30 @@ export async function getProtocolsByCategoryOrTag(
 			fees: fees.total24h === 0 && fees.total7d === 0 && fees.total30d === 0 ? null : fees,
 			revenue: revenue.total24h === 0 && revenue.total7d === 0 && revenue.total30d === 0 ? null : revenue,
 			dexVolume: dexVolume.total24h === 0 && dexVolume.total7d === 0 && dexVolume.total30d === 0 ? null : dexVolume,
+			dexAggregatorsVolume:
+				dexAggregatorsVolume.total24h === 0 && dexAggregatorsVolume.total7d === 0 && dexAggregatorsVolume.total30d === 0
+					? null
+					: dexAggregatorsVolume,
 			perpVolume:
 				perpVolume.total24h === 0 && perpVolume.total7d === 0 && perpVolume.total30d === 0 ? null : perpVolume,
-			openInterest: openInterest.total24h === 0 ? null : openInterest,
+			perpsAggregatorsVolume:
+				perpsAggregatorsVolume.total24h === 0 &&
+				perpsAggregatorsVolume.total7d === 0 &&
+				perpsAggregatorsVolume.total30d === 0
+					? null
+					: perpsAggregatorsVolume,
+			bridgeAggregatorsVolume:
+				bridgeAggregatorsVolume.total24h === 0 &&
+				bridgeAggregatorsVolume.total7d === 0 &&
+				bridgeAggregatorsVolume.total30d === 0
+					? null
+					: bridgeAggregatorsVolume,
+			normalizedVolume:
+				normalizedVolume.total24h === 0 && normalizedVolume.total7d === 0 && normalizedVolume.total30d === 0
+					? null
+					: normalizedVolume,
+			openInterest:
+				openInterest.total24h === 0 && openInterest.total7d === 0 && openInterest.total30d === 0 ? null : openInterest,
 			optionsPremium:
 				optionsPremium.total24h === 0 && optionsPremium.total7d === 0 && optionsPremium.total30d === 0
 					? null
@@ -813,6 +1012,9 @@ export async function getProtocolsByCategoryOrTag(
 		dexVolumeChartData,
 		dexAggregatorsVolumeChartData,
 		perpVolumeChartData,
+		perpsAggregatorsVolumeChartData,
+		bridgeAggregatorsVolumeChartData,
+		normalizedVolumeChartData,
 		openInterestChartData,
 		optionsPremiumVolumeChartData,
 		optionsNotionalVolumeChartData,
@@ -820,31 +1022,17 @@ export async function getProtocolsByCategoryOrTag(
 		stakingChartData: extraTvlCharts.staking
 	})
 
-	let fees7d = 0
-	let revenue7d = 0
-	let dexVolume7d = 0
-	let perpVolume7d = 0
-	let openInterest = 0
-	let optionsPremium7d = 0
-	let optionsNotional7d = 0
+	const filteredProtocols = (
+		chain ? finalProtocols.filter((protocol) => protocol.chains.includes(currentChainMetadata.name)) : finalProtocols
+	).sort((a, b) => (b.tvl ?? 0) - (a.tvl ?? 0))
 
-	for (const protocol of finalProtocols) {
-		fees7d += protocol.fees?.total7d ?? 0
-		revenue7d += protocol.revenue?.total7d ?? 0
-		dexVolume7d += protocol.dexVolume?.total7d ?? 0
-		perpVolume7d += protocol.perpVolume?.total7d ?? 0
-		openInterest += protocol.openInterest?.total24h ?? 0
-		optionsPremium7d += protocol.optionsPremium?.total7d ?? 0
-		optionsNotional7d += protocol.optionsNotional?.total7d ?? 0
-	}
+	const summaryMetrics = getSummaryMetricsFromRows(filteredProtocols)
 
 	return {
+		capabilities,
 		charts: categoryCharts,
 		chain: currentChainMetadata?.name ?? 'All',
-		protocols: (chain
-			? finalProtocols.filter((p) => p.chains.includes(currentChainMetadata.name))
-			: finalProtocols
-		).sort((a, b) => (b.tvl ?? 0) - (a.tvl ?? 0)),
+		protocols: filteredProtocols,
 		category: category ?? null,
 		tag: tag ?? null,
 		effectiveCategory,
@@ -852,13 +1040,7 @@ export async function getProtocolsByCategoryOrTag(
 			{ label: 'All', to: `/protocols/${slug(category ?? tag)}` },
 			...chains.map((c) => ({ label: c, to: `/protocols/${slug(category ?? tag)}/${slug(c)}` }))
 		],
-		fees7d: fees7d > 0 ? fees7d : null,
-		revenue7d: revenue7d > 0 ? revenue7d : null,
-		dexVolume7d: dexVolume7d > 0 ? dexVolume7d : null,
-		perpVolume7d: perpVolume7d > 0 ? perpVolume7d : null,
-		openInterest: openInterest > 0 ? openInterest : null,
-		optionsPremium7d: optionsPremium7d > 0 ? optionsPremium7d : null,
-		optionsNotional7d: optionsNotional7d > 0 ? optionsNotional7d : null,
+		summaryMetrics,
 		extraTvlCharts
 	}
 }
@@ -956,7 +1138,11 @@ function getCategoryKeysFromApi(categories: CategoriesApiResponse['categories'])
 	return []
 }
 
-export async function getProtocolsCategoriesPageData(): Promise<IProtocolsCategoriesPageData> {
+export async function getProtocolsCategoriesPageData({
+	categoriesAndTags
+}: {
+	categoriesAndTags: ICategoriesAndTags
+}): Promise<IProtocolsCategoriesPageData> {
 	const [{ protocols }, revenueData, { chart, categories }]: [
 		ProtocolsResponse,
 		IAdapterChainMetrics | null,
@@ -1057,6 +1243,7 @@ export async function getProtocolsCategoriesPageData(): Promise<IProtocolsCatego
 		}
 	}
 
+	const categoryKeysFromMetadata = categoriesAndTags.categories
 	const categoryKeysFromApi = getCategoryKeysFromApi(categories)
 	const fallbackCategoryKeysFromRows = Array.from(categoryRows.keys())
 	const fallbackCategoryKeysFromChart = Object.values(chart ?? {}).flatMap((chartByCategory) => {
@@ -1068,9 +1255,11 @@ export async function getProtocolsCategoriesPageData(): Promise<IProtocolsCatego
 	})
 	const categoryKeys = Array.from(
 		new Set(
-			categoryKeysFromApi.length > 0
-				? categoryKeysFromApi
-				: [...fallbackCategoryKeysFromRows, ...fallbackCategoryKeysFromChart]
+			categoryKeysFromMetadata.length > 0
+				? categoryKeysFromMetadata
+				: categoryKeysFromApi.length > 0
+					? categoryKeysFromApi
+					: [...fallbackCategoryKeysFromRows, ...fallbackCategoryKeysFromChart]
 		)
 	)
 	for (const categoryName of categoryKeys) {

--- a/src/containers/ProtocolsByCategoryOrTag/types.ts
+++ b/src/containers/ProtocolsByCategoryOrTag/types.ts
@@ -1,19 +1,18 @@
 import type { IMultiSeriesChart2Props } from '~/components/ECharts/types'
+import type { ProtocolCategoryMetrics } from './constants'
 
-interface IProtocolMetricTotals {
+export interface IProtocolMetricTotals {
 	total24h: number | null
 	total7d: number | null
 	total30d: number | null
 }
 
-interface IProtocolPerpMetricTotals extends IProtocolMetricTotals {
+export interface IProtocolPerpMetricTotals extends IProtocolMetricTotals {
 	doublecounted?: boolean
 	zeroFeePerp?: boolean
 }
 
-interface IProtocolOpenInterestTotals {
-	total24h: number | null
-}
+export interface IProtocolOpenInterestTotals extends IProtocolMetricTotals {}
 
 interface IProtocolByCategory {
 	name: string
@@ -26,7 +25,11 @@ interface IProtocolByCategory {
 	fees?: IProtocolMetricTotals | null
 	revenue?: IProtocolMetricTotals | null
 	dexVolume?: IProtocolMetricTotals | null
+	dexAggregatorsVolume?: IProtocolMetricTotals | null
 	perpVolume?: IProtocolPerpMetricTotals | null
+	perpsAggregatorsVolume?: IProtocolMetricTotals | null
+	bridgeAggregatorsVolume?: IProtocolMetricTotals | null
+	normalizedVolume?: IProtocolMetricTotals | null
 	openInterest?: IProtocolOpenInterestTotals | null
 	optionsPremium?: IProtocolMetricTotals | null
 	optionsNotional?: IProtocolMetricTotals | null
@@ -45,16 +48,23 @@ export interface IProtocolByCategoryOrTagPageData {
 	category: string | null
 	tag: string | null
 	effectiveCategory: string | null
+	capabilities: ProtocolCategoryMetrics
 	chains: Array<{ label: string; to: string }>
 	chain: string
 	charts: { dataset: IMultiSeriesChart2Props['dataset']; charts: NonNullable<IMultiSeriesChart2Props['charts']> }
-	fees7d: number | null
-	revenue7d: number | null
-	dexVolume7d: number | null
-	perpVolume7d: number | null
-	openInterest: number | null
-	optionsPremium7d: number | null
-	optionsNotional7d: number | null
+	summaryMetrics: {
+		fees?: IProtocolMetricTotals | null
+		revenue?: IProtocolMetricTotals | null
+		dexVolume?: IProtocolMetricTotals | null
+		dexAggregatorsVolume?: IProtocolMetricTotals | null
+		perpVolume?: IProtocolMetricTotals | null
+		perpsAggregatorsVolume?: IProtocolMetricTotals | null
+		bridgeAggregatorsVolume?: IProtocolMetricTotals | null
+		normalizedVolume?: IProtocolMetricTotals | null
+		openInterest?: IProtocolOpenInterestTotals | null
+		optionsPremiumVolume?: IProtocolMetricTotals | null
+		optionsNotionalVolume?: IProtocolMetricTotals | null
+	}
 	extraTvlCharts: Record<string, Record<string | number, number | null>>
 }
 

--- a/src/pages/categories.tsx
+++ b/src/pages/categories.tsx
@@ -11,7 +11,8 @@ const pageName = ['Protocol Categories']
 const finalTvlOptions = tvlOptions.filter((option) => !categoriesPageExcludedExtraTvls.has(option.key))
 
 export const getStaticProps = withPerformanceLogging('categories', async () => {
-	const pageData = await getProtocolsCategoriesPageData()
+	const metadataCache = await import('~/utils/metadata').then((m) => m.default)
+	const pageData = await getProtocolsCategoriesPageData({ categoriesAndTags: metadataCache.categoriesAndTags })
 
 	return {
 		props: pageData,

--- a/src/pages/protocols/[category].tsx
+++ b/src/pages/protocols/[category].tsx
@@ -47,6 +47,7 @@ export const getStaticProps = withPerformanceLogging(
 			? await getProtocolsByCategoryOrTag({
 					kind: 'category',
 					category: categoryName,
+					categoriesAndTags,
 					chain,
 					chainMetadata: metadataCache.chainMetadata
 				})
@@ -54,6 +55,7 @@ export const getStaticProps = withPerformanceLogging(
 					kind: 'tag',
 					tag: tagName,
 					tagCategory,
+					categoriesAndTags,
 					chain,
 					chainMetadata: metadataCache.chainMetadata
 				})

--- a/src/pages/protocols/[category]/[chain].tsx
+++ b/src/pages/protocols/[category]/[chain].tsx
@@ -43,6 +43,7 @@ export const getStaticProps = withPerformanceLogging(
 			? await getProtocolsByCategoryOrTag({
 					kind: 'category',
 					category: categoryName,
+					categoriesAndTags,
 					chain,
 					chainMetadata: metadataCache.chainMetadata
 				})
@@ -50,6 +51,7 @@ export const getStaticProps = withPerformanceLogging(
 					kind: 'tag',
 					tag: tagName,
 					tagCategory,
+					categoriesAndTags,
 					chain,
 					chainMetadata: metadataCache.chainMetadata
 				})

--- a/src/utils/metadata/fetch.ts
+++ b/src/utils/metadata/fetch.ts
@@ -145,7 +145,8 @@ export async function fetchCoreMetadata({
 			fetchWithDevFallback<ICategoriesAndTags>(CATEGORIES_AND_TAGS_DATA_URL, {
 				categories: [],
 				tags: [],
-				tagCategoryMap: {}
+				tagCategoryMap: {},
+				configs: {}
 			}),
 			fetchWithDevFallback<RawCexsResponse>(CEXS_DATA_URL, { cexs: [], cg_volume_cexs: [] }),
 			fetchWithDevFallback<IRWAList>(RWA_LIST_DATA_URL, {

--- a/src/utils/metadata/types.tsx
+++ b/src/utils/metadata/types.tsx
@@ -89,10 +89,29 @@ export interface ICexItem {
 	auditLink?: string | null
 }
 
+export interface ICategoriesAndTagsConfig {
+	category: string
+	chains: Array<string>
+	slug: string
+	dimAgg?: Record<string, unknown>
+	bridgeAggregators?: boolean
+	dexAggregators?: boolean
+	dexs?: boolean
+	fees?: boolean
+	normalizedVolume?: boolean
+	openInterest?: boolean
+	optionsNotionalVolume?: boolean
+	optionsPremiumVolume?: boolean
+	perps?: boolean
+	perpsAggregators?: boolean
+	revenue?: boolean
+}
+
 export interface ICategoriesAndTags {
 	categories: Array<string>
 	tags: Array<string>
 	tagCategoryMap: Record<string, string>
+	configs: Record<string, ICategoriesAndTagsConfig>
 }
 
 export interface IRWAList {


### PR DESCRIPTION
## Summary
- move protocol category and tag capability handling onto metadata cache configs instead of hardcoded metric and column definitions
- split adapter-backed category metrics into independent families for dex aggregators, perp aggregators, bridge aggregators, normalized volume, and options metrics
- derive summary cards and table columns from the resolved capabilities, including value-sorted stats and updated category page metadata wiring

## Testing
- bun run format
- bun run lint
- bun run ts
- bun run test -- src/containers/ProtocolsByCategoryOrTag/constants.test.ts src/containers/ProtocolsByCategoryOrTag/index.test.ts src/containers/ProtocolsByCategoryOrTag/queries.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for new volume metrics: perps aggregators, bridge aggregators, and normalized volume.
  * Added capability-driven metric configuration and summary metrics payload.

* **Improvements**
  * Redesigned summary metrics sidebar with data-driven sorting and presentation.
  * Dynamic table column generation based on resolved capabilities.
  * Repositioned "RWA by Chain" page in navigation.

* **Tests**
  * Expanded test coverage for capability resolution, data fetching, and rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->