### PR TITLE
Use canonical market IDs across RWA frontend

### DIFF
--- a/src/containers/Downloads/chart-datasets.ts
+++ b/src/containers/Downloads/chart-datasets.ts
@@ -151,7 +151,7 @@ const extractRWACategoryRows = (json: any): Array<Record<string, unknown>> => {
 		})
 }
 
-const extractRWATickerBreakdownRows = (json: any): Array<Record<string, unknown>> => {
+const extractRWAAssetBreakdownRows = (json: any): Array<Record<string, unknown>> => {
 	if (!json || typeof json !== 'object' || Array.isArray(json)) return []
 	const onChainMcap: any[] = json.onChainMcap ?? []
 	if (!Array.isArray(onChainMcap) || onChainMcap.length === 0) return []
@@ -266,24 +266,24 @@ export const chartDatasets: ChartDatasetDefinition[] = [
 				if (!resp.ok) return []
 				return extractRWACategoryRows(await resp.json())
 			}
-			const [tickerResp, assetsResp] = await Promise.all([
-				fetch(`${RWA_SERVER_URL}/chart/chain/${param}/ticker-breakdown`),
+			const [assetResp, assetsResp] = await Promise.all([
+				fetch(`${RWA_SERVER_URL}/chart/chain/${param}/asset-breakdown`),
 				fetch(`${RWA_SERVER_URL}/current?z=0`)
 			])
-			if (!tickerResp.ok || !assetsResp.ok) return []
-			const tickerData = await tickerResp.json()
+			if (!assetResp.ok || !assetsResp.ok) return []
+			const assetData = await assetResp.json()
 			const assets: any[] = await assetsResp.json()
-			const tickerToCategory = new Map<string, string>()
+			const assetToCategory = new Map<string, string>()
 			if (Array.isArray(assets)) {
 				for (const a of assets) {
-					const ticker = a?.ticker
+					const canonicalMarketId = a?.canonicalMarketId
 					const cats = a?.category
-					if (typeof ticker === 'string' && Array.isArray(cats) && cats.length > 0) {
-						tickerToCategory.set(ticker, cats[0])
+					if (typeof canonicalMarketId === 'string' && Array.isArray(cats) && cats.length > 0) {
+						assetToCategory.set(canonicalMarketId, cats[0])
 					}
 				}
 			}
-			const onChainMcap: any[] = tickerData?.onChainMcap ?? []
+			const onChainMcap: any[] = assetData?.onChainMcap ?? []
 			if (!Array.isArray(onChainMcap) || onChainMcap.length === 0) return []
 			return onChainMcap
 				.filter((item: any) => item && item.timestamp != null)
@@ -292,7 +292,7 @@ export const chartDatasets: ChartDatasetDefinition[] = [
 					const catTotals = new Map<string, number>()
 					for (const [key, val] of Object.entries(item)) {
 						if (key === 'timestamp') continue
-						const cat = tickerToCategory.get(key) ?? 'Other'
+						const cat = assetToCategory.get(key) ?? 'Other'
 						catTotals.set(cat, (catTotals.get(cat) ?? 0) + (Number(val) || 0))
 					}
 					for (const [cat, total] of catTotals) {
@@ -305,7 +305,7 @@ export const chartDatasets: ChartDatasetDefinition[] = [
 	{
 		slug: 'rwa-chain-chart',
 		name: 'RWA by Chain',
-		description: 'Historical per-ticker RWA on-chain mcap for a specific chain',
+		description: 'Historical per-asset RWA on-chain mcap for a specific chain',
 		category: 'RWA',
 		paramType: 'chain',
 		paramLabel: 'Chain',
@@ -328,8 +328,8 @@ export const chartDatasets: ChartDatasetDefinition[] = [
 			}
 			return [...chainMcap.entries()].sort(([, a], [, b]) => b - a).map(([c]) => ({ label: c, value: c }))
 		},
-		buildUrl: (param: string) => `${RWA_SERVER_URL}/chart/chain/${param}/ticker-breakdown`,
-		extractRows: extractRWATickerBreakdownRows
+		buildUrl: (param: string) => `${RWA_SERVER_URL}/chart/chain/${param}/asset-breakdown`,
+		extractRows: extractRWAAssetBreakdownRows
 	},
 
 	{

--- a/src/containers/ProDashboard/components/datasets/RWADataset/useRWAChartData.ts
+++ b/src/containers/ProDashboard/components/datasets/RWADataset/useRWAChartData.ts
@@ -13,7 +13,7 @@ import {
 	fetchRWACategoryBreakdownChartData,
 	fetchRWAPlatformBreakdownChartData,
 	fetchRWAAssetGroupBreakdownChartData,
-	fetchRWAChartDataByTicker,
+	fetchRWAChartDataByAsset,
 	toUnixMsTimestamp
 } from '~/containers/RWA/api'
 import type { IFetchedRWAProject } from '~/containers/RWA/api.types'
@@ -71,13 +71,13 @@ export function useRWABreakdownChartData(
 					const proxyData = await fetchRWABreakdownViaProxy(actualBreakdown, metric, authToken, chain)
 					return normalizeTimestamps(proxyData)
 				}
-				const tickerData = await fetchRWAChartDataByTicker({
+				const assetData = await fetchRWAChartDataByAsset({
 					target: { kind: 'chain', slug: chain },
 					includeStablecoins: false,
 					includeGovernance: false
 				})
-				if (!tickerData) return null
-				return normalizeTimestamps(tickerData[metric] ?? null)
+				if (!assetData) return null
+				return normalizeTimestamps(assetData[metric] ?? null)
 			}
 
 			if (authToken) {

--- a/src/containers/RWA/AssetsTable.tsx
+++ b/src/containers/RWA/AssetsTable.tsx
@@ -22,7 +22,7 @@ import { VirtualTable } from '~/components/Table/Table'
 import { prepareTableCsv, useSortColumnSizesAndOrders } from '~/components/Table/utils'
 import type { ColumnSizesByBreakpoint } from '~/components/Table/utils'
 import { Tooltip } from '~/components/Tooltip'
-import { formatNum, formattedNum, slug } from '~/utils'
+import { formatNum, formattedNum } from '~/utils'
 import type { IRWAAssetsOverview } from './api.types'
 import { normalizeRwaAssetGroup } from './assetGroup'
 import { BreakdownTooltipContent } from './BreakdownTooltipContent'
@@ -168,13 +168,13 @@ const columns = [
 				<span className="flex items-center gap-2">
 					<span className="vf-row-index shrink-0" aria-hidden="true" />
 					<span className="-my-1.5 flex flex-col overflow-hidden">
-						{info.row.original.ticker ? (
+						{info.row.original.canonicalMarketId ? (
 							<>
 								<BasicLink
-									href={`/rwa/asset/${slug(info.row.original.ticker)}`}
+									href={`/rwa/asset/${encodeURIComponent(info.row.original.canonicalMarketId)}`}
 									className="overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-(--link-text) hover:underline"
 								>
-									{info.row.original.assetName ?? info.row.original.ticker}
+									{info.row.original.assetName ?? info.row.original.canonicalMarketId}
 								</BasicLink>
 								{info.row.original.assetName ? (
 									<span className="text-[0.7rem] text-(--text-disabled)">{info.row.original.ticker}</span>

--- a/src/containers/RWA/Perps/api.test.ts
+++ b/src/containers/RWA/Perps/api.test.ts
@@ -39,11 +39,11 @@ describe('rwa perps api urls', () => {
 		})
 
 		expect(fetchJson.mock.calls).toEqual([
-			['https://example.com/rwa-perps/market/xyz%3AMETA%2F2026?zz=13'],
-			['https://example.com/rwa-perps/contract/xyz%3AMETA%2F2026?zz=13'],
-			['https://example.com/rwa-perps/venue/my%20venue?zz=13'],
-			['https://example.com/rwa-perps/assetGroup/US%20Equities?zz=13'],
-			['https://example.com/rwa-perps/chart/venue/venue%2Fone?zz=13'],
+			['https://example.com/rwa-perps/market/xyz%3AMETA%2F2026?zz=14'],
+			['https://example.com/rwa-perps/contract/xyz%3AMETA%2F2026?zz=14'],
+			['https://example.com/rwa-perps/venue/my%20venue?zz=14'],
+			['https://example.com/rwa-perps/assetGroup/US%20Equities?zz=14'],
+			['https://example.com/rwa-perps/chart/venue/venue%2Fone?zz=14'],
 			['https://example.com/rwa-perps/chart/overview-breakdown?breakdown=assetGroup&key=openInterest&venue=xyz'],
 			['https://example.com/rwa-perps/chart/contract-breakdown?key=markets&assetGroup=US+Equities']
 		])
@@ -56,8 +56,8 @@ describe('rwa perps api urls', () => {
 		await api.fetchRWAPerpsFundingHistory('xyz:META')
 
 		expect(fetchJson.mock.calls).toEqual([
-			['https://example.com/rwa-perps/funding/xyz%3AMETA?startTime=10&endTime=20&zz=13'],
-			['https://example.com/rwa-perps/funding/xyz%3AMETA?zz=13']
+			['https://example.com/rwa-perps/funding/xyz%3AMETA?startTime=10&endTime=20&zz=14'],
+			['https://example.com/rwa-perps/funding/xyz%3AMETA?zz=14']
 		])
 	})
 })

--- a/src/containers/RWA/Perps/api.ts
+++ b/src/containers/RWA/Perps/api.ts
@@ -31,35 +31,35 @@ function createRWAPerpsFundingHistoryUrl(id: string, params?: IRWAPerpsFundingHi
 
 	const qs = searchParams.toString()
 
-	return `${RWA_PERPS_SERVER_URL}/funding/${encodedId}${qs ? `?${qs}&zz=13` : '?zz=13'}`
+	return `${RWA_PERPS_SERVER_URL}/funding/${encodedId}${qs ? `?${qs}&zz=14` : '?zz=14'}`
 }
 
 /**
  * Fetch all markets from the latest snapshot.
  */
 export async function fetchRWAPerpsCurrent(): Promise<IRWAPerpsMarket[]> {
-	return fetchJson<IRWAPerpsMarket[]>(`${RWA_PERPS_SERVER_URL}/current?zz=13`)
+	return fetchJson<IRWAPerpsMarket[]>(`${RWA_PERPS_SERVER_URL}/current?zz=14`)
 }
 
 /**
  * Fetch the available contracts, venues, and categories.
  */
 export async function fetchRWAPerpsList(): Promise<IRWAPerpsListResponse> {
-	return fetchJson<IRWAPerpsListResponse>(`${RWA_PERPS_SERVER_URL}/list?zz=13`)
+	return fetchJson<IRWAPerpsListResponse>(`${RWA_PERPS_SERVER_URL}/list?zz=14`)
 }
 
 /**
  * Fetch aggregate totals by venue and category.
  */
 export async function fetchRWAPerpsStats(): Promise<IRWAPerpsStatsResponse> {
-	return fetchJson<IRWAPerpsStatsResponse>(`${RWA_PERPS_SERVER_URL}/stats?zz=13`)
+	return fetchJson<IRWAPerpsStatsResponse>(`${RWA_PERPS_SERVER_URL}/stats?zz=14`)
 }
 
 /**
  * Fetch the contract and venue to market ID mapping.
  */
 export async function fetchRWAPerpsIdMap(): Promise<IRWAPerpsIdMapResponse> {
-	return fetchJson<IRWAPerpsIdMapResponse>(`${RWA_PERPS_SERVER_URL}/id-map?zz=13`)
+	return fetchJson<IRWAPerpsIdMapResponse>(`${RWA_PERPS_SERVER_URL}/id-map?zz=14`)
 }
 
 /**
@@ -67,7 +67,7 @@ export async function fetchRWAPerpsIdMap(): Promise<IRWAPerpsIdMapResponse> {
  */
 export async function fetchRWAPerpsMarketById(id: string): Promise<IRWAPerpsMarket> {
 	const encodedId = encodeRWAPerpsPathSegment(id)
-	return fetchJson<IRWAPerpsMarket>(`${RWA_PERPS_SERVER_URL}/market/${encodedId}?zz=13`)
+	return fetchJson<IRWAPerpsMarket>(`${RWA_PERPS_SERVER_URL}/market/${encodedId}?zz=14`)
 }
 
 /**
@@ -75,7 +75,7 @@ export async function fetchRWAPerpsMarketById(id: string): Promise<IRWAPerpsMark
  */
 export async function fetchRWAPerpsMarketsByContract(contract: string): Promise<IRWAPerpsMarket[]> {
 	const encodedContract = encodeRWAPerpsPathSegment(contract)
-	return fetchJson<IRWAPerpsMarket[]>(`${RWA_PERPS_SERVER_URL}/contract/${encodedContract}?zz=13`)
+	return fetchJson<IRWAPerpsMarket[]>(`${RWA_PERPS_SERVER_URL}/contract/${encodedContract}?zz=14`)
 }
 
 /**
@@ -83,7 +83,7 @@ export async function fetchRWAPerpsMarketsByContract(contract: string): Promise<
  */
 export async function fetchRWAPerpsMarketsByVenue(venue: string): Promise<IRWAPerpsMarket[]> {
 	const encodedVenue = encodeRWAPerpsPathSegment(venue)
-	return fetchJson<IRWAPerpsMarket[]>(`${RWA_PERPS_SERVER_URL}/venue/${encodedVenue}?zz=13`)
+	return fetchJson<IRWAPerpsMarket[]>(`${RWA_PERPS_SERVER_URL}/venue/${encodedVenue}?zz=14`)
 }
 
 /**
@@ -91,7 +91,7 @@ export async function fetchRWAPerpsMarketsByVenue(venue: string): Promise<IRWAPe
  */
 export async function fetchRWAPerpsMarketsByAssetGroup(assetGroup: string): Promise<IRWAPerpsMarket[]> {
 	const encodedAssetGroup = encodeRWAPerpsPathSegment(assetGroup)
-	return fetchJson<IRWAPerpsMarket[]>(`${RWA_PERPS_SERVER_URL}/assetGroup/${encodedAssetGroup}?zz=13`)
+	return fetchJson<IRWAPerpsMarket[]>(`${RWA_PERPS_SERVER_URL}/assetGroup/${encodedAssetGroup}?zz=14`)
 }
 
 /**
@@ -99,7 +99,7 @@ export async function fetchRWAPerpsMarketsByAssetGroup(assetGroup: string): Prom
  */
 export async function fetchRWAPerpsMarketChart(id: string): Promise<IRWAPerpsMarketChartPoint[]> {
 	const encodedId = encodeRWAPerpsPathSegment(id)
-	return fetchJson<IRWAPerpsMarketChartPoint[]>(`${RWA_PERPS_SERVER_URL}/chart/${encodedId}?zz=13`)
+	return fetchJson<IRWAPerpsMarketChartPoint[]>(`${RWA_PERPS_SERVER_URL}/chart/${encodedId}?zz=14`)
 }
 
 /**
@@ -107,7 +107,7 @@ export async function fetchRWAPerpsMarketChart(id: string): Promise<IRWAPerpsMar
  */
 export async function fetchRWAPerpsVenueChart(venue: string): Promise<IRWAPerpsAggregateHistoricalPoint[]> {
 	const encodedVenue = encodeRWAPerpsPathSegment(venue)
-	return fetchJson<IRWAPerpsAggregateHistoricalPoint[]>(`${RWA_PERPS_SERVER_URL}/chart/venue/${encodedVenue}?zz=13`)
+	return fetchJson<IRWAPerpsAggregateHistoricalPoint[]>(`${RWA_PERPS_SERVER_URL}/chart/venue/${encodedVenue}?zz=14`)
 }
 
 type IRWAPerpsBreakdownChartParams = {

--- a/src/containers/RWA/api.ts
+++ b/src/containers/RWA/api.ts
@@ -4,14 +4,14 @@ import { fetchJson } from '~/utils/async'
 import type {
 	IFetchedRWAProject,
 	IRWAStatsResponse,
-	IRWAChartDataByTicker,
+	IRWAChartDataByAsset,
 	IRWAAssetData,
 	IRWABreakdownChartParams,
 	IRWABreakdownChartResponse,
 	IRWABreakdownChartRow,
 	RWAAssetChartDimension,
 	RWAAssetChartRow,
-	RWATickerChartTarget
+	RWAAssetChartTarget
 } from './api.types'
 
 export function toUnixMsTimestamp(ts: number): number {
@@ -46,15 +46,15 @@ export async function fetchRWAAssetDataById(assetId: string): Promise<IFetchedRW
 	return fetchJson<IFetchedRWAProject>(`${RWA_SERVER_URL}/rwa/${encodedAssetId}`)
 }
 
-export async function fetchRWAChartDataByTicker({
+export async function fetchRWAChartDataByAsset({
 	target,
 	includeStablecoins,
 	includeGovernance
 }: {
-	target: RWATickerChartTarget
+	target: RWAAssetChartTarget
 	includeStablecoins: boolean
 	includeGovernance: boolean
-}): Promise<IRWAChartDataByTicker | null> {
+}): Promise<IRWAChartDataByAsset | null> {
 	let chartUrl = `${RWA_SERVER_URL}/chart/chain/all`
 
 	switch (target.kind) {
@@ -81,8 +81,8 @@ export async function fetchRWAChartDataByTicker({
 		includeGovernance: String(includeGovernance)
 	})
 
-	return fetchJson<IRWAChartDataByTicker>(`${chartUrl}/ticker-breakdown?${searchParams.toString()}`).catch((error) => {
-		console.error('Failed to fetch RWA chart data by ticker:', error)
+	return fetchJson<IRWAChartDataByAsset>(`${chartUrl}/asset-breakdown?${searchParams.toString()}`).catch((error) => {
+		console.error('Failed to fetch RWA chart data by asset:', error)
 		return null
 	})
 }

--- a/src/containers/RWA/api.types.ts
+++ b/src/containers/RWA/api.types.ts
@@ -10,6 +10,7 @@ type RWAHoldersByChain = Record<string, string[]>
 // Raw API response types
 export interface IFetchedRWAProject {
 	id: string
+	canonicalMarketId?: string | null
 	ticker: string
 	assetName?: string | null
 	assetGroup?: string | null
@@ -165,7 +166,7 @@ export interface IRWAAssetsOverview {
 export type IRWAInitialChartDatasetRow = { timestamp: number } & Record<string, number>
 export type RWAChartMetricKey = 'onChainMcap' | 'activeMcap' | 'defiActiveTvl'
 export type IRWAChartMetricRows = Array<{ timestamp: number } & Record<string, number>>
-export type RWATickerChartTarget =
+export type RWAAssetChartTarget =
 	| { kind: 'all' }
 	| { kind: 'chain'; slug: string }
 	| { kind: 'category'; slug: string }
@@ -177,7 +178,7 @@ export type IRWAInitialChartDataset = Record<
 	{ source: IRWAInitialChartDatasetRow[]; dimensions: string[] }
 >
 
-export interface IRWAChartDataByTicker {
+export interface IRWAChartDataByAsset {
 	onChainMcap: IRWAChartMetricRows
 	activeMcap: IRWAChartMetricRows
 	defiActiveTvl: IRWAChartMetricRows

--- a/src/containers/RWA/chartAggregation.test.ts
+++ b/src/containers/RWA/chartAggregation.test.ts
@@ -5,6 +5,7 @@ import { aggregateRwaMetricData } from './chartAggregation'
 const assets: IRWAAssetsOverview['assets'] = [
 	{
 		id: '1',
+		canonicalMarketId: 'ondo/usdy',
 		ticker: 'AAA',
 		assetName: 'Alpha',
 		parentPlatform: 'Centrifuge',
@@ -15,6 +16,7 @@ const assets: IRWAAssetsOverview['assets'] = [
 	},
 	{
 		id: '2',
+		canonicalMarketId: 'superstate/ustb',
 		ticker: 'BBB',
 		assetName: 'Beta',
 		parentPlatform: ['Centrifuge', 'Maple'],
@@ -25,6 +27,7 @@ const assets: IRWAAssetsOverview['assets'] = [
 	},
 	{
 		id: '3',
+		canonicalMarketId: 'blackrock/buidl',
 		ticker: 'CCC',
 		assetName: 'Gamma',
 		parentPlatform: null,
@@ -36,13 +39,13 @@ const assets: IRWAAssetsOverview['assets'] = [
 ]
 
 describe('aggregateRwaMetricData', () => {
-	it('aggregates all ticker series into a single Total series when total mode is selected', () => {
+	it('aggregates all asset series into a single Total series when total mode is selected', () => {
 		expect(
 			aggregateRwaMetricData(
 				assets,
 				[
-					{ timestamp: 1, AAA: 100, BBB: 90, CCC: 50 },
-					{ timestamp: 2, AAA: 120, BBB: 80, CCC: 40 }
+					{ timestamp: 1, 'ondo/usdy': 100, 'superstate/ustb': 90, 'blackrock/buidl': 50 },
+					{ timestamp: 2, 'ondo/usdy': 120, 'superstate/ustb': 80, 'blackrock/buidl': 40 }
 				],
 				'total'
 			)
@@ -60,8 +63,8 @@ describe('aggregateRwaMetricData', () => {
 			aggregateRwaMetricData(
 				assets,
 				[
-					{ timestamp: 1, AAA: 100, BBB: 90, CCC: 50 },
-					{ timestamp: 2, AAA: 120, BBB: 80, CCC: 40 }
+					{ timestamp: 1, 'ondo/usdy': 100, 'superstate/ustb': 90, 'blackrock/buidl': 50 },
+					{ timestamp: 2, 'ondo/usdy': 120, 'superstate/ustb': 80, 'blackrock/buidl': 40 }
 				],
 				'platform'
 			)
@@ -80,6 +83,7 @@ describe('aggregateRwaMetricData', () => {
 				[
 					{
 						id: '1',
+						canonicalMarketId: 'circle/usdc',
 						ticker: 'AAA',
 						assetName: 'Alpha',
 						assetGroup: 'Stablecoins',
@@ -91,6 +95,7 @@ describe('aggregateRwaMetricData', () => {
 					},
 					{
 						id: '2',
+						canonicalMarketId: 'unknown/asset',
 						ticker: 'BBB',
 						assetName: 'Beta',
 						assetGroup: null,
@@ -101,7 +106,7 @@ describe('aggregateRwaMetricData', () => {
 						defiActiveTvl: null
 					}
 				],
-				[{ timestamp: 1, AAA: 100, BBB: 50 }],
+				[{ timestamp: 1, 'circle/usdc': 100, 'unknown/asset': 50 }],
 				'assetGroup'
 			)
 		).toEqual({

--- a/src/containers/RWA/chartAggregation.ts
+++ b/src/containers/RWA/chartAggregation.ts
@@ -1,7 +1,7 @@
-import type { IRWAAssetsOverview, IRWAChartDataByTicker, IRWAChartMetricRows, RWAChartMetricKey } from './api.types'
+import type { IRWAAssetsOverview, IRWAChartDataByAsset, IRWAChartMetricRows, RWAChartMetricKey } from './api.types'
 import { normalizeRwaAssetGroup } from './assetGroup'
 import { isTypeIncludedByDefault, type RWAOverviewMode } from './constants'
-import { computeWeightedGroups, getRwaPlatforms } from './grouping'
+import { computeWeightedGroups, getPrimaryRwaCategory, getRwaPlatforms } from './grouping'
 
 export type RWAChartMetric = RWAChartMetricKey
 
@@ -25,24 +25,26 @@ export function emptyChartDatasets(): RWAChartDatasetsByMetric {
 	return { onChainMcap: emptyChartDataset(), activeMcap: emptyChartDataset(), defiActiveTvl: emptyChartDataset() }
 }
 
-function buildTickerGroupMapping(
+function buildAssetGroupMapping(
 	assets: IRWAAssetsOverview['assets'],
 	mode: RWAChartAggregationMode
 ): Map<string, Map<string, number>> {
-	const tickerToGroups = new Map<string, Map<string, number>>()
+	const assetToGroups = new Map<string, Map<string, number>>()
 
 	for (const asset of assets) {
-		const ticker = asset.ticker
-		if (!ticker) continue
+		const assetKey = asset.canonicalMarketId
+		if (!assetKey) continue
 
 		let weightedGroups: ReturnType<typeof computeWeightedGroups>
 		switch (mode) {
 			case 'total':
 				weightedGroups = computeWeightedGroups(['Total'])
 				break
-			case 'category':
-				weightedGroups = computeWeightedGroups(asset.category)
+			case 'category': {
+				const primaryCategory = getPrimaryRwaCategory(asset.category)
+				weightedGroups = computeWeightedGroups(primaryCategory ? [primaryCategory] : [])
 				break
+			}
 			case 'assetClass':
 				weightedGroups = computeWeightedGroups(asset.assetClass)
 				break
@@ -64,19 +66,19 @@ function buildTickerGroupMapping(
 
 		if (weightedGroups.length === 0) continue
 
-		const groups = tickerToGroups.get(ticker) ?? new Map<string, number>()
+		const groups = assetToGroups.get(assetKey) ?? new Map<string, number>()
 		for (const { value: group, weight } of weightedGroups) {
 			groups.set(group, weight)
 		}
-		tickerToGroups.set(ticker, groups)
+		assetToGroups.set(assetKey, groups)
 	}
 
-	return tickerToGroups
+	return assetToGroups
 }
 
 function aggregateMetricRows(
 	rows: RWAChartRow[],
-	tickerToGroups: Map<string, Map<string, number>>,
+	assetToGroups: Map<string, Map<string, number>>,
 	seenGroups: Set<string>
 ): RWAChartRow[] {
 	const out: RWAChartRow[] = []
@@ -85,11 +87,11 @@ function aggregateMetricRows(
 		const outRow: RWAChartRow = { timestamp: row.timestamp }
 		let hasData = false
 
-		for (const [ticker, value] of Object.entries(row)) {
-			if (ticker === 'timestamp') continue
+		for (const [assetKey, value] of Object.entries(row)) {
+			if (assetKey === 'timestamp') continue
 			if (!Number.isFinite(value) || value === 0) continue
 
-			const groups = tickerToGroups.get(ticker)
+			const groups = assetToGroups.get(assetKey)
 			if (!groups || groups.size === 0) continue
 
 			hasData = true
@@ -109,10 +111,10 @@ function aggregateMetricRows(
 
 function buildAggregatedRwaDataset(
 	rows: IRWAChartMetricRows,
-	tickerToGroups: Map<string, Map<string, number>>
+	assetToGroups: Map<string, Map<string, number>>
 ): RWAChartDataset {
 	const seenGroups = new Set<string>()
-	const source = aggregateMetricRows(rows, tickerToGroups, seenGroups)
+	const source = aggregateMetricRows(rows, assetToGroups, seenGroups)
 
 	return {
 		source,
@@ -149,15 +151,15 @@ export function sortKeysByLatestTimestampValue(rows: RWAChartRow[], keys: Iterab
 
 export function aggregateRwaChartData(
 	assets: IRWAAssetsOverview['assets'],
-	chartDataByTicker: IRWAChartDataByTicker,
+	chartDataByAsset: IRWAChartDataByAsset,
 	mode: RWAChartAggregationMode
 ): RWAChartDatasetsByMetric {
-	const tickerToGroups = buildTickerGroupMapping(assets, mode)
+	const assetToGroups = buildAssetGroupMapping(assets, mode)
 
 	return {
-		onChainMcap: buildAggregatedRwaDataset(chartDataByTicker.onChainMcap, tickerToGroups),
-		activeMcap: buildAggregatedRwaDataset(chartDataByTicker.activeMcap, tickerToGroups),
-		defiActiveTvl: buildAggregatedRwaDataset(chartDataByTicker.defiActiveTvl, tickerToGroups)
+		onChainMcap: buildAggregatedRwaDataset(chartDataByAsset.onChainMcap, assetToGroups),
+		activeMcap: buildAggregatedRwaDataset(chartDataByAsset.activeMcap, assetToGroups),
+		defiActiveTvl: buildAggregatedRwaDataset(chartDataByAsset.defiActiveTvl, assetToGroups)
 	}
 }
 
@@ -166,8 +168,8 @@ export function aggregateRwaMetricData(
 	rows: IRWAChartMetricRows,
 	mode: RWAChartAggregationMode
 ): RWAChartDataset {
-	const tickerToGroups = buildTickerGroupMapping(assets, mode)
-	return buildAggregatedRwaDataset(rows, tickerToGroups)
+	const assetToGroups = buildAssetGroupMapping(assets, mode)
+	return buildAggregatedRwaDataset(rows, assetToGroups)
 }
 
 /**

--- a/src/containers/RWA/grouping.ts
+++ b/src/containers/RWA/grouping.ts
@@ -22,6 +22,10 @@ export const computeWeightedGroups = (values: Array<string> | null | undefined):
 	return groups.map((value) => ({ value, weight }))
 }
 
+export const getPrimaryRwaCategory = (values: Array<string> | null | undefined): string | null => {
+	return toUniqueNonEmptyValues(values)[0] ?? null
+}
+
 export const getRwaPlatforms = (value: RWAParentPlatform): string[] => {
 	const values = typeof value === 'string' ? [value] : Array.isArray(value) ? value : []
 	const seen = new Set<string>()

--- a/src/containers/RWA/hooks.test.tsx
+++ b/src/containers/RWA/hooks.test.tsx
@@ -182,7 +182,9 @@ describe('useRwaChartDataset', () => {
 			error: null
 		})
 
-		const markup = renderToStaticMarkup(React.createElement(DatasetProbe, { mode: 'category', chartAssets: multiCategoryAssets }))
+		const markup = renderToStaticMarkup(
+			React.createElement(DatasetProbe, { mode: 'category', chartAssets: multiCategoryAssets })
+		)
 
 		expect(markup).toContain('timestamp|Treasuries')
 		expect(markup).not.toContain('Private Credit')

--- a/src/containers/RWA/hooks.test.tsx
+++ b/src/containers/RWA/hooks.test.tsx
@@ -4,9 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { IRWAAssetsOverview } from './api.types'
 import type { RWAChartAggregationMode } from './chartAggregation'
 import {
-	getRwaTickerChartQueryKey,
+	getRwaAssetChartQueryKey,
 	hasActiveChartFilters,
 	resolveRWAOverviewInclusionFlag,
+	useRWAAssetCategoryPieChartData,
 	useRwaAssetGroupPieChartData,
 	useRwaChartDataset
 } from './hooks'
@@ -25,6 +26,7 @@ vi.mock('~/utils/async', () => ({
 const assets: IRWAAssetsOverview['assets'] = [
 	{
 		id: '1',
+		canonicalMarketId: 'ondo/usdy',
 		ticker: 'AAA',
 		assetName: 'Alpha',
 		category: ['Treasuries'],
@@ -36,6 +38,7 @@ const assets: IRWAAssetsOverview['assets'] = [
 	},
 	{
 		id: '2',
+		canonicalMarketId: 'superstate/ustb',
 		ticker: 'BBB',
 		assetName: 'Beta',
 		category: ['Private Credit'],
@@ -49,12 +52,14 @@ const assets: IRWAAssetsOverview['assets'] = [
 
 function DatasetProbe({
 	mode,
+	chartAssets = assets,
 	initialDataset = { source: [], dimensions: ['timestamp'] },
 	includeStablecoins = false,
 	includeGovernance = false,
 	useInitialDataset = false
 }: {
 	mode: RWAChartAggregationMode
+	chartAssets?: IRWAAssetsOverview['assets']
 	initialDataset?: { source: Array<{ timestamp: number }>; dimensions: string[] }
 	includeStablecoins?: boolean
 	includeGovernance?: boolean
@@ -63,7 +68,7 @@ function DatasetProbe({
 	const { chartDataset } = useRwaChartDataset({
 		selectedMetric: 'onChainMcap',
 		initialDataset,
-		filteredAssets: assets,
+		filteredAssets: chartAssets,
 		mode,
 		target: { kind: 'all' },
 		includeStablecoins,
@@ -82,6 +87,29 @@ function AssetGroupProbe({ enabled, chartAssets }: { enabled: boolean; chartAsse
 	})
 }
 
+function CategoryProbe({
+	enabled,
+	chartAssets,
+	categories,
+	selectedCategories
+}: {
+	enabled: boolean
+	chartAssets: IRWAAssetsOverview['assets']
+	categories: string[]
+	selectedCategories: string[]
+}) {
+	const result = useRWAAssetCategoryPieChartData({
+		enabled,
+		assets: chartAssets,
+		categories,
+		selectedCategories
+	})
+	return React.createElement('script', {
+		type: 'application/json',
+		dangerouslySetInnerHTML: { __html: JSON.stringify(result) }
+	})
+}
+
 function readJsonMarkup(markup: string) {
 	const match = markup.match(/<script type="application\/json">([\s\S]*)<\/script>/)
 	expect(match?.[1]).toBeTruthy()
@@ -93,11 +121,11 @@ describe('useRwaChartDataset', () => {
 		useQueryMock.mockReset()
 		fetchJsonMock.mockReset()
 		useQueryMock.mockReturnValue({
-			data: [{ timestamp: 1, AAA: 100, BBB: 80 }],
+			data: [{ timestamp: 1, 'ondo/usdy': 100, 'superstate/ustb': 80 }],
 			isLoading: false,
 			error: null
 		})
-		fetchJsonMock.mockResolvedValue([{ timestamp: 1, AAA: 100, BBB: 80 }])
+		fetchJsonMock.mockResolvedValue([{ timestamp: 1, 'ondo/usdy': 100, 'superstate/ustb': 80 }])
 	})
 
 	it('regroups cached ticker rows without changing the fetch key', () => {
@@ -110,13 +138,13 @@ describe('useRwaChartDataset', () => {
 		expect(totalMarkup).toContain('timestamp|Total')
 		expect(useQueryMock).toHaveBeenCalledTimes(3)
 		expect(useQueryMock.mock.calls[0][0]).toMatchObject({
-			queryKey: getRwaTickerChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false)
+			queryKey: getRwaAssetChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false)
 		})
 		expect(useQueryMock.mock.calls[1][0]).toMatchObject({
-			queryKey: getRwaTickerChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false)
+			queryKey: getRwaAssetChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false)
 		})
 		expect(useQueryMock.mock.calls[2][0]).toMatchObject({
-			queryKey: getRwaTickerChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false)
+			queryKey: getRwaAssetChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false)
 		})
 	})
 
@@ -125,14 +153,42 @@ describe('useRwaChartDataset', () => {
 		renderToStaticMarkup(React.createElement(DatasetProbe, { mode: 'category', includeStablecoins: true }))
 
 		expect(useQueryMock.mock.calls[0][0]).toMatchObject({
-			queryKey: getRwaTickerChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false)
+			queryKey: getRwaAssetChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false)
 		})
 		expect(useQueryMock.mock.calls[1][0]).toMatchObject({
-			queryKey: getRwaTickerChartQueryKey({ kind: 'all' }, 'onChainMcap', true, false)
+			queryKey: getRwaAssetChartQueryKey({ kind: 'all' }, 'onChainMcap', true, false)
 		})
 	})
 
-	it('passes the resolved inclusion flags to the ticker-breakdown fetcher', async () => {
+	it('uses the primary category when regrouping category chart rows', () => {
+		const multiCategoryAssets: IRWAAssetsOverview['assets'] = [
+			{
+				id: '1',
+				canonicalMarketId: 'ondo/usdy',
+				ticker: 'AAA',
+				assetName: 'Alpha',
+				category: ['Treasuries', 'Private Credit'],
+				parentPlatform: 'Centrifuge',
+				trueRWA: false,
+				onChainMcap: null,
+				activeMcap: null,
+				defiActiveTvl: null
+			}
+		]
+
+		useQueryMock.mockReturnValueOnce({
+			data: [{ timestamp: 1, 'ondo/usdy': 100 }],
+			isLoading: false,
+			error: null
+		})
+
+		const markup = renderToStaticMarkup(React.createElement(DatasetProbe, { mode: 'category', chartAssets: multiCategoryAssets }))
+
+		expect(markup).toContain('timestamp|Treasuries')
+		expect(markup).not.toContain('Private Credit')
+	})
+
+	it('passes the resolved inclusion flags to the asset-breakdown fetcher', async () => {
 		let capturedOptions: { queryFn: () => Promise<unknown> } | undefined
 		useQueryMock.mockImplementation((options: { queryFn: () => Promise<unknown> }) => {
 			capturedOptions = options
@@ -154,7 +210,7 @@ describe('useRwaChartDataset', () => {
 		await capturedOptions?.queryFn()
 
 		expect(fetchJsonMock).toHaveBeenCalledWith(
-			'/api/rwa/ticker-breakdown?key=onChainMcap&includeStablecoin=true&includeGovernance=false'
+			'/api/rwa/asset-breakdown?key=onChainMcap&includeStablecoin=true&includeGovernance=false'
 		)
 	})
 
@@ -179,7 +235,7 @@ describe('useRwaChartDataset', () => {
 		expect(markup).toContain('timestamp|Prerendered')
 		expect(useQueryMock).toHaveBeenCalledTimes(1)
 		expect(useQueryMock.mock.calls[0][0]).toMatchObject({
-			queryKey: getRwaTickerChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false),
+			queryKey: getRwaAssetChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false),
 			enabled: false
 		})
 	})
@@ -268,5 +324,39 @@ describe('useRwaAssetGroupPieChartData', () => {
 		expect(data.assetGroupOnChainMcapPieChartData).toEqual([])
 		expect(data.assetGroupActiveMcapPieChartData).toEqual([])
 		expect(data.assetGroupDefiActiveTvlPieChartData).toEqual([])
+	})
+})
+
+describe('useRWAAssetCategoryPieChartData', () => {
+	it('attributes category totals only to the primary category', () => {
+		const chartAssets: IRWAAssetsOverview['assets'] = [
+			{
+				id: '1',
+				canonicalMarketId: 'ondo/usdy',
+				ticker: 'AAA',
+				assetName: 'Alpha',
+				category: ['Treasuries', 'Private Credit'],
+				parentPlatform: 'Centrifuge',
+				trueRWA: false,
+				onChainMcap: { total: 100, breakdown: [] },
+				activeMcap: { total: 90, breakdown: [] },
+				defiActiveTvl: { total: 30, breakdown: [] }
+			}
+		]
+
+		const data = readJsonMarkup(
+			renderToStaticMarkup(
+				React.createElement(CategoryProbe, {
+					enabled: true,
+					chartAssets,
+					categories: ['Treasuries', 'Private Credit'],
+					selectedCategories: ['Treasuries', 'Private Credit']
+				})
+			)
+		)
+
+		expect(data.assetCategoryOnChainMcapPieChartData).toEqual([{ name: 'Treasuries', value: 100 }])
+		expect(data.assetCategoryActiveMcapPieChartData).toEqual([{ name: 'Treasuries', value: 90 }])
+		expect(data.assetCategoryDefiActiveTvlPieChartData).toEqual([{ name: 'Treasuries', value: 30 }])
 	})
 })

--- a/src/containers/RWA/hooks.tsx
+++ b/src/containers/RWA/hooks.tsx
@@ -13,7 +13,7 @@ import {
 	isTrueQueryParam,
 	pushShallowQuery
 } from '~/utils/routerQuery'
-import type { IRWAAssetsOverview, IRWAChartMetricRows, RWAChartMetricKey, RWATickerChartTarget } from './api.types'
+import type { IRWAAssetsOverview, IRWAChartMetricRows, RWAChartMetricKey, RWAAssetChartTarget } from './api.types'
 import { normalizeRwaAssetGroup } from './assetGroup'
 import {
 	aggregateRwaMetricData,
@@ -22,7 +22,7 @@ import {
 	type RWAChartAggregationMode
 } from './chartAggregation'
 import { getDefaultRWAOverviewInclusion, getDefaultSelectedTypes, type RWAOverviewMode } from './constants'
-import { computeWeightedGroups, toUniqueNonEmptyValues } from './grouping'
+import { computeWeightedGroups, getPrimaryRwaCategory, toUniqueNonEmptyValues } from './grouping'
 import { rwaSlug } from './rwaSlug'
 
 type PieChartDatum = { name: string; value: number }
@@ -751,15 +751,14 @@ export function useRWAAssetCategoryPieChartData({
 		const categoryTotals = new Map<string, { onChain: number; active: number; defi: number }>()
 
 		for (const asset of assets) {
-			for (const { value: category, weight } of computeWeightedGroups(asset.category)) {
-				if (!category || !selectedCategoriesSet.has(category)) continue
+			const primaryCategory = getPrimaryRwaCategory(asset.category)
+			if (!primaryCategory || !selectedCategoriesSet.has(primaryCategory)) continue
 
-				const prev = categoryTotals.get(category) ?? { onChain: 0, active: 0, defi: 0 }
-				prev.onChain += (asset.onChainMcap?.total ?? 0) * weight
-				prev.active += (asset.activeMcap?.total ?? 0) * weight
-				prev.defi += (asset.defiActiveTvl?.total ?? 0) * weight
-				categoryTotals.set(category, prev)
-			}
+			const prev = categoryTotals.get(primaryCategory) ?? { onChain: 0, active: 0, defi: 0 }
+			prev.onChain += asset.onChainMcap?.total ?? 0
+			prev.active += asset.activeMcap?.total ?? 0
+			prev.defi += asset.defiActiveTvl?.total ?? 0
+			categoryTotals.set(primaryCategory, prev)
 		}
 
 		const toSortedChartData = (metric: 'onChain' | 'active' | 'defi') => {
@@ -1232,14 +1231,14 @@ export function hasActiveChartFilters(
 	return false
 }
 
-export function getRwaTickerChartQueryKey(
-	target: RWATickerChartTarget,
+export function getRwaAssetChartQueryKey(
+	target: RWAAssetChartTarget,
 	selectedMetric: RWAChartMetricKey,
 	includeStablecoins: boolean,
 	includeGovernance: boolean
 ) {
 	return [
-		'rwa-ticker-chart',
+		'rwa-asset-chart',
 		target.kind,
 		target.kind === 'all' ? 'all' : target.slug,
 		selectedMetric,
@@ -1258,9 +1257,9 @@ function assertNever(value: never): never {
 	throw new Error(`Unexpected value: ${String(value)}`)
 }
 
-async function fetchRwaTickerChartData(params: {
+async function fetchRwaAssetChartData(params: {
 	key: RWAChartMetricKey
-	target: RWATickerChartTarget
+	target: RWAAssetChartTarget
 	includeStablecoins: boolean
 	includeGovernance: boolean
 }): Promise<IRWAChartMetricRows> {
@@ -1287,7 +1286,7 @@ async function fetchRwaTickerChartData(params: {
 			assertNever(params.target)
 	}
 
-	return fetchJson<IRWAChartMetricRows>(`/api/rwa/ticker-breakdown?${searchParams.toString()}`)
+	return fetchJson<IRWAChartMetricRows>(`/api/rwa/asset-breakdown?${searchParams.toString()}`)
 }
 
 export function useRwaChartDataset({
@@ -1304,7 +1303,7 @@ export function useRwaChartDataset({
 	initialDataset: RWAChartDataset
 	filteredAssets: IRWAAssetsOverview['assets']
 	mode: RWAChartAggregationMode
-	target: RWATickerChartTarget
+	target: RWAAssetChartTarget
 	includeStablecoins: boolean
 	includeGovernance: boolean
 	useInitialDataset: boolean
@@ -1314,13 +1313,13 @@ export function useRwaChartDataset({
 	chartError: string | null
 } {
 	const {
-		data: tickerRows,
+		data: assetRows,
 		isLoading,
 		error
 	} = useQuery({
-		queryKey: getRwaTickerChartQueryKey(target, selectedMetric, includeStablecoins, includeGovernance),
+		queryKey: getRwaAssetChartQueryKey(target, selectedMetric, includeStablecoins, includeGovernance),
 		queryFn: () =>
-			fetchRwaTickerChartData({
+			fetchRwaAssetChartData({
 				key: selectedMetric,
 				target,
 				includeStablecoins,
@@ -1336,9 +1335,9 @@ export function useRwaChartDataset({
 
 	const chartDataset = useMemo(() => {
 		if (useInitialDataset) return initialDataset
-		if (!tickerRows) return emptyChartDataset()
-		return aggregateRwaMetricData(filteredAssets, tickerRows, mode)
-	}, [useInitialDataset, initialDataset, tickerRows, filteredAssets, mode])
+		if (!assetRows) return emptyChartDataset()
+		return aggregateRwaMetricData(filteredAssets, assetRows, mode)
+	}, [useInitialDataset, initialDataset, assetRows, filteredAssets, mode])
 
 	return {
 		chartDataset,

--- a/src/containers/RWA/index.tsx
+++ b/src/containers/RWA/index.tsx
@@ -17,7 +17,7 @@ import { CHART_COLORS } from '~/constants/colors'
 import { useChartImageExport } from '~/hooks/useChartImageExport'
 import { formattedNum, slug } from '~/utils'
 import { pushShallowQuery, toQueryString } from '~/utils/routerQuery'
-import type { IRWAAssetsOverview, RWATickerChartTarget } from './api.types'
+import type { IRWAAssetsOverview, RWAAssetChartTarget } from './api.types'
 import { RWAAssetsTable } from './AssetsTable'
 import { emptyChartDatasets, type RWAChartAggregationMode } from './chartAggregation'
 import {
@@ -178,7 +178,7 @@ export const RWAOverview = (props: IRWAAssetsOverview) => {
 
 	const activeFilters = hasActiveChartFilters(router.query, mode, props.categorySlug)
 	const initialChartDataset = props.initialChartDataset ?? EMPTY_INITIAL_CHART_DATASET
-	const chartTarget = getTickerChartTarget(props)
+	const chartTarget = getAssetChartTarget(props)
 	const { chartDataset, isChartLoading, chartError } = useRwaChartDataset({
 		selectedMetric: chartTypeKey,
 		initialDataset: initialChartDataset[chartTypeKey],
@@ -804,7 +804,7 @@ const getRwaChartAggregationMode = (state: RWAChartBreakdown | 'total'): RWAChar
 	}
 }
 
-const getTickerChartTarget = (props: IRWAAssetsOverview): RWATickerChartTarget => {
+const getAssetChartTarget = (props: IRWAAssetsOverview): RWAAssetChartTarget => {
 	if (props.assetGroupSlug) return { kind: 'assetGroup', slug: props.assetGroupSlug }
 	if (props.categorySlug) return { kind: 'category', slug: props.categorySlug }
 	if (props.platformSlug) return { kind: 'platform', slug: props.platformSlug }

--- a/src/containers/RWA/queries.tsx
+++ b/src/containers/RWA/queries.tsx
@@ -9,14 +9,14 @@ import {
 	fetchRWACategoryBreakdownChartData,
 	fetchRWAPlatformBreakdownChartData,
 	fetchRWAStats,
-	fetchRWAChartDataByTicker,
+	fetchRWAChartDataByAsset,
 	fetchRWAAssetDataById,
 	fetchRWAAssetChartData,
 	toUnixMsTimestamp
 } from './api'
 import type {
 	IFetchedRWAProject,
-	IRWAChartDataByTicker,
+	IRWAChartDataByAsset,
 	IRWAProject,
 	IRWAAssetsOverview,
 	IRWAAssetData,
@@ -28,7 +28,7 @@ import type {
 	IRWAPlatformsOverviewRow,
 	IRWAAssetGroupsOverview,
 	IRWAAssetGroupsOverviewRow,
-	RWATickerChartTarget
+	RWAAssetChartTarget
 } from './api.types'
 import { UNKNOWN_RWA_ASSET_GROUP, appendUnknownRwaAssetGroup, normalizeRwaAssetGroup } from './assetGroup'
 import { toBreakdownChartDataset } from './breakdownDataset'
@@ -40,7 +40,7 @@ import {
 } from './chartAggregation'
 import { getDefaultRWAOverviewInclusion, type RWAOverviewMode } from './constants'
 import { definitions } from './definitions'
-import { getRwaPlatforms, UNKNOWN_PLATFORM } from './grouping'
+import { getPrimaryRwaCategory, getRwaPlatforms, UNKNOWN_PLATFORM } from './grouping'
 import { rwaSlug } from './rwaSlug'
 
 type ChainMetricBreakdown = Record<string, number | string> | null
@@ -210,7 +210,7 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 			Number(!!selectedChain) + Number(!!selectedCategory) + Number(!!selectedPlatform) + Number(!!selectedAssetGroup)
 		if (selectedCount > 1) return null
 
-		const target: RWATickerChartTarget = selectedChain
+		const target: RWAAssetChartTarget = selectedChain
 			? { kind: 'chain', slug: selectedChain }
 			: selectedCategory
 				? { kind: 'category', slug: selectedCategory }
@@ -228,9 +228,9 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 					: 'chain'
 		const defaultInclusion = getDefaultRWAOverviewInclusion(mode, selectedCategory ?? null)
 
-		const [data, chartData]: [Array<IFetchedRWAProject>, IRWAChartDataByTicker | null] = await Promise.all([
+		const [data, chartData]: [Array<IFetchedRWAProject>, IRWAChartDataByAsset | null] = await Promise.all([
 			fetchRWAActiveTVLs(),
-			fetchRWAChartDataByTicker({
+			fetchRWAChartDataByAsset({
 				target,
 				includeStablecoins: defaultInclusion.includeStablecoins,
 				includeGovernance: defaultInclusion.includeGovernance
@@ -247,7 +247,7 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 			? appendUnknownRwaAssetGroup(params.rwaList.assetGroups)
 			: params.rwaList.assetGroups
 
-		const chartDataMs: IRWAChartDataByTicker | null = chartData
+		const chartDataMs: IRWAChartDataByAsset | null = chartData
 			? {
 					onChainMcap: ensureChronologicalRows(
 						(chartData.onChainMcap ?? []).map((row) => ({ ...row, timestamp: toUnixMsTimestamp(row.timestamp) }))
@@ -503,10 +503,9 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 						assetClasses.set(assetClass, (assetClasses.get(assetClass) ?? 0) + effectiveOnChainMcap)
 					}
 				}
-				for (const category of asset.category ?? []) {
-					if (category) {
-						categories.set(category, (categories.get(category) ?? 0) + effectiveOnChainMcap)
-					}
+				const primaryCategory = getPrimaryRwaCategory(asset.category)
+				if (primaryCategory) {
+					categories.set(primaryCategory, (categories.get(primaryCategory) ?? 0) + effectiveOnChainMcap)
 				}
 				for (const platform of getRwaPlatforms(asset.parentPlatform)) {
 					if (platform === UNKNOWN_PLATFORM) continue
@@ -1023,7 +1022,7 @@ export async function getRWAAssetData({ assetId }: { assetId: string }): Promise
 
 		return {
 			...data,
-			slug: rwaSlug(data.ticker),
+			slug: data.canonicalMarketId ?? data.id,
 			trueRWA: isTrueRWA,
 			rwaClassification: isTrueRWA ? 'RWA' : (data.rwaClassification ?? null),
 			rwaClassificationDescription,

--- a/src/containers/RWA/tickerBreakdownApi.test.ts
+++ b/src/containers/RWA/tickerBreakdownApi.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { buildTickerBreakdownUrl, parseTickerBreakdownRequest } from '~/pages/api/rwa/ticker-breakdown'
+import { buildAssetBreakdownUrl, parseAssetBreakdownRequest } from '~/pages/api/rwa/asset-breakdown'
 
-describe('parseTickerBreakdownRequest', () => {
+describe('parseAssetBreakdownRequest', () => {
 	it('rejects requests when inclusion flags are omitted', () => {
 		expect(
-			parseTickerBreakdownRequest({
+			parseAssetBreakdownRequest({
 				query: {
 					category: 'rwa-yield-wrapper',
 					key: 'activeMcap'
@@ -15,7 +15,7 @@ describe('parseTickerBreakdownRequest', () => {
 
 	it('accepts explicit true and false inclusion flags', () => {
 		expect(
-			parseTickerBreakdownRequest({
+			parseAssetBreakdownRequest({
 				query: {
 					platform: 'ondo',
 					key: 'onChainMcap',
@@ -32,15 +32,15 @@ describe('parseTickerBreakdownRequest', () => {
 	})
 })
 
-describe('buildTickerBreakdownUrl', () => {
-	it('forwards both inclusion flags to the upstream ticker-breakdown endpoint', () => {
+describe('buildAssetBreakdownUrl', () => {
+	it('forwards both inclusion flags to the upstream asset-breakdown endpoint', () => {
 		expect(
-			buildTickerBreakdownUrl({
+			buildAssetBreakdownUrl({
 				target: { kind: 'category', slug: 'rwa-yield-wrapper' },
 				key: 'defiActiveTvl',
 				includeStablecoin: false,
 				includeGovernance: true
 			})
-		).toContain('/chart/category/rwa-yield-wrapper/ticker-breakdown?includeStablecoin=false&includeGovernance=true')
+		).toContain('/chart/category/rwa-yield-wrapper/asset-breakdown?includeStablecoin=false&includeGovernance=true')
 	})
 })

--- a/src/pages/api/dashboard/[dashboardId]/stream.ts
+++ b/src/pages/api/dashboard/[dashboardId]/stream.ts
@@ -372,16 +372,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 					(async () => {
 						let data: any = null
 						if (resolvedChain !== 'All') {
-							const tickerData = await withTimeout(
-								rwaApi.fetchRWAChartDataByTicker({
+							const assetData = await withTimeout(
+								rwaApi.fetchRWAChartDataByAsset({
 									target: { kind: 'chain', slug: resolvedChain },
 									includeStablecoins: false,
 									includeGovernance: false
 								}),
 								10_000
 							)
-							if (tickerData) {
-								const rows = (tickerData as any)[metric || 'activeMcap'] ?? null
+							if (assetData) {
+								const rows = (assetData as any)[metric || 'activeMcap'] ?? null
 								if (rows) {
 									data = rows.map((row: any) => ({
 										...row,

--- a/src/pages/api/dashboard/fetch.ts
+++ b/src/pages/api/dashboard/fetch.ts
@@ -132,17 +132,17 @@ async function dispatchFetch(type: string, params: any): Promise<any> {
 			const rwaApi = await import('~/containers/RWA/api')
 
 			if (chain && chain !== 'All') {
-				const tickerData = await withTimeout(
-					rwaApi.fetchRWAChartDataByTicker({
+				const assetData = await withTimeout(
+					rwaApi.fetchRWAChartDataByAsset({
 						target: { kind: 'chain', slug: chain },
 						includeStablecoins: false,
 						includeGovernance: false
 					}),
 					FETCH_TIMEOUT
 				)
-				if (!tickerData) return null
-				const metricKey = (metric || 'activeMcap') as keyof typeof tickerData
-				return tickerData[metricKey] ?? null
+				if (!assetData) return null
+				const metricKey = (metric || 'activeMcap') as keyof typeof assetData
+				return assetData[metricKey] ?? null
 			}
 
 			const breakdownParams = { key: metric || 'activeMcap', includeStablecoin: false, includeGovernance: false }

--- a/src/pages/api/rwa/asset-breakdown.ts
+++ b/src/pages/api/rwa/asset-breakdown.ts
@@ -3,39 +3,39 @@ import { ensureChronologicalRows } from '~/components/ECharts/utils'
 import { RWA_SERVER_URL } from '~/constants'
 import { toUnixMsTimestamp } from '~/containers/RWA/api'
 import type {
-	IRWAChartDataByTicker,
+	IRWAChartDataByAsset,
 	IRWAChartMetricRows,
 	RWAChartMetricKey,
-	RWATickerChartTarget
+	RWAAssetChartTarget
 } from '~/containers/RWA/api.types'
 import { rwaSlug } from '~/containers/RWA/rwaSlug'
 import { fetchJson } from '~/utils/async'
 
-type RWATickerBreakdownRequest = {
-	target: RWATickerChartTarget
+type RWAAssetBreakdownRequest = {
+	target: RWAAssetChartTarget
 	key: RWAChartMetricKey
 	includeStablecoin: boolean
 	includeGovernance: boolean
 }
 
-export function buildTickerBreakdownUrl(request: RWATickerBreakdownRequest): string {
+export function buildAssetBreakdownUrl(request: RWAAssetBreakdownRequest): string {
 	let pathname: string
 
 	switch (request.target.kind) {
 		case 'all':
-			pathname = `${RWA_SERVER_URL}/chart/chain/all/ticker-breakdown`
+			pathname = `${RWA_SERVER_URL}/chart/chain/all/asset-breakdown`
 			break
 		case 'chain':
-			pathname = `${RWA_SERVER_URL}/chart/chain/${encodeURIComponent(rwaSlug(request.target.slug))}/ticker-breakdown`
+			pathname = `${RWA_SERVER_URL}/chart/chain/${encodeURIComponent(rwaSlug(request.target.slug))}/asset-breakdown`
 			break
 		case 'category':
-			pathname = `${RWA_SERVER_URL}/chart/category/${encodeURIComponent(rwaSlug(request.target.slug))}/ticker-breakdown`
+			pathname = `${RWA_SERVER_URL}/chart/category/${encodeURIComponent(rwaSlug(request.target.slug))}/asset-breakdown`
 			break
 		case 'platform':
-			pathname = `${RWA_SERVER_URL}/chart/platform/${encodeURIComponent(rwaSlug(request.target.slug))}/ticker-breakdown`
+			pathname = `${RWA_SERVER_URL}/chart/platform/${encodeURIComponent(rwaSlug(request.target.slug))}/asset-breakdown`
 			break
 		case 'assetGroup':
-			pathname = `${RWA_SERVER_URL}/chart/assetGroup/${encodeURIComponent(rwaSlug(request.target.slug))}/ticker-breakdown`
+			pathname = `${RWA_SERVER_URL}/chart/assetGroup/${encodeURIComponent(rwaSlug(request.target.slug))}/asset-breakdown`
 			break
 		default:
 			return assertNever(request.target)
@@ -49,8 +49,8 @@ export function buildTickerBreakdownUrl(request: RWATickerBreakdownRequest): str
 	return `${pathname}?${searchParams.toString()}`
 }
 
-function normalizeTickerBreakdownData(raw: IRWAChartDataByTicker): IRWAChartDataByTicker {
-	const normalize = (rows: IRWAChartDataByTicker['onChainMcap']) =>
+function normalizeAssetBreakdownData(raw: IRWAChartDataByAsset): IRWAChartDataByAsset {
+	const normalize = (rows: IRWAChartDataByAsset['onChainMcap']) =>
 		ensureChronologicalRows((rows ?? []).map((row) => ({ ...row, timestamp: toUnixMsTimestamp(row.timestamp) })))
 
 	return {
@@ -70,7 +70,7 @@ function parseChartMetricKey(value: string | string[] | undefined): RWAChartMetr
 	return null
 }
 
-function parseTarget(req: Pick<NextApiRequest, 'query'>): RWATickerChartTarget | null {
+function parseTarget(req: Pick<NextApiRequest, 'query'>): RWAAssetChartTarget | null {
 	const rawChain = req.query.chain
 	const rawCategory = req.query.category
 	const rawPlatform = req.query.platform
@@ -104,7 +104,7 @@ function parseBooleanFlag(value: string | string[] | undefined): boolean | null 
 	return null
 }
 
-export function parseTickerBreakdownRequest(req: Pick<NextApiRequest, 'query'>): RWATickerBreakdownRequest | null {
+export function parseAssetBreakdownRequest(req: Pick<NextApiRequest, 'query'>): RWAAssetBreakdownRequest | null {
 	const target = parseTarget(req)
 	const key = parseChartMetricKey(req.query.key)
 	const includeStablecoin = parseBooleanFlag(req.query.includeStablecoin)
@@ -122,7 +122,7 @@ export function parseTickerBreakdownRequest(req: Pick<NextApiRequest, 'query'>):
 	}
 }
 
-function getMetricRows(data: IRWAChartDataByTicker, key: RWAChartMetricKey): IRWAChartMetricRows {
+function getMetricRows(data: IRWAChartDataByAsset, key: RWAChartMetricKey): IRWAChartMetricRows {
 	switch (key) {
 		case 'onChainMcap':
 			return data.onChainMcap
@@ -140,23 +140,23 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 		return res.status(405).json({ error: 'Method not allowed' })
 	}
 
-	const request = parseTickerBreakdownRequest(req)
+	const request = parseAssetBreakdownRequest(req)
 
 	if (request == null) {
 		return res.status(400).json({ error: 'Invalid query parameters' })
 	}
 
 	try {
-		const raw = await fetchJson<IRWAChartDataByTicker>(buildTickerBreakdownUrl(request), {
+		const raw = await fetchJson<IRWAChartDataByAsset>(buildAssetBreakdownUrl(request), {
 			timeout: 30_000
 		})
-		const normalized = normalizeTickerBreakdownData(raw)
+		const normalized = normalizeAssetBreakdownData(raw)
 		const rows = getMetricRows(normalized, request.key)
 
 		res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=1800')
 		return res.status(200).json(rows)
 	} catch (error) {
-		console.error('RWA ticker-breakdown proxy error:', error)
+		console.error('RWA asset-breakdown proxy error:', error)
 		return res.status(502).json({ error: 'Failed to fetch upstream chart data' })
 	}
 }

--- a/src/pages/rwa/asset/[asset].tsx
+++ b/src/pages/rwa/asset/[asset].tsx
@@ -28,7 +28,9 @@ export async function getStaticPaths() {
 	const metadataCache = await import('~/utils/metadata').then((m) => m.default)
 	const rwaList = metadataCache.rwaList
 	return {
-		paths: rwaList.canonicalMarketIds.slice(0, 10).map((canonicalMarketId) => ({ params: { asset: canonicalMarketId } })),
+		paths: rwaList.canonicalMarketIds
+			.slice(0, 10)
+			.map((canonicalMarketId) => ({ params: { asset: canonicalMarketId } })),
 		fallback: 'blocking'
 	}
 }

--- a/src/pages/rwa/asset/[asset].tsx
+++ b/src/pages/rwa/asset/[asset].tsx
@@ -2,10 +2,17 @@ import type { GetStaticPropsContext } from 'next'
 import { SKIP_BUILD_STATIC_GENERATION } from '~/constants'
 import { RWAAssetPage } from '~/containers/RWA/Asset'
 import { getRWAAssetData } from '~/containers/RWA/queries'
-import { rwaSlug } from '~/containers/RWA/rwaSlug'
 import Layout from '~/layout'
 import { maxAgeForNext } from '~/utils/maxAgeForNext'
 import { withPerformanceLogging } from '~/utils/perf'
+
+function safeDecodeAssetParam(value: string): string {
+	try {
+		return decodeURIComponent(value)
+	} catch {
+		return value
+	}
+}
 
 export async function getStaticPaths() {
 	// When this is true (in preview environments) don't
@@ -21,7 +28,7 @@ export async function getStaticPaths() {
 	const metadataCache = await import('~/utils/metadata').then((m) => m.default)
 	const rwaList = metadataCache.rwaList
 	return {
-		paths: rwaList.tickers.slice(0, 10).map((ticker) => ({ params: { asset: rwaSlug(ticker) } })),
+		paths: rwaList.canonicalMarketIds.slice(0, 10).map((canonicalMarketId) => ({ params: { asset: canonicalMarketId } })),
 		fallback: 'blocking'
 	}
 }
@@ -33,18 +40,11 @@ export const getStaticProps = withPerformanceLogging(
 			return { notFound: true }
 		}
 
-		const assetSlug = rwaSlug(params.asset)
+		const canonicalMarketId = safeDecodeAssetParam(params.asset)
 
-		let assetId = null
 		const metadataCache = await import('~/utils/metadata').then((m) => m.default)
 		const rwaList = metadataCache.rwaList
-
-		for (const ticker in rwaList.idMap) {
-			if (rwaSlug(ticker) === assetSlug) {
-				assetId = rwaList.idMap[ticker]
-				break
-			}
-		}
+		const assetId = rwaList.idMap[canonicalMarketId] ?? null
 		if (!assetId) {
 			return { notFound: true }
 		}
@@ -75,7 +75,7 @@ export default function RWAAssetDetailPage({ asset }) {
 			title={`${displayName} - RWA Dashboard & Analytics - DefiLlama`}
 			description={`Overview of the tokenized real-world asset ${displayName}, including supply, blockchain distribution, and platform data. DefiLlama provides transparent, ad-free RWA analytics.`}
 			pageName={pageName}
-			canonicalUrl={`/rwa/asset/${asset.slug}`}
+			canonicalUrl={`/rwa/asset/${encodeURIComponent(asset.slug)}`}
 		>
 			<RWAAssetPage asset={asset} />
 		</Layout>

--- a/src/pages/sitemap.xml.js
+++ b/src/pages/sitemap.xml.js
@@ -213,10 +213,9 @@ async function buildRWAAssetRoutes() {
 	const metadataModule = await import('~/utils/metadata')
 	await metadataModule.refreshMetadataIfStale()
 	const rwaList = metadataModule.default.rwaList
-	if (rwaList?.tickers) {
-		for (const ticker of rwaList.tickers) {
-			const tickerSlug = rwaSlug(ticker)
-			if (tickerSlug) routes.push(`rwa/asset/${tickerSlug}`)
+	if (rwaList?.canonicalMarketIds) {
+		for (const canonicalMarketId of rwaList.canonicalMarketIds) {
+			if (canonicalMarketId) routes.push(`rwa/asset/${encodeURIComponent(canonicalMarketId)}`)
 		}
 	}
 	if (rwaList?.platforms) {

--- a/src/utils/metadata/fetch.ts
+++ b/src/utils/metadata/fetch.ts
@@ -149,7 +149,7 @@ export async function fetchCoreMetadata({
 			}),
 			fetchWithDevFallback<RawCexsResponse>(CEXS_DATA_URL, { cexs: [], cg_volume_cexs: [] }),
 			fetchWithDevFallback<IRWAList>(RWA_LIST_DATA_URL, {
-				tickers: [],
+				canonicalMarketIds: [],
 				platforms: [],
 				chains: [],
 				categories: [],

--- a/src/utils/metadata/fetch.ts
+++ b/src/utils/metadata/fetch.ts
@@ -119,13 +119,13 @@ export async function fetchCoreMetadata({
 		? `https://pro-api.llama.fi/${API_KEY}/datasets`
 		: 'https://defillama-datasets.llama.fi'
 
-	const PROTOCOLS_DATA_URL = `${API_SERVER_URL}/config/smol/appMetadata-protocols.json?zz=13`
-	const CHAINS_DATA_URL = `${API_SERVER_URL}/config/smol/appMetadata-chains.json?zz=13`
-	const CATEGORIES_AND_TAGS_DATA_URL = `${API_SERVER_URL}/config/smol/appMetadata-categoriesAndTags.json?zz=13`
-	const CEXS_DATA_URL = `${API_SERVER_URL}/cexs?zz=13`
-	const RWA_LIST_DATA_URL = `${RWA_SERVER_URL}/list?zz=13`
-	const RWA_PERPS_LIST_DATA_URL = `${RWA_PERPS_SERVER_URL}/list?zz=13`
-	const TOKENLIST_DATA_URL = `${DATASETS_SERVER_URL}/tokenlist/sorted.json?zz=13`
+	const PROTOCOLS_DATA_URL = `${API_SERVER_URL}/config/smol/appMetadata-protocols.json?zz=14`
+	const CHAINS_DATA_URL = `${API_SERVER_URL}/config/smol/appMetadata-chains.json?zz=14`
+	const CATEGORIES_AND_TAGS_DATA_URL = `${API_SERVER_URL}/config/smol/appMetadata-categoriesAndTags.json?zz=14`
+	const CEXS_DATA_URL = `${API_SERVER_URL}/cexs?zz=14`
+	const RWA_LIST_DATA_URL = `${RWA_SERVER_URL}/list?zz=14`
+	const RWA_PERPS_LIST_DATA_URL = `${RWA_PERPS_SERVER_URL}/list?zz=14`
+	const TOKENLIST_DATA_URL = `${DATASETS_SERVER_URL}/tokenlist/sorted.json?zz=14`
 	const BRIDGES_DATA_URL = `${BRIDGES_SERVER_URL}/bridges?includeChains=true`
 
 	const isDev = process.env.NODE_ENV === 'development'

--- a/src/utils/metadata/index.ts
+++ b/src/utils/metadata/index.ts
@@ -40,7 +40,7 @@ const metadataCache: {
 	protocolMetadata,
 	categoriesAndTags,
 	cexs,
-	rwaList,
+	rwaList: rwaList as IRWAList,
 	rwaPerpsList: {
 		...(rwaPerpsList as IRWAPerpsList),
 		assetGroups: (rwaPerpsList as IRWAPerpsList).assetGroups ?? []

--- a/src/utils/metadata/types.tsx
+++ b/src/utils/metadata/types.tsx
@@ -96,7 +96,7 @@ export interface ICategoriesAndTags {
 }
 
 export interface IRWAList {
-	tickers: Array<string>
+	canonicalMarketIds: Array<string>
 	platforms: Array<string>
 	chains: Array<string>
 	categories: Array<string>


### PR DESCRIPTION
## Summary
- switch RWA asset links, metadata, sitemap entries, and search routes to canonicalMarketId
- rename the grouped RWA chart proxy surface from ticker-breakdown to asset-breakdown
- update grouped chart consumers and downloads to read canonicalMarketId-keyed series
- align frontend category totals and category charts with the backend primary-category aggregation rule

## Testing
- bun x vitest run src/containers/RWA/hooks.test.tsx src/containers/RWA/tickerBreakdownApi.test.ts
- bun x vitest run src/containers/RWA/chartAggregation.test.ts
- bun x tsc -p tsconfig.vitest.json --noEmit --incremental false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * RWA assets are now organized by canonical market identifier instead of ticker, improving asset disambiguation.
  * Enhanced category aggregation for assets with multiple classifications—metrics are now attributed to the primary category.

* **Updates**
  * Asset detail pages and routes now use canonical market identifiers in URLs.
  * Updated RWA perps API endpoints with improved data versioning.
  * Cache-busted metadata endpoints to reflect latest asset definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->