### PR TITLE
Merge RWA perps into the overview

### DIFF
--- a/src/containers/RWA/AssetsTable.test.tsx
+++ b/src/containers/RWA/AssetsTable.test.tsx
@@ -3,7 +3,7 @@ import type { IRWAAssetsOverview } from './api.types'
 import { getActiveMetricValue, getDefiMetricValue, getMetricColumnHeaders, getOnChainMetricValue } from './AssetsTable'
 
 function createSpotAsset(
-	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }>>
+	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }>> = {}
 ): Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }> {
 	return {
 		id: '1',
@@ -44,7 +44,7 @@ function createSpotAsset(
 }
 
 function createPerpsAsset(
-	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'perps' }>>
+	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'perps' }>> = {}
 ): Extract<IRWAAssetsOverview['assets'][number], { kind: 'perps' }> {
 	return {
 		id: 'perps-1',

--- a/src/containers/RWA/AssetsTable.test.tsx
+++ b/src/containers/RWA/AssetsTable.test.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import type { IRWAAssetsOverview } from './api.types'
+import { getActiveMetricValue, getDefiMetricValue, getMetricColumnHeaders, getOnChainMetricValue } from './AssetsTable'
+
+function createSpotAsset(
+	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }>>
+): Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }> {
+	return {
+		id: '1',
+		kind: 'spot',
+		detailHref: '/rwa/asset/ondo%2Fusdy',
+		canonicalMarketId: 'ondo/usdy',
+		ticker: 'USDY',
+		assetName: 'Ondo USDY',
+		primaryChain: null,
+		chain: null,
+		price: 1,
+		openInterest: null,
+		volume24h: null,
+		volume30d: null,
+		assetGroup: 'Treasuries',
+		parentPlatform: 'Ondo',
+		category: ['Treasuries'],
+		assetClass: ['Bonds'],
+		accessModel: 'Permissioned',
+		type: 'Bond Fund',
+		rwaClassification: 'RWA',
+		issuer: 'Ondo',
+		redeemable: null,
+		attestations: null,
+		cexListed: null,
+		kycForMintRedeem: null,
+		kycAllowlistedWhitelistedToTransferHold: null,
+		transferable: null,
+		selfCustody: null,
+		stablecoin: null,
+		governance: null,
+		trueRWA: false,
+		onChainMcap: { total: 200, breakdown: [] },
+		activeMcap: { total: 100, breakdown: [] },
+		defiActiveTvl: { total: 25, breakdown: [] },
+		...overrides
+	}
+}
+
+function createPerpsAsset(
+	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'perps' }>>
+): Extract<IRWAAssetsOverview['assets'][number], { kind: 'perps' }> {
+	return {
+		id: 'perps-1',
+		kind: 'perps',
+		detailHref: '/rwa/perps/contract/xyz%3Ausdy',
+		contract: 'xyz:USDY',
+		ticker: 'xyz:USDY',
+		assetName: 'USDY Perp',
+		primaryChain: null,
+		chain: null,
+		price: 1,
+		openInterest: 333,
+		volume24h: 111,
+		volume30d: 222,
+		assetGroup: 'Treasuries',
+		parentPlatform: 'XYZ',
+		category: ['Treasuries'],
+		assetClass: ['Bond Perp'],
+		accessModel: 'Permissionless',
+		type: 'Perp',
+		rwaClassification: 'RWA',
+		issuer: 'XYZ',
+		redeemable: null,
+		attestations: null,
+		cexListed: null,
+		kycForMintRedeem: null,
+		kycAllowlistedWhitelistedToTransferHold: null,
+		transferable: null,
+		selfCustody: null,
+		stablecoin: null,
+		governance: null,
+		trueRWA: false,
+		onChainMcap: null,
+		activeMcap: null,
+		defiActiveTvl: null,
+		...overrides
+	}
+}
+
+describe('RWAAssetsTable', () => {
+	it('keeps the original metric headers when the perps toggle is off', () => {
+		expect(getMetricColumnHeaders(false)).toEqual({
+			active: 'Active Marketcap',
+			onChain: 'Onchain Marketcap',
+			defi: 'DeFi Active TVL'
+		})
+	})
+
+	it('switches metric headers and uses perps metrics when the perps toggle is on', () => {
+		expect(getMetricColumnHeaders(true)).toEqual({
+			active: 'Active Mcap or 24h Volume',
+			onChain: 'Onchain Mcap or 30d Volume',
+			defi: 'Defi Active TVL or OI'
+		})
+
+		expect(getActiveMetricValue(createSpotAsset())).toBe(100)
+		expect(getOnChainMetricValue(createSpotAsset())).toBe(200)
+		expect(getDefiMetricValue(createSpotAsset())).toBe(25)
+		expect(getActiveMetricValue(createPerpsAsset())).toBe(111)
+		expect(getOnChainMetricValue(createPerpsAsset())).toBe(222)
+		expect(getDefiMetricValue(createPerpsAsset())).toBe(333)
+	})
+})

--- a/src/containers/RWA/AssetsTable.test.tsx
+++ b/src/containers/RWA/AssetsTable.test.tsx
@@ -93,18 +93,18 @@ describe('RWAAssetsTable', () => {
 		})
 	})
 
-	it('switches metric headers and uses perps metrics when the perps toggle is on', () => {
+	it('uses OI in the active mcap column when the perps toggle is on', () => {
 		expect(getMetricColumnHeaders(true)).toEqual({
-			active: 'Active Mcap or 24h Volume',
-			onChain: 'Onchain Mcap or 30d Volume',
-			defi: 'Defi Active TVL or OI'
+			active: 'Active Mcap or OI',
+			onChain: 'Onchain Marketcap',
+			defi: 'DeFi Active TVL'
 		})
 
 		expect(getActiveMetricValue(createSpotAsset())).toBe(100)
 		expect(getOnChainMetricValue(createSpotAsset())).toBe(200)
 		expect(getDefiMetricValue(createSpotAsset())).toBe(25)
-		expect(getActiveMetricValue(createPerpsAsset())).toBe(111)
-		expect(getOnChainMetricValue(createPerpsAsset())).toBe(222)
-		expect(getDefiMetricValue(createPerpsAsset())).toBe(333)
+		expect(getActiveMetricValue(createPerpsAsset())).toBe(333)
+		expect(getOnChainMetricValue(createPerpsAsset())).toBeNull()
+		expect(getDefiMetricValue(createPerpsAsset())).toBeNull()
 	})
 })

--- a/src/containers/RWA/AssetsTable.tsx
+++ b/src/containers/RWA/AssetsTable.tsx
@@ -229,6 +229,8 @@ function MixedMetricCell({
 }
 
 function createColumns(includeRwaPerps: boolean) {
+	const metricHeaders = getMetricColumnHeaders(includeRwaPerps)
+
 	return [
 		columnHelper.accessor((asset) => asset.assetName ?? asset.ticker, {
 			id: 'name',
@@ -288,7 +290,7 @@ function createColumns(includeRwaPerps: boolean) {
 		}),
 		columnHelper.accessor((asset) => getActiveMetricValue(asset) ?? undefined, {
 			id: 'activeMcap.total',
-			header: includeRwaPerps ? MIXED_ACTIVE_HEADER : definitions.activeMcap.label,
+			header: metricHeaders.active,
 			cell: (info) => (
 				<MixedMetricCell
 					asset={info.row.original}
@@ -305,7 +307,7 @@ function createColumns(includeRwaPerps: boolean) {
 		}),
 		columnHelper.accessor((asset) => getOnChainMetricValue(asset) ?? undefined, {
 			id: 'onChainMcap.total',
-			header: definitions.onChainMcap.label,
+			header: metricHeaders.onChain,
 			cell: (info) => (
 				<MixedMetricCell
 					asset={info.row.original}
@@ -322,7 +324,7 @@ function createColumns(includeRwaPerps: boolean) {
 		}),
 		columnHelper.accessor((asset) => getDefiMetricValue(asset) ?? undefined, {
 			id: 'defiActiveTvl.total',
-			header: definitions.defiActiveTvl.label,
+			header: metricHeaders.defi,
 			cell: (info) => (
 				<MixedMetricCell
 					asset={info.row.original}

--- a/src/containers/RWA/AssetsTable.tsx
+++ b/src/containers/RWA/AssetsTable.tsx
@@ -32,10 +32,12 @@ import { rwaSlug } from './rwaSlug'
 
 export function RWAAssetsTable({
 	assets,
-	selectedChain
+	selectedChain,
+	includeRwaPerps
 }: {
 	assets: IRWAAssetsOverview['assets']
 	selectedChain: string
+	includeRwaPerps: boolean
 }) {
 	const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
 	const [sorting, setSorting] = useState<SortingState>([{ id: 'activeMcap.total', desc: true }])
@@ -50,10 +52,12 @@ export function RWAAssetsTable({
 		if (!deferredSearchValue) return assets
 
 		return matchSorter(assets, deferredSearchValue, {
-			keys: ['assetName', 'ticker'],
+			keys: ['assetName', 'ticker', 'parentPlatform'],
 			threshold: matchSorter.rankings.CONTAINS
 		})
 	}, [assets, deferredSearchValue])
+
+	const columns = useMemo(() => createColumns(includeRwaPerps), [includeRwaPerps])
 
 	const instance = useReactTable({
 		data: assetsData,
@@ -94,7 +98,7 @@ export function RWAAssetsTable({
 					help: c.meta?.headerHelperText as string | undefined
 				}
 			}),
-		[]
+		[columns]
 	)
 
 	const selectedColumns = instance
@@ -156,259 +160,347 @@ type AssetRow = IRWAAssetsOverview['assets'][0]
 const columnHelper = createColumnHelper<AssetRow>()
 const PLATFORM_COLUMN_HELP = 'Platform associated with issuance, custody, trading, or management of the asset.'
 
+function assertNever(value: never): never {
+	throw new Error(`Unexpected value: ${String(value)}`)
+}
+
 const formatAssetPlatforms = (asset: AssetRow) => getRwaPlatforms(asset.parentPlatform).join(', ')
 
-const columns = [
-	columnHelper.accessor((asset) => asset.assetName ?? asset.ticker, {
-		id: 'name',
-		header: 'Name',
-		enableSorting: false,
-		cell: (info) => {
-			return (
-				<span className="flex items-center gap-2">
-					<span className="vf-row-index shrink-0" aria-hidden="true" />
-					<span className="-my-1.5 flex flex-col overflow-hidden">
-						{info.row.original.canonicalMarketId ? (
-							<>
-								<BasicLink
-									href={`/rwa/asset/${encodeURIComponent(info.row.original.canonicalMarketId)}`}
-									className="overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-(--link-text) hover:underline"
-								>
-									{info.row.original.assetName ?? info.row.original.canonicalMarketId}
-								</BasicLink>
-								{info.row.original.assetName ? (
-									<span className="text-[0.7rem] text-(--text-disabled)">{info.row.original.ticker}</span>
-								) : null}
-							</>
-						) : (
-							<>
-								{info.row.original.assetName ? (
+const MIXED_ACTIVE_HEADER = 'Active Mcap or 24h Volume'
+const MIXED_ONCHAIN_HEADER = 'Onchain Mcap or 30d Volume'
+const MIXED_DEFI_HEADER = 'Defi Active TVL or OI'
+const MIXED_ACTIVE_HELP = `${definitions.activeMcap.description} For perps rows, this column shows 24h volume.`
+const MIXED_ONCHAIN_HELP = `${definitions.onChainMcap.description} For perps rows, this column shows 30d volume.`
+const MIXED_DEFI_HELP = `${definitions.defiActiveTvl.description} For perps rows, this column shows open interest.`
+
+export function getMetricColumnHeaders(includeRwaPerps: boolean) {
+	return {
+		active: includeRwaPerps ? MIXED_ACTIVE_HEADER : definitions.activeMcap.label,
+		onChain: includeRwaPerps ? MIXED_ONCHAIN_HEADER : definitions.onChainMcap.label,
+		defi: includeRwaPerps ? MIXED_DEFI_HEADER : definitions.defiActiveTvl.label
+	}
+}
+
+export function getActiveMetricValue(asset: AssetRow): number | null {
+	switch (asset.kind) {
+		case 'spot':
+			return asset.activeMcap?.total ?? null
+		case 'perps':
+			return asset.volume24h
+		default:
+			return assertNever(asset)
+	}
+}
+
+export function getOnChainMetricValue(asset: AssetRow): number | null {
+	switch (asset.kind) {
+		case 'spot':
+			return asset.onChainMcap?.total ?? null
+		case 'perps':
+			return asset.volume30d
+		default:
+			return assertNever(asset)
+	}
+}
+
+export function getDefiMetricValue(asset: AssetRow): number | null {
+	switch (asset.kind) {
+		case 'spot':
+			return asset.defiActiveTvl?.total ?? null
+		case 'perps':
+			return asset.openInterest
+		default:
+			return assertNever(asset)
+	}
+}
+
+function MixedMetricCell({
+	asset,
+	value,
+	breakdown,
+	description
+}: {
+	asset: AssetRow
+	value: number | null | undefined
+	breakdown: Array<[string, number]> | null | undefined
+	description: string
+}) {
+	if (asset.kind === 'spot') {
+		return <TVLBreakdownCell value={value} breakdown={breakdown} description={description} />
+	}
+
+	return value != null ? <span>{formattedNum(value, true)}</span> : null
+}
+
+function createColumns(includeRwaPerps: boolean) {
+	return [
+		columnHelper.accessor((asset) => asset.assetName ?? asset.ticker, {
+			id: 'name',
+			header: 'Name',
+			enableSorting: false,
+			cell: (info) => {
+				return (
+					<span className="flex items-center gap-2">
+						<span className="vf-row-index shrink-0" aria-hidden="true" />
+						<span className="-my-1.5 flex flex-col overflow-hidden">
+							{info.row.original.detailHref ? (
+								<>
+									<BasicLink
+										href={info.row.original.detailHref}
+										className="overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap text-(--link-text) hover:underline"
+									>
+										{info.row.original.assetName}
+									</BasicLink>
+									<span className="text-[0.7rem] text-(--text-disabled)">
+										{getAssetSecondaryLabel(info.row.original)}
+									</span>
+								</>
+							) : (
+								<>
 									<span className="overflow-hidden text-sm font-medium text-ellipsis whitespace-nowrap">
 										{info.row.original.assetName}
 									</span>
-								) : null}
-							</>
-						)}
+								</>
+							)}
+						</span>
 					</span>
-				</span>
-			)
-		},
-		size: 240
-	}),
-	columnHelper.accessor((asset) => asset.price, {
-		id: 'price',
-		header: 'Token Price',
-		cell: (info) => (info.getValue() != null ? <span>{formattedNum(info.getValue(), true)}</span> : null),
-		size: 120,
-		meta: {
-			align: 'end'
-		}
-	}),
-	columnHelper.accessor((asset) => normalizeRwaAssetGroup(asset.assetGroup), {
-		id: 'assetGroup',
-		header: 'Asset Group',
-		cell: (info) => {
-			const value = info.getValue()
-			return <span className="overflow-hidden text-ellipsis whitespace-nowrap">{value}</span>
-		},
-		size: 168,
-		enableSorting: false,
-		meta: {
-			align: 'end'
-		}
-	}),
-	columnHelper.accessor((asset) => asset.activeMcap?.total, {
-		id: 'activeMcap.total',
-		header: definitions.activeMcap.label,
-		cell: (info) => (
-			<TVLBreakdownCell
-				value={info.getValue()}
-				breakdown={info.row.original.activeMcap?.breakdown}
-				description={definitions.activeMcap.description}
-			/>
-		),
-		meta: {
-			headerHelperText: definitions.activeMcap.description,
-			align: 'end'
-		}
-	}),
-	columnHelper.accessor((asset) => asset.onChainMcap?.total, {
-		id: 'onChainMcap.total',
-		header: definitions.onChainMcap.label,
-		cell: (info) => (
-			<TVLBreakdownCell
-				value={info.getValue()}
-				breakdown={info.row.original.onChainMcap?.breakdown}
-				description={definitions.onChainMcap.description}
-			/>
-		),
-		size: 168,
-		meta: {
-			headerHelperText: definitions.onChainMcap.description,
-			align: 'end'
-		}
-	}),
-	columnHelper.accessor((asset) => asset.defiActiveTvl?.total, {
-		id: 'defiActiveTvl.total',
-		header: definitions.defiActiveTvl.label,
-		cell: (info) => (
-			<TVLBreakdownCell
-				value={info.getValue()}
-				breakdown={info.row.original.defiActiveTvl?.breakdown}
-				description={definitions.defiActiveTvl.description}
-			/>
-		),
-		meta: {
-			headerHelperText: definitions.defiActiveTvl.description,
-			align: 'end'
-		}
-	}),
-	columnHelper.accessor(
-		(asset) =>
-			Number.isNaN(Number(asset.defiActiveTvl?.total)) ||
-			Number.isNaN(Number(asset.activeMcap?.total)) ||
-			Number(asset.activeMcap?.total) === 0
-				? null
-				: (Number(asset.defiActiveTvl.total) / Number(asset.activeMcap.total)) * 100,
-		{
-			header: 'Utilization',
-			cell: (info) => (info.getValue() != null ? `${formatNum(info.getValue(), 2)}%` : null),
-			id: 'utilization',
+				)
+			},
+			size: 240
+		}),
+		columnHelper.accessor((asset) => asset.price ?? undefined, {
+			id: 'price',
+			header: 'Token Price',
+			cell: (info) => (info.getValue() != null ? <span>{formattedNum(info.getValue(), true)}</span> : null),
 			size: 120,
-			meta: { align: 'end', headerHelperText: 'DeFi Active TVL / Active Mcap' }
-		}
-	),
-	columnHelper.accessor((asset) => formatAssetPlatforms(asset), {
-		id: 'platform',
-		header: 'Platform',
-		cell: (info) => {
-			const platforms = getRwaPlatforms(info.row.original.parentPlatform)
-			const value = platforms.join(', ')
+			meta: {
+				align: 'end'
+			}
+		}),
+		columnHelper.accessor((asset) => normalizeRwaAssetGroup(asset.assetGroup), {
+			id: 'assetGroup',
+			header: 'Asset Group',
+			cell: (info) => {
+				const value = info.getValue()
+				return <span className="overflow-hidden text-ellipsis whitespace-nowrap">{value}</span>
+			},
+			size: 168,
+			enableSorting: false,
+			meta: {
+				align: 'end'
+			}
+		}),
+		columnHelper.accessor((asset) => getActiveMetricValue(asset) ?? undefined, {
+			id: 'activeMcap.total',
+			header: includeRwaPerps ? MIXED_ACTIVE_HEADER : definitions.activeMcap.label,
+			cell: (info) => (
+				<MixedMetricCell
+					asset={info.row.original}
+					value={info.getValue()}
+					breakdown={info.row.original.activeMcap?.breakdown}
+					description={definitions.activeMcap.description}
+				/>
+			),
+			meta: {
+				headerHelperText: includeRwaPerps ? MIXED_ACTIVE_HELP : definitions.activeMcap.description,
+				align: 'end'
+			},
+			size: includeRwaPerps ? 224 : 168
+		}),
+		columnHelper.accessor((asset) => getOnChainMetricValue(asset) ?? undefined, {
+			id: 'onChainMcap.total',
+			header: includeRwaPerps ? MIXED_ONCHAIN_HEADER : definitions.onChainMcap.label,
+			cell: (info) => (
+				<MixedMetricCell
+					asset={info.row.original}
+					value={info.getValue()}
+					breakdown={info.row.original.onChainMcap?.breakdown}
+					description={definitions.onChainMcap.description}
+				/>
+			),
+			size: includeRwaPerps ? 240 : 168,
+			meta: {
+				headerHelperText: includeRwaPerps ? MIXED_ONCHAIN_HELP : definitions.onChainMcap.description,
+				align: 'end'
+			}
+		}),
+		columnHelper.accessor((asset) => getDefiMetricValue(asset) ?? undefined, {
+			id: 'defiActiveTvl.total',
+			header: includeRwaPerps ? MIXED_DEFI_HEADER : definitions.defiActiveTvl.label,
+			cell: (info) => (
+				<MixedMetricCell
+					asset={info.row.original}
+					value={info.getValue()}
+					breakdown={info.row.original.defiActiveTvl?.breakdown}
+					description={definitions.defiActiveTvl.description}
+				/>
+			),
+			meta: {
+				headerHelperText: includeRwaPerps ? MIXED_DEFI_HELP : definitions.defiActiveTvl.description,
+				align: 'end'
+			},
+			size: includeRwaPerps ? 180 : 168
+		}),
+		columnHelper.accessor(
+			(asset) =>
+				Number.isNaN(Number(asset.defiActiveTvl?.total)) ||
+				Number.isNaN(Number(asset.activeMcap?.total)) ||
+				Number(asset.activeMcap?.total) === 0
+					? undefined
+					: (Number(asset.defiActiveTvl.total) / Number(asset.activeMcap.total)) * 100,
+			{
+				header: 'Utilization',
+				cell: (info) => (info.getValue() != null ? `${formatNum(info.getValue(), 2)}%` : null),
+				id: 'utilization',
+				size: 120,
+				meta: { align: 'end', headerHelperText: 'DeFi Active TVL / Active Mcap' }
+			}
+		),
+		columnHelper.accessor((asset) => formatAssetPlatforms(asset), {
+			id: 'platform',
+			header: 'Platform',
+			cell: (info) => {
+				const platforms = getRwaPlatforms(info.row.original.parentPlatform)
+				const value = platforms.join(', ')
 
-			if (platforms.length === 1 && platforms[0] !== UNKNOWN_PLATFORM) {
+				if (platforms.length === 1 && platforms[0] !== UNKNOWN_PLATFORM) {
+					return (
+						<BasicLink
+							href={`/rwa/platform/${rwaSlug(platforms[0])}`}
+							className="overflow-hidden text-ellipsis whitespace-nowrap text-(--link-text) hover:underline"
+						>
+							{value}
+						</BasicLink>
+					)
+				}
+
 				return (
-					<BasicLink
-						href={`/rwa/platform/${rwaSlug(platforms[0])}`}
-						className="overflow-hidden text-ellipsis whitespace-nowrap text-(--link-text) hover:underline"
+					<Tooltip
+						content={value}
+						className="inline-block max-w-full justify-end overflow-hidden text-ellipsis whitespace-nowrap"
 					>
 						{value}
-					</BasicLink>
+					</Tooltip>
 				)
+			},
+			size: 180,
+			enableSorting: false,
+			meta: {
+				align: 'end',
+				headerHelperText: PLATFORM_COLUMN_HELP
 			}
-
-			return (
-				<Tooltip
-					content={value}
-					className="inline-block max-w-full justify-end overflow-hidden text-ellipsis whitespace-nowrap"
-				>
-					{value}
-				</Tooltip>
-			)
-		},
-		size: 180,
-		enableSorting: false,
-		meta: {
-			align: 'end',
-			headerHelperText: PLATFORM_COLUMN_HELP
-		}
-	}),
-	columnHelper.accessor((asset) => asset.category, {
-		id: 'category',
-		header: definitions.category.label,
-		cell: (info) => {
-			const value = info.getValue() ?? []
-			const tooltipContent = value
-				.map((category) => {
-					const description = definitions.category.values?.[category]
-					return `${category}:\n${description || '-'}`
-				})
-				.join('\n\n')
-			if (tooltipContent) {
+		}),
+		columnHelper.accessor((asset) => asset.category ?? undefined, {
+			id: 'category',
+			header: definitions.category.label,
+			cell: (info) => {
+				const value = getAssetCategoryLabels(info.row.original)
+				const tooltipContent = value
+					.map((category) => {
+						const description = definitions.category.values?.[category]
+						return `${category}:\n${description || '-'}`
+					})
+					.join('\n\n')
+				if (tooltipContent) {
+					return (
+						<Tooltip
+							content={tooltipContent}
+							className="inline-block max-w-full justify-end overflow-hidden text-ellipsis whitespace-nowrap"
+						>
+							{value.join(', ')}
+						</Tooltip>
+					)
+				}
+				return (
+					<span title={value.join(', ')} className="overflow-hidden text-ellipsis whitespace-nowrap">
+						{value.join(', ')}
+					</span>
+				)
+			},
+			size: 168,
+			enableSorting: false,
+			meta: {
+				align: 'end',
+				headerHelperText: definitions.category.description
+			}
+		}),
+		columnHelper.accessor((asset) => asset.assetClass?.join(', ') ?? '', {
+			id: 'assetClass',
+			header: definitions.assetClass.label,
+			cell: (info) => {
+				const assetClasses = info.row.original.assetClass
+				if (!assetClasses || assetClasses.length === 0) return null
+				// For single asset class with definition, show tooltip
+				if (assetClasses.length === 1) {
+					const ac = assetClasses[0]
+					const description = definitions.assetClass.values?.[ac]
+					if (description) {
+						return (
+							<Tooltip
+								content={description}
+								className="inline-block max-w-full justify-end overflow-hidden text-ellipsis whitespace-nowrap"
+							>
+								{ac}
+							</Tooltip>
+						)
+					}
+					return <span className="inline-block max-w-full overflow-hidden text-ellipsis whitespace-nowrap">{ac}</span>
+				}
+				// For multiple asset classes, show combined tooltip
+				const tooltipContent = (
+					<span className="flex flex-col gap-1">
+						{assetClasses.map((ac) => {
+							const description = definitions.assetClass.values?.[ac]
+							return (
+								<span key={ac}>
+									<strong>{ac}</strong>: {description || 'No description'}
+								</span>
+							)
+						})}
+					</span>
+				)
 				return (
 					<Tooltip
 						content={tooltipContent}
 						className="inline-block max-w-full justify-end overflow-hidden text-ellipsis whitespace-nowrap"
 					>
-						{value.join(', ')}
+						{assetClasses.join(', ')}
 					</Tooltip>
 				)
+			},
+			size: 168,
+			enableSorting: false,
+			meta: {
+				align: 'end',
+				headerHelperText: definitions.assetClass.description
 			}
-			return (
-				<span title={value.join(', ')} className="overflow-hidden text-ellipsis whitespace-nowrap">
-					{value.join(', ')}
-				</span>
-			)
-		},
-		size: 168,
-		enableSorting: false,
-		meta: {
-			align: 'end',
-			headerHelperText: definitions.category.description
-		}
-	}),
-	columnHelper.accessor((asset) => asset.assetClass?.join(', ') ?? '', {
-		id: 'assetClass',
-		header: definitions.assetClass.label,
-		cell: (info) => {
-			const assetClasses = info.row.original.assetClass
-			if (!assetClasses || assetClasses.length === 0) return null
-			// For single asset class with definition, show tooltip
-			if (assetClasses.length === 1) {
-				const ac = assetClasses[0]
-				const description = definitions.assetClass.values?.[ac]
-				if (description) {
+		}),
+		columnHelper.accessor((asset) => asset.accessModel ?? undefined, {
+			id: 'accessModel',
+			header: definitions.accessModel.label,
+			cell: (info) => {
+				const value = info.getValue()
+				const valueDescription = definitions.accessModel.values?.[value]
+				if (valueDescription) {
 					return (
 						<Tooltip
-							content={description}
-							className="inline-block max-w-full justify-end overflow-hidden text-ellipsis whitespace-nowrap"
+							content={valueDescription}
+							className={clsx(
+								'justify-end',
+								value === 'Permissioned' && 'text-(--warning)',
+								value === 'Permissionless' && 'text-(--success)',
+								value === 'Non-transferable' && 'text-(--error)',
+								value === 'Custodial Only' && 'text-(--error)'
+							)}
 						>
-							{ac}
+							{value}
 						</Tooltip>
 					)
 				}
-				return <span className="inline-block max-w-full overflow-hidden text-ellipsis whitespace-nowrap">{ac}</span>
-			}
-			// For multiple asset classes, show combined tooltip
-			const tooltipContent = (
-				<span className="flex flex-col gap-1">
-					{assetClasses.map((ac) => {
-						const description = definitions.assetClass.values?.[ac]
-						return (
-							<span key={ac}>
-								<strong>{ac}</strong>: {description || 'No description'}
-							</span>
-						)
-					})}
-				</span>
-			)
-			return (
-				<Tooltip
-					content={tooltipContent}
-					className="inline-block max-w-full justify-end overflow-hidden text-ellipsis whitespace-nowrap"
-				>
-					{assetClasses.join(', ')}
-				</Tooltip>
-			)
-		},
-		size: 168,
-		enableSorting: false,
-		meta: {
-			align: 'end',
-			headerHelperText: definitions.assetClass.description
-		}
-	}),
-	columnHelper.accessor((asset) => asset.accessModel, {
-		id: 'accessModel',
-		header: definitions.accessModel.label,
-		cell: (info) => {
-			const value = info.getValue()
-			const valueDescription = definitions.accessModel.values?.[value]
-			if (valueDescription) {
 				return (
-					<Tooltip
-						content={valueDescription}
+					<span
 						className={clsx(
-							'justify-end',
+							'inline-block max-w-full overflow-hidden text-ellipsis whitespace-nowrap',
 							value === 'Permissioned' && 'text-(--warning)',
 							value === 'Permissionless' && 'text-(--success)',
 							value === 'Non-transferable' && 'text-(--error)',
@@ -416,201 +508,211 @@ const columns = [
 						)}
 					>
 						{value}
-					</Tooltip>
+					</span>
 				)
+			},
+			size: 180,
+			enableSorting: false,
+			meta: {
+				align: 'end',
+				headerHelperText: definitions.accessModel.description
 			}
-			return (
-				<span
-					className={clsx(
-						'inline-block max-w-full overflow-hidden text-ellipsis whitespace-nowrap',
-						value === 'Permissioned' && 'text-(--warning)',
-						value === 'Permissionless' && 'text-(--success)',
-						value === 'Non-transferable' && 'text-(--error)',
-						value === 'Custodial Only' && 'text-(--error)'
-					)}
-				>
-					{value}
-				</span>
-			)
-		},
-		size: 180,
-		enableSorting: false,
-		meta: {
-			align: 'end',
-			headerHelperText: definitions.accessModel.description
-		}
-	}),
-	columnHelper.accessor((asset) => asset.type, {
-		id: 'type',
-		header: definitions.type.label,
-		cell: (info) => {
-			const value = info.getValue()
-			const tooltipContent = definitions.type.values?.[value]
-			if (tooltipContent) {
+		}),
+		columnHelper.accessor((asset) => asset.type ?? undefined, {
+			id: 'type',
+			header: definitions.type.label,
+			cell: (info) => {
+				const value = info.getValue()
+				const tooltipContent = definitions.type.values?.[value]
+				if (tooltipContent) {
+					return (
+						<Tooltip
+							content={tooltipContent}
+							className="inline-block max-w-full justify-end overflow-hidden text-ellipsis whitespace-nowrap"
+						>
+							{value}
+						</Tooltip>
+					)
+				}
+				return <span className="inline-block max-w-full overflow-hidden text-ellipsis whitespace-nowrap">{value}</span>
+			},
+			size: 120,
+			enableSorting: false,
+			meta: {
+				align: 'end',
+				headerHelperText: definitions.type.description
+			}
+		}),
+		columnHelper.accessor((asset) => asset.rwaClassification ?? undefined, {
+			id: 'rwaClassification',
+			header: definitions.rwaClassification.label,
+			cell: (info) => {
+				const value = info.getValue()
+				const isTrueRWA = info.row.original.trueRWA
+				// If trueRWA flag, show green color with True RWA definition but display "RWA"
+				const tooltipContent = isTrueRWA
+					? definitions.rwaClassification.values?.['True RWA']
+					: definitions.rwaClassification.values?.[value]
+				if (tooltipContent) {
+					return (
+						<Tooltip
+							content={tooltipContent}
+							className={`inline-block max-w-full justify-end overflow-hidden text-ellipsis whitespace-nowrap ${isTrueRWA ? 'text-(--success)' : ''}`}
+						>
+							{value}
+						</Tooltip>
+					)
+				}
+				return <span className="inline-block max-w-full overflow-hidden text-ellipsis whitespace-nowrap">{value}</span>
+			},
+			size: 180,
+			enableSorting: false,
+			meta: {
+				align: 'end',
+				headerHelperText: definitions.rwaClassification.description
+			}
+		}),
+		columnHelper.accessor((asset) => asset.issuer ?? undefined, {
+			id: 'issuer',
+			header: definitions.issuer.label,
+			cell: (info) => {
+				const value = info.getValue()
 				return (
-					<Tooltip
-						content={tooltipContent}
-						className="inline-block max-w-full justify-end overflow-hidden text-ellipsis whitespace-nowrap"
-					>
+					<span title={value} className="overflow-hidden text-ellipsis whitespace-nowrap">
 						{value}
-					</Tooltip>
+					</span>
 				)
+			},
+			size: 120,
+			enableSorting: false,
+			meta: {
+				align: 'end',
+				headerHelperText: definitions.issuer.description
 			}
-			return <span className="inline-block max-w-full overflow-hidden text-ellipsis whitespace-nowrap">{value}</span>
-		},
-		size: 120,
-		enableSorting: false,
-		meta: {
-			align: 'end',
-			headerHelperText: definitions.type.description
-		}
-	}),
-	columnHelper.accessor((asset) => asset.rwaClassification, {
-		id: 'rwaClassification',
-		header: definitions.rwaClassification.label,
-		cell: (info) => {
-			const value = info.getValue()
-			const isTrueRWA = info.row.original.trueRWA
-			// If trueRWA flag, show green color with True RWA definition but display "RWA"
-			const tooltipContent = isTrueRWA
-				? definitions.rwaClassification.values?.['True RWA']
-				: definitions.rwaClassification.values?.[value]
-			if (tooltipContent) {
-				return (
-					<Tooltip
-						content={tooltipContent}
-						className={`inline-block max-w-full justify-end overflow-hidden text-ellipsis whitespace-nowrap ${isTrueRWA ? 'text-(--success)' : ''}`}
-					>
-						{value}
-					</Tooltip>
-				)
-			}
-			return <span className="inline-block max-w-full overflow-hidden text-ellipsis whitespace-nowrap">{value}</span>
-		},
-		size: 180,
-		enableSorting: false,
-		meta: {
-			align: 'end',
-			headerHelperText: definitions.rwaClassification.description
-		}
-	}),
-	columnHelper.accessor((asset) => asset.issuer, {
-		id: 'issuer',
-		header: definitions.issuer.label,
-		cell: (info) => {
-			const value = info.getValue()
-			return (
-				<span title={value} className="overflow-hidden text-ellipsis whitespace-nowrap">
-					{value}
+		}),
+		columnHelper.accessor((asset) => asset.redeemable ?? undefined, {
+			id: 'redeemable',
+			header: definitions.redeemable.label,
+			cell: (info) => (
+				<span className={info.getValue() ? 'text-(--success)' : 'text-(--error)'}>
+					{info.getValue() != null ? (info.getValue() ? 'Yes' : 'No') : null}
 				</span>
-			)
-		},
-		size: 120,
-		enableSorting: false,
-		meta: {
-			align: 'end',
-			headerHelperText: definitions.issuer.description
-		}
-	}),
-	columnHelper.accessor((asset) => asset.redeemable, {
-		id: 'redeemable',
-		header: definitions.redeemable.label,
-		cell: (info) => (
-			<span className={info.getValue() ? 'text-(--success)' : 'text-(--error)'}>
-				{info.getValue() != null ? (info.getValue() ? 'Yes' : 'No') : null}
-			</span>
-		),
-		meta: {
-			align: 'end',
-			headerHelperText: definitions.redeemable.description
-		},
-		size: 120
-	}),
-	columnHelper.accessor((asset) => asset.attestations, {
-		id: 'attestations',
-		header: definitions.attestations.label,
-		cell: (info) => (
-			<span className={info.getValue() ? 'text-(--success)' : 'text-(--error)'}>
-				{info.getValue() != null ? (info.getValue() ? 'Yes' : 'No') : null}
-			</span>
-		),
-		meta: {
-			align: 'end',
-			headerHelperText: definitions.attestations.description
-		},
-		size: 120
-	}),
-	columnHelper.accessor((asset) => asset.cexListed, {
-		id: 'cexListed',
-		header: definitions.cexListed.label,
-		cell: (info) => (
-			<span className={info.getValue() ? 'text-(--success)' : 'text-(--error)'}>
-				{info.getValue() != null ? (info.getValue() ? 'Yes' : 'No') : null}
-			</span>
-		),
-		meta: {
-			align: 'end',
-			headerHelperText: definitions.cexListed.description
-		},
-		size: 120
-	}),
-	columnHelper.accessor((asset) => asset.kycForMintRedeem, {
-		id: 'kycForMintRedeem',
-		header: definitions.kycForMintRedeem.label,
-		cell: (info) => (
-			<span className={info.getValue() ? 'text-(--warning)' : 'text-(--success)'}>
-				{info.getValue() != null ? (info.getValue() ? 'Yes' : 'No') : null}
-			</span>
-		),
-		meta: {
-			align: 'end',
-			headerHelperText: definitions.kycForMintRedeem.description
-		},
-		size: 188
-	}),
-	columnHelper.accessor((asset) => asset.kycAllowlistedWhitelistedToTransferHold, {
-		id: 'kycAllowlistedWhitelistedToTransferHold',
-		header: definitions.kycAllowlistedWhitelistedToTransferHold.label,
-		cell: (info) => (
-			<span className={info.getValue() ? 'text-(--warning)' : 'text-(--success)'}>
-				{info.getValue() != null ? (info.getValue() ? 'Yes' : 'No') : null}
-			</span>
-		),
-		meta: {
-			align: 'end',
-			headerHelperText: definitions.kycAllowlistedWhitelistedToTransferHold.description
-		},
-		size: 332
-	}),
-	columnHelper.accessor((asset) => asset.transferable, {
-		id: 'transferable',
-		header: definitions.transferable.label,
-		cell: (info) => (
-			<span className={info.getValue() ? 'text-(--success)' : 'text-(--error)'}>
-				{info.getValue() != null ? (info.getValue() ? 'Yes' : 'No') : null}
-			</span>
-		),
-		meta: {
-			align: 'end',
-			headerHelperText: definitions.transferable.description
-		},
-		size: 120
-	}),
-	columnHelper.accessor((asset) => asset.selfCustody, {
-		id: 'selfCustody',
-		header: definitions.selfCustody.label,
-		cell: (info) => (
-			<span className={info.getValue() ? 'text-(--success)' : 'text-(--error)'}>
-				{info.getValue() != null ? (info.getValue() ? 'Yes' : 'No') : null}
-			</span>
-		),
-		meta: {
-			align: 'end',
-			headerHelperText: definitions.selfCustody.description
-		},
-		size: 120
-	})
-]
+			),
+			meta: {
+				align: 'end',
+				headerHelperText: definitions.redeemable.description
+			},
+			size: 120
+		}),
+		columnHelper.accessor((asset) => asset.attestations ?? undefined, {
+			id: 'attestations',
+			header: definitions.attestations.label,
+			cell: (info) => (
+				<span className={info.getValue() ? 'text-(--success)' : 'text-(--error)'}>
+					{info.getValue() != null ? (info.getValue() ? 'Yes' : 'No') : null}
+				</span>
+			),
+			meta: {
+				align: 'end',
+				headerHelperText: definitions.attestations.description
+			},
+			size: 120
+		}),
+		columnHelper.accessor((asset) => asset.cexListed ?? undefined, {
+			id: 'cexListed',
+			header: definitions.cexListed.label,
+			cell: (info) => (
+				<span className={info.getValue() ? 'text-(--success)' : 'text-(--error)'}>
+					{info.getValue() != null ? (info.getValue() ? 'Yes' : 'No') : null}
+				</span>
+			),
+			meta: {
+				align: 'end',
+				headerHelperText: definitions.cexListed.description
+			},
+			size: 120
+		}),
+		columnHelper.accessor((asset) => asset.kycForMintRedeem ?? undefined, {
+			id: 'kycForMintRedeem',
+			header: definitions.kycForMintRedeem.label,
+			cell: (info) => (
+				<span className={info.getValue() ? 'text-(--warning)' : 'text-(--success)'}>
+					{info.getValue() != null ? (info.getValue() ? 'Yes' : 'No') : null}
+				</span>
+			),
+			meta: {
+				align: 'end',
+				headerHelperText: definitions.kycForMintRedeem.description
+			},
+			size: 188
+		}),
+		columnHelper.accessor((asset) => asset.kycAllowlistedWhitelistedToTransferHold ?? undefined, {
+			id: 'kycAllowlistedWhitelistedToTransferHold',
+			header: definitions.kycAllowlistedWhitelistedToTransferHold.label,
+			cell: (info) => (
+				<span className={info.getValue() ? 'text-(--warning)' : 'text-(--success)'}>
+					{info.getValue() != null ? (info.getValue() ? 'Yes' : 'No') : null}
+				</span>
+			),
+			meta: {
+				align: 'end',
+				headerHelperText: definitions.kycAllowlistedWhitelistedToTransferHold.description
+			},
+			size: 332
+		}),
+		columnHelper.accessor((asset) => asset.transferable ?? undefined, {
+			id: 'transferable',
+			header: definitions.transferable.label,
+			cell: (info) => (
+				<span className={info.getValue() ? 'text-(--success)' : 'text-(--error)'}>
+					{info.getValue() != null ? (info.getValue() ? 'Yes' : 'No') : null}
+				</span>
+			),
+			meta: {
+				align: 'end',
+				headerHelperText: definitions.transferable.description
+			},
+			size: 120
+		}),
+		columnHelper.accessor((asset) => asset.selfCustody ?? undefined, {
+			id: 'selfCustody',
+			header: definitions.selfCustody.label,
+			cell: (info) => (
+				<span className={info.getValue() ? 'text-(--success)' : 'text-(--error)'}>
+					{info.getValue() != null ? (info.getValue() ? 'Yes' : 'No') : null}
+				</span>
+			),
+			meta: {
+				align: 'end',
+				headerHelperText: definitions.selfCustody.description
+			},
+			size: 120
+		})
+	]
+}
+
+function getAssetSecondaryLabel(asset: AssetRow): string {
+	switch (asset.kind) {
+		case 'spot':
+			return asset.ticker
+		case 'perps':
+			return asset.contract
+		default:
+			return assertNever(asset)
+	}
+}
+
+function getAssetCategoryLabels(asset: AssetRow): string[] {
+	if (asset.category && asset.category.length > 0) {
+		return asset.category
+	}
+
+	if (asset.kind === 'perps') {
+		return ['RWA Perp']
+	}
+
+	return []
+}
 
 const TVLBreakdownCell = ({
 	value,

--- a/src/containers/RWA/AssetsTable.tsx
+++ b/src/containers/RWA/AssetsTable.tsx
@@ -388,7 +388,7 @@ function createColumns(includeRwaPerps: boolean) {
 				headerHelperText: PLATFORM_COLUMN_HELP
 			}
 		}),
-		columnHelper.accessor((asset) => asset.category ?? undefined, {
+		columnHelper.accessor((asset) => getAssetCategoryLabels(asset).join(', ') || undefined, {
 			id: 'category',
 			header: definitions.category.label,
 			cell: (info) => {
@@ -649,7 +649,7 @@ function createColumns(includeRwaPerps: boolean) {
 			header: definitions.kycAllowlistedWhitelistedToTransferHold.label,
 			cell: (info) => (
 				<span className={info.getValue() ? 'text-(--warning)' : 'text-(--success)'}>
-					{info.getValue() != null ? (info.getValue() ? 'Yes' : 'No') : null}
+					{info.getValue() ? (info.getValue() ? 'Yes' : 'No') : null}
 				</span>
 			),
 			meta: {

--- a/src/containers/RWA/AssetsTable.tsx
+++ b/src/containers/RWA/AssetsTable.tsx
@@ -166,18 +166,14 @@ function assertNever(value: never): never {
 
 const formatAssetPlatforms = (asset: AssetRow) => getRwaPlatforms(asset.parentPlatform).join(', ')
 
-const MIXED_ACTIVE_HEADER = 'Active Mcap or 24h Volume'
-const MIXED_ONCHAIN_HEADER = 'Onchain Mcap or 30d Volume'
-const MIXED_DEFI_HEADER = 'Defi Active TVL or OI'
-const MIXED_ACTIVE_HELP = `${definitions.activeMcap.description} For perps rows, this column shows 24h volume.`
-const MIXED_ONCHAIN_HELP = `${definitions.onChainMcap.description} For perps rows, this column shows 30d volume.`
-const MIXED_DEFI_HELP = `${definitions.defiActiveTvl.description} For perps rows, this column shows open interest.`
+const MIXED_ACTIVE_HEADER = 'Active Mcap or OI'
+const MIXED_ACTIVE_HELP = `${definitions.activeMcap.description} For perps rows, this column shows open interest.`
 
 export function getMetricColumnHeaders(includeRwaPerps: boolean) {
 	return {
 		active: includeRwaPerps ? MIXED_ACTIVE_HEADER : definitions.activeMcap.label,
-		onChain: includeRwaPerps ? MIXED_ONCHAIN_HEADER : definitions.onChainMcap.label,
-		defi: includeRwaPerps ? MIXED_DEFI_HEADER : definitions.defiActiveTvl.label
+		onChain: definitions.onChainMcap.label,
+		defi: definitions.defiActiveTvl.label
 	}
 }
 
@@ -186,7 +182,7 @@ export function getActiveMetricValue(asset: AssetRow): number | null {
 		case 'spot':
 			return asset.activeMcap?.total ?? null
 		case 'perps':
-			return asset.volume24h
+			return asset.openInterest
 		default:
 			return assertNever(asset)
 	}
@@ -197,7 +193,7 @@ export function getOnChainMetricValue(asset: AssetRow): number | null {
 		case 'spot':
 			return asset.onChainMcap?.total ?? null
 		case 'perps':
-			return asset.volume30d
+			return null
 		default:
 			return assertNever(asset)
 	}
@@ -208,7 +204,7 @@ export function getDefiMetricValue(asset: AssetRow): number | null {
 		case 'spot':
 			return asset.defiActiveTvl?.total ?? null
 		case 'perps':
-			return asset.openInterest
+			return null
 		default:
 			return assertNever(asset)
 	}
@@ -305,11 +301,11 @@ function createColumns(includeRwaPerps: boolean) {
 				headerHelperText: includeRwaPerps ? MIXED_ACTIVE_HELP : definitions.activeMcap.description,
 				align: 'end'
 			},
-			size: includeRwaPerps ? 224 : 168
+			size: 168
 		}),
 		columnHelper.accessor((asset) => getOnChainMetricValue(asset) ?? undefined, {
 			id: 'onChainMcap.total',
-			header: includeRwaPerps ? MIXED_ONCHAIN_HEADER : definitions.onChainMcap.label,
+			header: definitions.onChainMcap.label,
 			cell: (info) => (
 				<MixedMetricCell
 					asset={info.row.original}
@@ -318,15 +314,15 @@ function createColumns(includeRwaPerps: boolean) {
 					description={definitions.onChainMcap.description}
 				/>
 			),
-			size: includeRwaPerps ? 240 : 168,
+			size: 168,
 			meta: {
-				headerHelperText: includeRwaPerps ? MIXED_ONCHAIN_HELP : definitions.onChainMcap.description,
+				headerHelperText: definitions.onChainMcap.description,
 				align: 'end'
 			}
 		}),
 		columnHelper.accessor((asset) => getDefiMetricValue(asset) ?? undefined, {
 			id: 'defiActiveTvl.total',
-			header: includeRwaPerps ? MIXED_DEFI_HEADER : definitions.defiActiveTvl.label,
+			header: definitions.defiActiveTvl.label,
 			cell: (info) => (
 				<MixedMetricCell
 					asset={info.row.original}
@@ -336,10 +332,10 @@ function createColumns(includeRwaPerps: boolean) {
 				/>
 			),
 			meta: {
-				headerHelperText: includeRwaPerps ? MIXED_DEFI_HELP : definitions.defiActiveTvl.description,
+				headerHelperText: definitions.defiActiveTvl.description,
 				align: 'end'
 			},
-			size: includeRwaPerps ? 180 : 168
+			size: 168
 		}),
 		columnHelper.accessor(
 			(asset) =>
@@ -383,7 +379,7 @@ function createColumns(includeRwaPerps: boolean) {
 					</Tooltip>
 				)
 			},
-			size: 180,
+			size: 168,
 			enableSorting: false,
 			meta: {
 				align: 'end',
@@ -583,7 +579,7 @@ function createColumns(includeRwaPerps: boolean) {
 					</span>
 				)
 			},
-			size: 120,
+			size: 168,
 			enableSorting: false,
 			meta: {
 				align: 'end',

--- a/src/containers/RWA/Filters.tsx
+++ b/src/containers/RWA/Filters.tsx
@@ -48,6 +48,7 @@ const FILTER_QUERY_KEYS = [
 	'maxDefiActiveTvlToActiveMcapPct',
 	'includeStablecoins',
 	'includeGovernance',
+	'includeRwaPerps',
 	'redeemableStates',
 	'attestationsStates',
 	'cexListedStates',
@@ -120,6 +121,7 @@ type RWAFilterSelections = {
 	maxDefiActiveTvlToActiveMcapPct: number | null
 	includeStablecoins: boolean
 	includeGovernance: boolean
+	includeRwaPerps: boolean
 }
 
 type RWAFilterActions = {
@@ -128,6 +130,7 @@ type RWAFilterActions = {
 	setDefiActiveTvlToActiveMcapPctRange: (minValue: string | number | null, maxValue: string | number | null) => void
 	setIncludeStablecoins: (value: boolean) => void
 	setIncludeGovernance: (value: boolean) => void
+	setIncludeRwaPerps: (value: boolean) => void
 	setRedeemableStates: (values: RWAAttributeFilterState[]) => void
 	setAttestationsStates: (values: RWAAttributeFilterState[]) => void
 	setCexListedStates: (values: RWAAttributeFilterState[]) => void
@@ -505,6 +508,17 @@ function Filters({
 				}}
 			>
 				Governance Tokens
+			</Checkbox>
+			<Checkbox
+				variant={nestedMenu ? 'filter-borderless' : 'filter'}
+				value="includeRwaPerps"
+				checked={selections.includeRwaPerps}
+				onChange={() => {
+					const next = !selections.includeRwaPerps
+					actions.setIncludeRwaPerps(next)
+				}}
+			>
+				RWA Perps
 			</Checkbox>
 			<button
 				onClick={() => {

--- a/src/containers/RWA/Perps/Dashboard.test.tsx
+++ b/src/containers/RWA/Perps/Dashboard.test.tsx
@@ -172,11 +172,11 @@ describe('RWAPerpsDashboard treemap controls', () => {
 		expect(html).toContain('reset')
 	})
 
-	it('shows hbar by default when no chart view is provided on the overview page', () => {
+	it('shows time series by default when no chart view is provided on the overview page', () => {
 		const html = renderToStaticMarkup(<RWAPerpsDashboard mode="overview" data={overviewData} />)
 
-		expect(html).toContain('Asset Group')
-		expect(html).toContain('HBar Chart')
+		expect(html).toContain('Time Series Chart')
+		expect(html).toContain('Total')
 		expect(html).not.toContain('Nested by:')
 		expect(html).not.toContain('reset')
 	})

--- a/src/containers/RWA/Perps/Dashboard.tsx
+++ b/src/containers/RWA/Perps/Dashboard.tsx
@@ -40,7 +40,7 @@ import {
 	getRWAPerpsTreemapNestedByOptions,
 	getRWAPerpsTreemapNestedByQueryValue,
 	getRWAPerpsChartViewOptions,
-	getRWAPerpsChartViewQueryValue,
+	getRWAPerpsChartViewQueryValueForMode,
 	parseRWAPerpsChartState,
 	setRWAPerpsChartBreakdown,
 	setRWAPerpsTimeSeriesMode,
@@ -873,7 +873,7 @@ export function RWAPerpsDashboard(props: RWAPerpsDashboardProps) {
 		const selectedView = (Array.isArray(value) ? value[0] : value) as typeof chartState.view
 		const nextState = setRWAPerpsChartView(chartState, selectedView)
 		void pushShallowQuery(router, {
-			chartView: getRWAPerpsChartViewQueryValue(nextState.view),
+			chartView: getRWAPerpsChartViewQueryValueForMode(props.mode, nextState.view),
 			timeSeriesChartBreakdown:
 				nextState.view === 'timeSeries' ? getRWAPerpsChartBreakdownQueryValue(nextState) : undefined,
 			nonTimeSeriesChartBreakdown:

--- a/src/containers/RWA/Perps/chartState.test.ts
+++ b/src/containers/RWA/Perps/chartState.test.ts
@@ -5,6 +5,7 @@ import {
 	getDefaultRWAPerpsChartBreakdown,
 	getRWAPerpsChartBreakdownOptions,
 	getRWAPerpsChartMetricOptions,
+	getRWAPerpsChartViewQueryValueForMode,
 	getRWAPerpsTimeSeriesModeOptions,
 	getRWAPerpsTimeSeriesModeQueryValue,
 	getRWAPerpsTreemapNestedByOptions,
@@ -129,6 +130,11 @@ describe('perps chartState options', () => {
 		expect(getDefaultRWAPerpsChartView('overview')).toBe('timeSeries')
 		expect(getDefaultRWAPerpsChartView('venue')).toBe('timeSeries')
 		expect(getDefaultRWAPerpsChartView('assetGroup')).toBe('timeSeries')
+		expect(getRWAPerpsChartViewQueryValueForMode('overview', getDefaultRWAPerpsChartView('overview'))).toBe(undefined)
+		expect(getRWAPerpsChartViewQueryValueForMode('venue', getDefaultRWAPerpsChartView('venue'))).toBe(undefined)
+		expect(getRWAPerpsChartViewQueryValueForMode('assetGroup', getDefaultRWAPerpsChartView('assetGroup'))).toBe(
+			undefined
+		)
 	})
 
 	it('uses the expected defaults for each page/view', () => {

--- a/src/containers/RWA/Perps/chartState.test.ts
+++ b/src/containers/RWA/Perps/chartState.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
 	DEFAULT_CHART_VIEW,
+	getDefaultRWAPerpsChartView,
 	getDefaultRWAPerpsChartBreakdown,
 	getRWAPerpsChartBreakdownOptions,
 	getRWAPerpsChartMetricOptions,
@@ -27,25 +28,25 @@ describe('parseRWAPerpsChartState', () => {
 		expect(state.view).toBe('hbar')
 	})
 
-	it('defaults all pages to hbar when no chart view is provided', () => {
+	it('defaults all pages to time series when no chart view is provided', () => {
 		const overviewState = parseRWAPerpsChartState({}, 'overview')
 		const venueState = parseRWAPerpsChartState({}, 'venue')
 		const assetGroupState = parseRWAPerpsChartState({}, 'assetGroup')
 
 		expect(overviewState).toMatchObject({
-			view: 'hbar',
+			view: 'timeSeries',
 			breakdown: 'assetGroup',
 			timeSeriesMode: 'grouped',
 			treemapNestedBy: 'baseAsset'
 		})
 		expect(venueState).toMatchObject({
-			view: 'hbar',
+			view: 'timeSeries',
 			breakdown: 'assetGroup',
 			timeSeriesMode: 'grouped',
 			treemapNestedBy: 'baseAsset'
 		})
 		expect(assetGroupState).toMatchObject({
-			view: 'hbar',
+			view: 'timeSeries',
 			breakdown: 'baseAsset',
 			timeSeriesMode: 'grouped',
 			treemapNestedBy: 'contract'
@@ -120,8 +121,14 @@ describe('parseRWAPerpsChartState', () => {
 })
 
 describe('perps chartState options', () => {
-	it('uses hbar as the shared default chart view', () => {
-		expect(DEFAULT_CHART_VIEW).toBe('hbar')
+	it('uses time series as the shared default chart view', () => {
+		expect(DEFAULT_CHART_VIEW).toBe('timeSeries')
+	})
+
+	it('uses time series as the default chart view for every perps page', () => {
+		expect(getDefaultRWAPerpsChartView('overview')).toBe('timeSeries')
+		expect(getDefaultRWAPerpsChartView('venue')).toBe('timeSeries')
+		expect(getDefaultRWAPerpsChartView('assetGroup')).toBe('timeSeries')
 	})
 
 	it('uses the expected defaults for each page/view', () => {

--- a/src/containers/RWA/Perps/chartState.ts
+++ b/src/containers/RWA/Perps/chartState.ts
@@ -143,6 +143,11 @@ const DEFAULT_TREEMAP_NESTED_BY: Record<
 export const DEFAULT_CHART_VIEW: RWAPerpsChartView = 'timeSeries'
 const DEFAULT_CHART_METRIC: RWAPerpsChartMetricKey = 'openInterest'
 const DEFAULT_TIME_SERIES_MODE: RWAPerpsTimeSeriesMode = 'grouped'
+const DEFAULT_CHART_VIEW_BY_MODE: Record<RWAPerpsChartMode, RWAPerpsChartView> = {
+	overview: DEFAULT_CHART_VIEW,
+	venue: DEFAULT_CHART_VIEW,
+	assetGroup: DEFAULT_CHART_VIEW
+}
 const VALID_CHART_VIEWS = new Set<RWAPerpsChartView>(CHART_VIEW_OPTIONS.map((option) => option.key))
 const VALID_CHART_METRICS = new Set<RWAPerpsChartMetricKey>(CHART_METRIC_KEYS)
 const VALID_TIME_SERIES_MODES = new Set<RWAPerpsTimeSeriesMode>(TIME_SERIES_MODE_OPTIONS.map((option) => option.key))
@@ -161,8 +166,8 @@ export function getRWAPerpsTimeSeriesModeOptions() {
 	return TIME_SERIES_MODE_OPTIONS
 }
 
-export function getDefaultRWAPerpsChartView(_mode: RWAPerpsChartMode): RWAPerpsChartView {
-	return DEFAULT_CHART_VIEW
+export function getDefaultRWAPerpsChartView(mode: RWAPerpsChartMode): RWAPerpsChartView {
+	return DEFAULT_CHART_VIEW_BY_MODE[mode] ?? DEFAULT_CHART_VIEW
 }
 
 export function getRWAPerpsChartMetricOptions(labels: RWAPerpsChartLabels) {
@@ -317,8 +322,8 @@ export function getRWAPerpsChartViewQueryValue(view: RWAPerpsChartView) {
 	return view === DEFAULT_CHART_VIEW ? undefined : view
 }
 
-export function getRWAPerpsChartViewQueryValueForMode(_mode: RWAPerpsChartMode, view: RWAPerpsChartView) {
-	return view === DEFAULT_CHART_VIEW ? undefined : view
+export function getRWAPerpsChartViewQueryValueForMode(mode: RWAPerpsChartMode, view: RWAPerpsChartView) {
+	return view === getDefaultRWAPerpsChartView(mode) ? undefined : view
 }
 
 export function getRWAPerpsChartMetricQueryValue(metric: RWAPerpsChartMetricKey) {

--- a/src/containers/RWA/Perps/chartState.ts
+++ b/src/containers/RWA/Perps/chartState.ts
@@ -140,7 +140,7 @@ const DEFAULT_TREEMAP_NESTED_BY: Record<
 	}
 }
 
-export const DEFAULT_CHART_VIEW: RWAPerpsChartView = 'hbar'
+export const DEFAULT_CHART_VIEW: RWAPerpsChartView = 'timeSeries'
 const DEFAULT_CHART_METRIC: RWAPerpsChartMetricKey = 'openInterest'
 const DEFAULT_TIME_SERIES_MODE: RWAPerpsTimeSeriesMode = 'grouped'
 const VALID_CHART_VIEWS = new Set<RWAPerpsChartView>(CHART_VIEW_OPTIONS.map((option) => option.key))
@@ -159,6 +159,10 @@ export function getRWAPerpsChartViewOptions() {
 
 export function getRWAPerpsTimeSeriesModeOptions() {
 	return TIME_SERIES_MODE_OPTIONS
+}
+
+export function getDefaultRWAPerpsChartView(_mode: RWAPerpsChartMode): RWAPerpsChartView {
+	return DEFAULT_CHART_VIEW
 }
 
 export function getRWAPerpsChartMetricOptions(labels: RWAPerpsChartLabels) {
@@ -243,7 +247,7 @@ export function getRWAPerpsTreemapNestedByOptions(
 }
 
 export function parseRWAPerpsChartState(query: ParsedUrlQuery, mode: RWAPerpsChartMode): RWAPerpsChartState {
-	const view = normalizeChartView(readSingleQueryValue(query.chartView))
+	const view = normalizeChartView(mode, readSingleQueryValue(query.chartView))
 	const metric = normalizeChartMetric(readSingleQueryValue(query.chartType))
 	const breakdown = normalizeBreakdown(mode, view, readSingleQueryValue(query[getBreakdownQueryKey(view)]))
 	const timeSeriesMode = normalizeTimeSeriesMode(readSingleQueryValue(query.timeSeriesMode))
@@ -313,6 +317,10 @@ export function getRWAPerpsChartViewQueryValue(view: RWAPerpsChartView) {
 	return view === DEFAULT_CHART_VIEW ? undefined : view
 }
 
+export function getRWAPerpsChartViewQueryValueForMode(_mode: RWAPerpsChartMode, view: RWAPerpsChartView) {
+	return view === DEFAULT_CHART_VIEW ? undefined : view
+}
+
 export function getRWAPerpsChartMetricQueryValue(metric: RWAPerpsChartMetricKey) {
 	return metric === DEFAULT_CHART_METRIC ? undefined : metric
 }
@@ -346,10 +354,10 @@ function getBreakdownQueryKey(view: RWAPerpsChartView): 'timeSeriesChartBreakdow
 	return view === 'timeSeries' ? 'timeSeriesChartBreakdown' : 'nonTimeSeriesChartBreakdown'
 }
 
-function normalizeChartView(value: string | undefined): RWAPerpsChartView {
+function normalizeChartView(mode: RWAPerpsChartMode, value: string | undefined): RWAPerpsChartView {
 	if (value === 'bar') return 'hbar'
 	if (value && VALID_CHART_VIEWS.has(value as RWAPerpsChartView)) return value as RWAPerpsChartView
-	return DEFAULT_CHART_VIEW
+	return getDefaultRWAPerpsChartView(mode)
 }
 
 function normalizeChartMetric(value: string | undefined): RWAPerpsChartMetricKey {

--- a/src/containers/RWA/Perps/queries.test.ts
+++ b/src/containers/RWA/Perps/queries.test.ts
@@ -408,7 +408,7 @@ describe('getRWAPerpsContractData', () => {
 })
 
 describe('perps overview queries', () => {
-	it('builds the overview page model with totals, sorted markets, and no preloaded chart for the default hbar view', async () => {
+	it('builds the overview page model with totals, sorted markets, and a preloaded chart for the default time-series view', async () => {
 		const result = await getRWAPerpsOverview()
 
 		expect(result).toMatchObject({
@@ -423,7 +423,13 @@ describe('perps overview queries', () => {
 			},
 			markets: [{ id: 'xyz:nvda' }, { id: 'xyz:meta' }, { id: 'flx:gold' }]
 		})
-		expect(result.initialChartDataset).toEqual({ source: [], dimensions: ['timestamp'] })
+		expect(result.initialChartDataset).toEqual({
+			source: [
+				{ timestamp: 1774483200000, Equities: 120 },
+				{ timestamp: 1774569600000, Commodities: 100, Equities: 130 }
+			],
+			dimensions: ['timestamp', 'Equities', 'Commodities']
+		})
 	})
 
 	it('preloads the overview time-series dataset when the active view is timeSeries', async () => {
@@ -497,7 +503,7 @@ describe('perps overview queries', () => {
 		})
 	})
 
-	it('builds the venue page model with links and aggregated protocol fees', async () => {
+	it('builds the venue page model with links, aggregated protocol fees, and a preloaded default time-series chart', async () => {
 		const result = await getRWAPerpsVenuePage({ venue: 'xyz' })
 
 		expect(result).toMatchObject({
@@ -517,7 +523,13 @@ describe('perps overview queries', () => {
 		})
 		expect(result?.totals.openInterestChange24h).toBe(8.333333333333332)
 		expect(result?.totals.volume24hChange24h).toBe(200)
-		expect(result?.initialChartDataset).toEqual({ source: [], dimensions: ['timestamp'] })
+		expect(result?.initialChartDataset).toEqual({
+			source: [
+				{ timestamp: 1774483200000, Equities: 120 },
+				{ timestamp: 1774569600000, Equities: 130 }
+			],
+			dimensions: ['timestamp', 'Equities']
+		})
 	})
 
 	it('resolves venue slugs back to the canonical venue name', async () => {
@@ -584,7 +596,7 @@ describe('perps overview queries', () => {
 		await expect(getRWAPerpsVenuePage({ venue: 'missing' })).resolves.toBeNull()
 	})
 
-	it('builds the asset-group page model and overview rows', async () => {
+	it('builds the asset-group page model, overview rows, and a preloaded default time-series chart', async () => {
 		const result = await getRWAPerpsAssetGroupPage({ assetGroup: 'equities' })
 
 		expect(result).toMatchObject({
@@ -603,6 +615,13 @@ describe('perps overview queries', () => {
 			]
 		})
 		expect(result?.totals.openInterestChange24h).toBe(8.333333333333332)
+		expect(result?.initialChartDataset).toEqual({
+			source: [
+				{ timestamp: 1774483200000, Meta: 120 },
+				{ timestamp: 1774569600000, NVIDIA: 130 }
+			],
+			dimensions: ['timestamp', 'NVIDIA', 'Meta']
+		})
 	})
 })
 

--- a/src/containers/RWA/Perps/queries.ts
+++ b/src/containers/RWA/Perps/queries.ts
@@ -23,7 +23,7 @@ import type {
 } from './api.types'
 import { getRWAPerpsBreakdownChartSnapshotTotals, toRWAPerpsBreakdownChartDataset } from './breakdownDataset'
 import { getRWAPerpsOverviewSnapshotBreakdownLabel, getRWAPerpsVenueSnapshotBreakdownLabel } from './breakdownLabels'
-import { DEFAULT_CHART_VIEW, getDefaultRWAPerpsChartBreakdown, getDefaultRWAPerpsChartView } from './chartState'
+import { getDefaultRWAPerpsChartBreakdown, getDefaultRWAPerpsChartView } from './chartState'
 import type {
 	IRWAPerpsAssetGroupBreakdownRequest,
 	IRWAPerpsAssetGroupPageData,
@@ -442,7 +442,7 @@ export async function getRWAPerpsOverview({
 
 export async function getRWAPerpsVenuePage({
 	venue,
-	activeView = DEFAULT_CHART_VIEW
+	activeView = getDefaultRWAPerpsChartView('venue')
 }: {
 	venue: string
 	activeView?: RWAPerpsChartView
@@ -529,7 +529,7 @@ export async function getRWAPerpsVenuesOverview(): Promise<IRWAPerpsVenuesOvervi
 
 export async function getRWAPerpsAssetGroupPage({
 	assetGroup,
-	activeView = DEFAULT_CHART_VIEW
+	activeView = getDefaultRWAPerpsChartView('assetGroup')
 }: {
 	assetGroup: string
 	activeView?: RWAPerpsChartView

--- a/src/containers/RWA/Perps/queries.ts
+++ b/src/containers/RWA/Perps/queries.ts
@@ -23,7 +23,7 @@ import type {
 } from './api.types'
 import { getRWAPerpsBreakdownChartSnapshotTotals, toRWAPerpsBreakdownChartDataset } from './breakdownDataset'
 import { getRWAPerpsOverviewSnapshotBreakdownLabel, getRWAPerpsVenueSnapshotBreakdownLabel } from './breakdownLabels'
-import { DEFAULT_CHART_VIEW, getDefaultRWAPerpsChartBreakdown } from './chartState'
+import { DEFAULT_CHART_VIEW, getDefaultRWAPerpsChartBreakdown, getDefaultRWAPerpsChartView } from './chartState'
 import type {
 	IRWAPerpsAssetGroupBreakdownRequest,
 	IRWAPerpsAssetGroupPageData,
@@ -397,7 +397,7 @@ async function getInitialTimeSeriesDataset({
 }
 
 export async function getRWAPerpsOverview({
-	activeView = DEFAULT_CHART_VIEW
+	activeView = getDefaultRWAPerpsChartView('overview')
 }: {
 	activeView?: RWAPerpsChartView
 } = {}): Promise<IRWAPerpsOverviewPageData> {

--- a/src/containers/RWA/api.types.ts
+++ b/src/containers/RWA/api.types.ts
@@ -107,8 +107,61 @@ export interface IRWAProject extends Omit<IFetchedRWAProject, 'onChainMcap' | 'a
 	} | null
 }
 
+export type RWAOverviewMetric = {
+	total: number
+	breakdown: Array<[string, number]>
+} | null
+
+export type RWAOverviewAssetBase = {
+	id: string
+	kind: 'spot' | 'perps'
+	detailHref: string
+	assetName: string
+	ticker: string
+	primaryChain: string | null
+	chain: string[] | null
+	price: number | null
+	openInterest: number | null
+	volume24h: number | null
+	volume30d: number | null
+	assetGroup: string | null
+	parentPlatform: string | string[] | null
+	category: string[] | null
+	assetClass: string[] | null
+	accessModel: string | null
+	type: string | null
+	rwaClassification: string | null
+	issuer: string | null
+	redeemable: boolean | null
+	attestations: boolean | null
+	cexListed: boolean | null
+	kycForMintRedeem: boolean | null
+	kycAllowlistedWhitelistedToTransferHold: boolean | null
+	transferable: boolean | null
+	selfCustody: boolean | null
+	stablecoin: boolean | null
+	governance: boolean | null
+	trueRWA: boolean
+	onChainMcap: RWAOverviewMetric
+	activeMcap: RWAOverviewMetric
+	defiActiveTvl: RWAOverviewMetric
+	defiActiveTvlByChain?: RWAOverviewMetric
+}
+
+export type RWASpotOverviewAsset = RWAOverviewAssetBase & {
+	kind: 'spot'
+	canonicalMarketId: string
+}
+
+export type RWAPerpsOverviewAsset = RWAOverviewAssetBase & {
+	kind: 'perps'
+	contract: string
+}
+
+export type RWAOverviewAsset = RWASpotOverviewAsset | RWAPerpsOverviewAsset
+
 export interface IRWAAssetsOverview {
-	assets: Array<IRWAProject>
+	assets: Array<RWAOverviewAsset>
 	types: Array<string>
 	typeOptions: Array<{ key: string; name: string; help?: string }>
 	assetClasses: Array<string>

--- a/src/containers/RWA/api.types.ts
+++ b/src/containers/RWA/api.types.ts
@@ -210,6 +210,7 @@ export interface IRWAAssetsOverview {
 		}
 	}
 	initialChartDataset: IRWAInitialChartDataset | null
+	initialOpenInterestChartDataset: IRWAInitialTimeSeriesDataset | null
 	chainSlug: string | null
 	categorySlug: string | null
 	platformSlug: string | null
@@ -217,6 +218,10 @@ export interface IRWAAssetsOverview {
 }
 
 export type IRWAInitialChartDatasetRow = { timestamp: number } & Record<string, number>
+export type IRWAInitialTimeSeriesDataset = {
+	source: IRWAInitialChartDatasetRow[]
+	dimensions: string[]
+}
 export type RWAChartMetricKey = 'onChainMcap' | 'activeMcap' | 'defiActiveTvl'
 export type IRWAChartMetricRows = Array<{ timestamp: number } & Record<string, number>>
 export type RWAAssetChartTarget =
@@ -226,10 +231,7 @@ export type RWAAssetChartTarget =
 	| { kind: 'platform'; slug: string }
 	| { kind: 'assetGroup'; slug: string }
 
-export type IRWAInitialChartDataset = Record<
-	RWAChartMetricKey,
-	{ source: IRWAInitialChartDatasetRow[]; dimensions: string[] }
->
+export type IRWAInitialChartDataset = Record<RWAChartMetricKey, IRWAInitialTimeSeriesDataset>
 
 export interface IRWAChartDataByAsset {
 	onChainMcap: IRWAChartMetricRows

--- a/src/containers/RWA/chartAggregation.test.ts
+++ b/src/containers/RWA/chartAggregation.test.ts
@@ -259,6 +259,24 @@ describe('buildRwaOpenInterestDataset', () => {
 			dimensions: ['timestamp', 'RWA Perps OI']
 		})
 	})
+
+	it('preserves all-zero RWA Perps OI series when the source contains real zero values', () => {
+		expect(
+			buildRwaOpenInterestDataset([createPerpsAsset({ contract: 'xyz:alpha' })], {
+				source: [
+					{ timestamp: 1, 'xyz:alpha': 0 },
+					{ timestamp: 2, 'xyz:alpha': 0 }
+				],
+				dimensions: ['timestamp', 'xyz:alpha']
+			})
+		).toEqual({
+			source: [
+				{ timestamp: 1, 'RWA Perps OI': 0 },
+				{ timestamp: 2, 'RWA Perps OI': 0 }
+			],
+			dimensions: ['timestamp', 'RWA Perps OI']
+		})
+	})
 })
 
 describe('mergeRwaChartDatasets', () => {

--- a/src/containers/RWA/chartAggregation.test.ts
+++ b/src/containers/RWA/chartAggregation.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import type { IRWAAssetsOverview } from './api.types'
-import { aggregateRwaMetricData, appendRwaChartDatasetTotal, selectRwaChartDatasetSeries } from './chartAggregation'
+import {
+	aggregateRwaMetricData,
+	appendRwaChartDatasetTotal,
+	buildRwaOpenInterestDataset,
+	mergeRwaChartDatasets,
+	renameRwaChartDatasetTotal,
+	selectRwaChartDatasetSeries
+} from './chartAggregation'
 
 function createSpotAsset(
 	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }>>
@@ -24,6 +31,47 @@ function createSpotAsset(
 		assetClass: null,
 		accessModel: null,
 		type: null,
+		rwaClassification: null,
+		issuer: null,
+		redeemable: null,
+		attestations: null,
+		cexListed: null,
+		kycForMintRedeem: null,
+		kycAllowlistedWhitelistedToTransferHold: null,
+		transferable: null,
+		selfCustody: null,
+		stablecoin: null,
+		governance: null,
+		trueRWA: false,
+		onChainMcap: null,
+		activeMcap: null,
+		defiActiveTvl: null,
+		...overrides
+	}
+}
+
+function createPerpsAsset(
+	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'perps' }>>
+): Extract<IRWAAssetsOverview['assets'][number], { kind: 'perps' }> {
+	return {
+		id: 'perps-1',
+		kind: 'perps',
+		detailHref: '/rwa/perps/contract/xyz%3Aalpha',
+		contract: 'xyz:alpha',
+		ticker: 'xyz:alpha',
+		assetName: 'Alpha Perp',
+		primaryChain: null,
+		chain: null,
+		price: 1,
+		openInterest: 1,
+		volume24h: 2,
+		volume30d: 3,
+		assetGroup: null,
+		parentPlatform: null,
+		category: null,
+		assetClass: null,
+		accessModel: null,
+		type: 'Perp',
 		rwaClassification: null,
 		issuer: null,
 		redeemable: null,
@@ -160,6 +208,70 @@ describe('selectRwaChartDatasetSeries', () => {
 		).toEqual({
 			source: [{ timestamp: 1, Treasuries: 100, Credit: 40, Total: 140 }],
 			dimensions: ['timestamp', 'Total']
+		})
+	})
+})
+
+describe('renameRwaChartDatasetTotal', () => {
+	it('renames the Total series to the selected metric label', () => {
+		expect(
+			renameRwaChartDatasetTotal(
+				{
+					source: [{ timestamp: 1, Total: 140, Treasuries: 100 }],
+					dimensions: ['timestamp', 'Total', 'Treasuries']
+				},
+				'activeMcap'
+			)
+		).toEqual({
+			source: [{ timestamp: 1, 'Total Active Mcap': 140, Treasuries: 100 }],
+			dimensions: ['timestamp', 'Total Active Mcap', 'Treasuries']
+		})
+	})
+})
+
+describe('buildRwaOpenInterestDataset', () => {
+	it('collapses filtered perps contracts into a single RWA Perps OI line', () => {
+		expect(
+			buildRwaOpenInterestDataset(
+				[
+					createSpotAsset({ canonicalMarketId: 'ondo/usdy' }),
+					createPerpsAsset({ contract: 'xyz:alpha' }),
+					createPerpsAsset({ id: 'perps-2', contract: 'xyz:beta' })
+				],
+				{
+					source: [
+						{ timestamp: 1, 'xyz:alpha': 10, 'xyz:beta': 15, 'xyz:gamma': 100 },
+						{ timestamp: 2, 'xyz:alpha': 12, 'xyz:beta': 18, 'xyz:gamma': 120 }
+					],
+					dimensions: ['timestamp', 'xyz:gamma', 'xyz:beta', 'xyz:alpha']
+				}
+			)
+		).toEqual({
+			source: [
+				{ timestamp: 1, 'RWA Perps OI': 25 },
+				{ timestamp: 2, 'RWA Perps OI': 30 }
+			],
+			dimensions: ['timestamp', 'RWA Perps OI']
+		})
+	})
+})
+
+describe('mergeRwaChartDatasets', () => {
+	it('merges a spot chart dataset with the RWA Perps OI overlay line', () => {
+		expect(
+			mergeRwaChartDatasets(
+				{
+					source: [{ timestamp: 1, 'Total Active Mcap': 100, Treasuries: 100 }],
+					dimensions: ['timestamp', 'Total Active Mcap', 'Treasuries']
+				},
+				{
+					source: [{ timestamp: 1, 'RWA Perps OI': 25 }],
+					dimensions: ['timestamp', 'RWA Perps OI']
+				}
+			)
+		).toEqual({
+			source: [{ timestamp: 1, 'Total Active Mcap': 100, Treasuries: 100, 'RWA Perps OI': 25 }],
+			dimensions: ['timestamp', 'Total Active Mcap', 'Treasuries', 'RWA Perps OI']
 		})
 	})
 })

--- a/src/containers/RWA/chartAggregation.test.ts
+++ b/src/containers/RWA/chartAggregation.test.ts
@@ -2,40 +2,62 @@ import { describe, expect, it } from 'vitest'
 import type { IRWAAssetsOverview } from './api.types'
 import { aggregateRwaMetricData, appendRwaChartDatasetTotal, selectRwaChartDatasetSeries } from './chartAggregation'
 
-const assets: IRWAAssetsOverview['assets'] = [
-	{
+function createSpotAsset(
+	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }>>
+): Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }> {
+	return {
 		id: '1',
+		kind: 'spot',
+		detailHref: '/rwa/asset/ondo%2Fusdy',
 		canonicalMarketId: 'ondo/usdy',
 		ticker: 'AAA',
 		assetName: 'Alpha',
-		parentPlatform: 'Centrifuge',
+		primaryChain: null,
+		chain: null,
+		price: null,
+		openInterest: null,
+		volume24h: null,
+		volume30d: null,
+		assetGroup: null,
+		parentPlatform: null,
+		category: null,
+		assetClass: null,
+		accessModel: null,
+		type: null,
+		rwaClassification: null,
+		issuer: null,
+		redeemable: null,
+		attestations: null,
+		cexListed: null,
+		kycForMintRedeem: null,
+		kycAllowlistedWhitelistedToTransferHold: null,
+		transferable: null,
+		selfCustody: null,
+		stablecoin: null,
+		governance: null,
 		trueRWA: false,
 		onChainMcap: null,
 		activeMcap: null,
-		defiActiveTvl: null
-	},
-	{
+		defiActiveTvl: null,
+		...overrides
+	}
+}
+
+const assets: IRWAAssetsOverview['assets'] = [
+	createSpotAsset({ id: '1', canonicalMarketId: 'ondo/usdy', parentPlatform: 'Centrifuge' }),
+	createSpotAsset({
 		id: '2',
 		canonicalMarketId: 'superstate/ustb',
 		ticker: 'BBB',
 		assetName: 'Beta',
-		parentPlatform: ['Centrifuge', 'Maple'],
-		trueRWA: false,
-		onChainMcap: null,
-		activeMcap: null,
-		defiActiveTvl: null
-	},
-	{
+		parentPlatform: ['Centrifuge', 'Maple']
+	}),
+	createSpotAsset({
 		id: '3',
 		canonicalMarketId: 'blackrock/buidl',
 		ticker: 'CCC',
-		assetName: 'Gamma',
-		parentPlatform: null,
-		trueRWA: false,
-		onChainMcap: null,
-		activeMcap: null,
-		defiActiveTvl: null
-	}
+		assetName: 'Gamma'
+	})
 ]
 
 describe('aggregateRwaMetricData', () => {
@@ -81,30 +103,19 @@ describe('aggregateRwaMetricData', () => {
 		expect(
 			aggregateRwaMetricData(
 				[
-					{
+					createSpotAsset({
 						id: '1',
 						canonicalMarketId: 'circle/usdc',
-						ticker: 'AAA',
-						assetName: 'Alpha',
 						assetGroup: 'Stablecoins',
-						parentPlatform: 'Centrifuge',
-						trueRWA: false,
-						onChainMcap: null,
-						activeMcap: null,
-						defiActiveTvl: null
-					},
-					{
+						parentPlatform: 'Centrifuge'
+					}),
+					createSpotAsset({
 						id: '2',
 						canonicalMarketId: 'unknown/asset',
 						ticker: 'BBB',
 						assetName: 'Beta',
-						assetGroup: null,
-						parentPlatform: 'Maple',
-						trueRWA: false,
-						onChainMcap: null,
-						activeMcap: null,
-						defiActiveTvl: null
-					}
+						parentPlatform: 'Maple'
+					})
 				],
 				[{ timestamp: 1, 'circle/usdc': 100, 'unknown/asset': 50 }],
 				'assetGroup'

--- a/src/containers/RWA/chartAggregation.test.ts
+++ b/src/containers/RWA/chartAggregation.test.ts
@@ -10,7 +10,7 @@ import {
 } from './chartAggregation'
 
 function createSpotAsset(
-	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }>>
+	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }>> = {}
 ): Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }> {
 	return {
 		id: '1',
@@ -51,7 +51,7 @@ function createSpotAsset(
 }
 
 function createPerpsAsset(
-	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'perps' }>>
+	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'perps' }>> = {}
 ): Extract<IRWAAssetsOverview['assets'][number], { kind: 'perps' }> {
 	return {
 		id: 'perps-1',
@@ -163,6 +163,11 @@ describe('aggregateRwaMetricData', () => {
 						ticker: 'BBB',
 						assetName: 'Beta',
 						parentPlatform: 'Maple'
+					}),
+					createPerpsAsset({
+						id: 'perps-2',
+						contract: 'unknown/asset',
+						assetGroup: 'Stablecoins'
 					})
 				],
 				[{ timestamp: 1, 'circle/usdc': 100, 'unknown/asset': 50 }],

--- a/src/containers/RWA/chartAggregation.ts
+++ b/src/containers/RWA/chartAggregation.ts
@@ -4,8 +4,10 @@ import { isTypeIncludedByDefault, type RWAOverviewMode } from './constants'
 import { computeWeightedGroups, getPrimaryRwaCategory, getRwaPlatforms } from './grouping'
 
 export type RWAChartMetric = RWAChartMetricKey
+export const RWA_OPEN_INTEREST_SERIES_LABEL = 'RWA Perps OI'
 
 export type RWAChartRow = { timestamp: number } & Record<string, number>
+type RWAOpenInterestSourceRow = Record<string, number | string>
 
 export type RWAChartDataset = { source: RWAChartRow[]; dimensions: string[] }
 
@@ -43,6 +45,41 @@ export function appendRwaChartDatasetTotal(dataset: RWAChartDataset): RWAChartDa
 	}
 }
 
+export function getRwaChartTotalLabel(metric: RWAChartMetricKey): string {
+	switch (metric) {
+		case 'activeMcap':
+			return 'Total Active Mcap'
+		case 'onChainMcap':
+			return 'Total Onchain Mcap'
+		case 'defiActiveTvl':
+			return 'Total DeFi Active TVL'
+		default:
+			return assertNever(metric)
+	}
+}
+
+export function renameRwaChartDatasetTotal(dataset: RWAChartDataset, metric: RWAChartMetricKey): RWAChartDataset {
+	if (!dataset.dimensions.includes('Total') && !dataset.source.some((row) => row.Total != null)) {
+		return dataset
+	}
+
+	const totalLabel = getRwaChartTotalLabel(metric)
+
+	return {
+		source: dataset.source.map((row) => {
+			if (row.Total == null) return row
+
+			const { Total, ...rest } = row
+
+			return {
+				...rest,
+				[totalLabel]: Total
+			}
+		}),
+		dimensions: dataset.dimensions.map((dimension) => (dimension === 'Total' ? totalLabel : dimension))
+	}
+}
+
 export function selectRwaChartDatasetSeries(dataset: RWAChartDataset, seriesDimensions: string[]): RWAChartDataset {
 	const allowedSeries = new Set(seriesDimensions)
 	const dimensions = dataset.dimensions.filter((dimension) => dimension === 'timestamp' || allowedSeries.has(dimension))
@@ -59,6 +96,76 @@ export function selectRwaChartDatasetSeries(dataset: RWAChartDataset, seriesDime
 	return {
 		source: dataset.source,
 		dimensions
+	}
+}
+
+export function buildRwaOpenInterestDataset(
+	assets: IRWAAssetsOverview['assets'],
+	dataset: { source: RWAOpenInterestSourceRow[]; dimensions: string[] }
+): RWAChartDataset {
+	const contracts = new Set(
+		assets
+			.filter((asset) => asset.kind === 'perps')
+			.map((asset) => asset.contract)
+			.filter(Boolean)
+	)
+
+	if (contracts.size === 0 || dataset.source.length === 0) return emptyChartDataset()
+
+	const source = dataset.source.map((row) => {
+		let totalOpenInterest = 0
+
+		for (const contract of contracts) {
+			const value = row[contract]
+			const numericValue = typeof value === 'number' ? value : Number(value)
+			if (Number.isFinite(numericValue)) {
+				totalOpenInterest += numericValue
+			}
+		}
+
+		return {
+			timestamp: Number(row.timestamp),
+			[RWA_OPEN_INTEREST_SERIES_LABEL]: totalOpenInterest
+		}
+	})
+
+	if (!source.some((row) => row[RWA_OPEN_INTEREST_SERIES_LABEL] > 0)) {
+		return emptyChartDataset()
+	}
+
+	return {
+		source,
+		dimensions: ['timestamp', RWA_OPEN_INTEREST_SERIES_LABEL]
+	}
+}
+
+export function mergeRwaChartDatasets(primary: RWAChartDataset, overlay: RWAChartDataset): RWAChartDataset {
+	if (overlay.dimensions.length <= 1 || overlay.source.length === 0) return primary
+	if (primary.dimensions.length <= 1 || primary.source.length === 0) return overlay
+
+	const mergedRows = new Map<number, RWAChartRow>()
+
+	for (const row of primary.source) {
+		mergedRows.set(row.timestamp, { ...row })
+	}
+
+	for (const row of overlay.source) {
+		const existingRow = mergedRows.get(row.timestamp)
+		if (existingRow) {
+			Object.assign(existingRow, row)
+			continue
+		}
+
+		mergedRows.set(row.timestamp, { ...row })
+	}
+
+	return {
+		source: [...mergedRows.values()].sort((a, b) => a.timestamp - b.timestamp),
+		dimensions: [
+			'timestamp',
+			...primary.dimensions.filter((dimension) => dimension !== 'timestamp'),
+			...overlay.dimensions.filter((dimension) => dimension !== 'timestamp' && !primary.dimensions.includes(dimension))
+		]
 	}
 }
 

--- a/src/containers/RWA/chartAggregation.ts
+++ b/src/containers/RWA/chartAggregation.ts
@@ -112,6 +112,7 @@ export function buildRwaOpenInterestDataset(
 
 	if (contracts.size === 0 || dataset.source.length === 0) return emptyChartDataset()
 
+	let hasOpenInterestData = false
 	const source = dataset.source.map((row) => {
 		let totalOpenInterest = 0
 
@@ -119,6 +120,7 @@ export function buildRwaOpenInterestDataset(
 			const value = row[contract]
 			const numericValue = typeof value === 'number' ? value : Number(value)
 			if (Number.isFinite(numericValue)) {
+				hasOpenInterestData = true
 				totalOpenInterest += numericValue
 			}
 		}
@@ -129,7 +131,7 @@ export function buildRwaOpenInterestDataset(
 		}
 	})
 
-	if (!source.some((row) => row[RWA_OPEN_INTEREST_SERIES_LABEL] > 0)) {
+	if (!hasOpenInterestData) {
 		return emptyChartDataset()
 	}
 

--- a/src/containers/RWA/chartAggregation.ts
+++ b/src/containers/RWA/chartAggregation.ts
@@ -179,6 +179,7 @@ function buildAssetGroupMapping(
 		if (asset.kind !== 'spot') continue
 
 		const assetKey = asset.canonicalMarketId
+		if (!assetKey) continue
 
 		let weightedGroups: ReturnType<typeof computeWeightedGroups>
 		switch (mode) {

--- a/src/containers/RWA/chartAggregation.ts
+++ b/src/containers/RWA/chartAggregation.ts
@@ -69,8 +69,9 @@ function buildAssetGroupMapping(
 	const assetToGroups = new Map<string, Map<string, number>>()
 
 	for (const asset of assets) {
+		if (asset.kind !== 'spot') continue
+
 		const assetKey = asset.canonicalMarketId
-		if (!assetKey) continue
 
 		let weightedGroups: ReturnType<typeof computeWeightedGroups>
 		switch (mode) {

--- a/src/containers/RWA/hooks.test.tsx
+++ b/src/containers/RWA/hooks.test.tsx
@@ -5,6 +5,7 @@ import type { IRWAAssetsOverview } from './api.types'
 import type { RWAChartAggregationMode } from './chartAggregation'
 import {
 	getRwaAssetChartQueryKey,
+	getRwaOpenInterestChartQueryKey,
 	hasActiveChartFilters,
 	resolveRWAOverviewInclusionFlag,
 	useRWAAssetCategoryPieChartData,
@@ -123,25 +124,33 @@ function DatasetProbe({
 	mode,
 	chartAssets = assets,
 	initialDataset = { source: [], dimensions: ['timestamp'] },
+	initialOpenInterestDataset = null,
+	selectedMetric = 'onChainMcap',
 	includeStablecoins = false,
 	includeGovernance = false,
+	includeRwaPerps = false,
 	useInitialDataset = false
 }: {
 	mode: RWAChartAggregationMode
 	chartAssets?: IRWAAssetsOverview['assets']
 	initialDataset?: { source: Array<{ timestamp: number }>; dimensions: string[] }
+	initialOpenInterestDataset?: { source: Array<{ timestamp: number }>; dimensions: string[] } | null
+	selectedMetric?: 'onChainMcap' | 'activeMcap' | 'defiActiveTvl'
 	includeStablecoins?: boolean
 	includeGovernance?: boolean
+	includeRwaPerps?: boolean
 	useInitialDataset?: boolean
 }) {
 	const { chartDataset } = useRwaChartDataset({
-		selectedMetric: 'onChainMcap',
+		selectedMetric,
 		initialDataset,
+		initialOpenInterestDataset,
 		filteredAssets: chartAssets,
 		mode,
 		target: { kind: 'all' },
 		includeStablecoins,
 		includeGovernance,
+		includeRwaPerps,
 		useInitialDataset
 	})
 
@@ -237,10 +246,23 @@ describe('useRwaChartDataset', () => {
 	beforeEach(() => {
 		useQueryMock.mockReset()
 		fetchJsonMock.mockReset()
-		useQueryMock.mockReturnValue({
-			data: [{ timestamp: 1, 'ondo/usdy': 100, 'superstate/ustb': 80 }],
-			isLoading: false,
-			error: null
+		useQueryMock.mockImplementation((options: { queryKey: unknown[] }) => {
+			if (options.queryKey[0] === 'rwa-perps-open-interest-chart') {
+				return {
+					data: {
+						source: [{ timestamp: 1, 'xyz:alpha': 20, 'xyz:beta': 10 }],
+						dimensions: ['timestamp', 'xyz:alpha', 'xyz:beta']
+					},
+					isLoading: false,
+					error: null
+				}
+			}
+
+			return {
+				data: [{ timestamp: 1, 'ondo/usdy': 100, 'superstate/ustb': 80 }],
+				isLoading: false,
+				error: null
+			}
 		})
 		fetchJsonMock.mockResolvedValue([{ timestamp: 1, 'ondo/usdy': 100, 'superstate/ustb': 80 }])
 	})
@@ -250,15 +272,16 @@ describe('useRwaChartDataset', () => {
 		const platformMarkup = renderToStaticMarkup(React.createElement(DatasetProbe, { mode: 'platform' }))
 		const totalMarkup = renderToStaticMarkup(React.createElement(DatasetProbe, { mode: 'total' }))
 
-		expect(categoryMarkup).toContain('timestamp|Total|Treasuries|Private Credit')
-		expect(platformMarkup).toContain('timestamp|Total|Centrifuge|Maple')
-		expect(totalMarkup).toContain('timestamp|Total')
-		expect(useQueryMock).toHaveBeenCalledTimes(3)
+		expect(categoryMarkup).toContain('timestamp|Total Onchain Mcap|Treasuries|Private Credit')
+		expect(platformMarkup).toContain('timestamp|Total Onchain Mcap|Centrifuge|Maple')
+		expect(totalMarkup).toContain('timestamp|Total Onchain Mcap')
+		expect(useQueryMock).toHaveBeenCalledTimes(6)
 		expect(useQueryMock.mock.calls[0][0]).toMatchObject({
 			queryKey: getRwaAssetChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false)
 		})
 		expect(useQueryMock.mock.calls[1][0]).toMatchObject({
-			queryKey: getRwaAssetChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false)
+			queryKey: getRwaOpenInterestChartQueryKey(),
+			enabled: false
 		})
 		expect(useQueryMock.mock.calls[2][0]).toMatchObject({
 			queryKey: getRwaAssetChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false)
@@ -273,6 +296,10 @@ describe('useRwaChartDataset', () => {
 			queryKey: getRwaAssetChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false)
 		})
 		expect(useQueryMock.mock.calls[1][0]).toMatchObject({
+			queryKey: getRwaOpenInterestChartQueryKey(),
+			enabled: false
+		})
+		expect(useQueryMock.mock.calls[2][0]).toMatchObject({
 			queryKey: getRwaAssetChartQueryKey({ kind: 'all' }, 'onChainMcap', true, false)
 		})
 	})
@@ -295,14 +322,16 @@ describe('useRwaChartDataset', () => {
 			React.createElement(DatasetProbe, { mode: 'category', chartAssets: multiCategoryAssets })
 		)
 
-		expect(markup).toContain('timestamp|Total|Treasuries')
+		expect(markup).toContain('timestamp|Total Onchain Mcap|Treasuries')
 		expect(markup).not.toContain('Private Credit')
 	})
 
 	it('passes the resolved inclusion flags to the asset-breakdown fetcher', async () => {
 		let capturedOptions: { queryFn: () => Promise<unknown> } | undefined
-		useQueryMock.mockImplementation((options: { queryFn: () => Promise<unknown> }) => {
-			capturedOptions = options
+		useQueryMock.mockImplementation((options: { queryKey: unknown[]; queryFn: () => Promise<unknown> }) => {
+			if (options.queryKey[0] === 'rwa-asset-chart') {
+				capturedOptions = options
+			}
 			return {
 				data: undefined,
 				isLoading: false,
@@ -343,10 +372,52 @@ describe('useRwaChartDataset', () => {
 			})
 		)
 
-		expect(markup).toContain('timestamp|Total|Prerendered')
-		expect(useQueryMock).toHaveBeenCalledTimes(1)
+		expect(markup).toContain('timestamp|Total Onchain Mcap|Prerendered')
+		expect(useQueryMock).toHaveBeenCalledTimes(2)
 		expect(useQueryMock.mock.calls[0][0]).toMatchObject({
 			queryKey: getRwaAssetChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false),
+			enabled: false
+		})
+		expect(useQueryMock.mock.calls[1][0]).toMatchObject({
+			queryKey: getRwaOpenInterestChartQueryKey(),
+			enabled: false
+		})
+	})
+
+	it('uses the prerendered RWA Perps OI dataset without runtime fetching in the default state', () => {
+		useQueryMock.mockImplementation((options: { queryKey: unknown[] }) => ({
+			data: undefined,
+			isLoading: false,
+			error: null,
+			queryKey: options.queryKey
+		}))
+
+		const markup = renderToStaticMarkup(
+			React.createElement(DatasetProbe, {
+				mode: 'category',
+				chartAssets: [createSpotAsset(), createPerpsAsset()],
+				initialDataset: {
+					source: [{ timestamp: 1, Treasuries: 100, Total: 100 }],
+					dimensions: ['timestamp', 'Treasuries']
+				},
+				initialOpenInterestDataset: {
+					source: [{ timestamp: 1, 'RWA Perps OI': 25 }],
+					dimensions: ['timestamp', 'RWA Perps OI']
+				},
+				selectedMetric: 'activeMcap',
+				includeRwaPerps: true,
+				useInitialDataset: true
+			})
+		)
+
+		expect(markup).toContain('timestamp|Total Active Mcap|Treasuries|RWA Perps OI')
+		expect(useQueryMock).toHaveBeenCalledTimes(2)
+		expect(useQueryMock.mock.calls[0][0]).toMatchObject({
+			queryKey: getRwaAssetChartQueryKey({ kind: 'all' }, 'activeMcap', false, false),
+			enabled: false
+		})
+		expect(useQueryMock.mock.calls[1][0]).toMatchObject({
+			queryKey: getRwaOpenInterestChartQueryKey(),
 			enabled: false
 		})
 	})
@@ -369,11 +440,43 @@ describe('useRwaChartDataset', () => {
 			})
 		)
 
-		expect(markup).toContain('timestamp|Total')
-		expect(useQueryMock).toHaveBeenCalledTimes(1)
+		expect(markup).toContain('timestamp|Total Onchain Mcap')
+		expect(useQueryMock).toHaveBeenCalledTimes(2)
 		expect(useQueryMock.mock.calls[0][0]).toMatchObject({
 			queryKey: getRwaAssetChartQueryKey({ kind: 'all' }, 'onChainMcap', false, false),
 			enabled: false
+		})
+		expect(useQueryMock.mock.calls[1][0]).toMatchObject({
+			queryKey: getRwaOpenInterestChartQueryKey(),
+			enabled: false
+		})
+	})
+
+	it('overlays filtered RWA Perps OI on the selected chart metric', () => {
+		const markup = renderToStaticMarkup(
+			React.createElement(DatasetProbe, {
+				mode: 'category',
+				chartAssets: [
+					createSpotAsset({
+						onChainMcap: { total: 100, breakdown: [] },
+						category: ['Treasuries'],
+						parentPlatform: 'Centrifuge'
+					}),
+					createPerpsAsset({ contract: 'xyz:alpha', category: ['Treasuries'], parentPlatform: 'Centrifuge' })
+				],
+				selectedMetric: 'defiActiveTvl',
+				includeRwaPerps: true
+			})
+		)
+
+		expect(markup).toContain('timestamp|Total DeFi Active TVL|Treasuries|RWA Perps OI')
+		expect(useQueryMock.mock.calls[0][0]).toMatchObject({
+			queryKey: getRwaAssetChartQueryKey({ kind: 'all' }, 'defiActiveTvl', false, false),
+			enabled: true
+		})
+		expect(useQueryMock.mock.calls[1][0]).toMatchObject({
+			queryKey: getRwaOpenInterestChartQueryKey(),
+			enabled: true
 		})
 	})
 })
@@ -395,6 +498,7 @@ describe('hasActiveChartFilters', () => {
 		expect(hasActiveChartFilters({ includeStablecoins: 'true' }, 'category', 'rwa-yield-wrapper')).toBe(false)
 		expect(hasActiveChartFilters({ includeGovernance: 'true' }, 'category', 'rwa-yield-wrapper')).toBe(false)
 		expect(hasActiveChartFilters({ includeStablecoins: 'false' }, 'chain', null)).toBe(false)
+		expect(hasActiveChartFilters({ includeRwaPerps: 'false' }, 'chain', null)).toBe(false)
 	})
 
 	it('treats inclusion params as active when they override the current defaults', () => {

--- a/src/containers/RWA/hooks.test.tsx
+++ b/src/containers/RWA/hooks.test.tsx
@@ -8,6 +8,7 @@ import {
 	hasActiveChartFilters,
 	resolveRWAOverviewInclusionFlag,
 	useRWAAssetCategoryPieChartData,
+	useFilteredRwaAssets,
 	useRwaAssetGroupPieChartData,
 	useRwaChartDataset
 } from './hooks'
@@ -23,31 +24,99 @@ vi.mock('~/utils/async', () => ({
 	fetchJson: (...args: unknown[]) => fetchJsonMock(...args)
 }))
 
-const assets: IRWAAssetsOverview['assets'] = [
-	{
+function createSpotAsset(
+	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }>>
+): Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }> {
+	return {
 		id: '1',
+		kind: 'spot',
+		detailHref: '/rwa/asset/ondo%2Fusdy',
 		canonicalMarketId: 'ondo/usdy',
 		ticker: 'AAA',
 		assetName: 'Alpha',
-		category: ['Treasuries'],
-		parentPlatform: 'Centrifuge',
+		primaryChain: null,
+		chain: null,
+		price: null,
+		openInterest: null,
+		volume24h: null,
+		volume30d: null,
+		assetGroup: null,
+		parentPlatform: null,
+		category: null,
+		assetClass: null,
+		accessModel: null,
+		type: null,
+		rwaClassification: null,
+		issuer: null,
+		redeemable: null,
+		attestations: null,
+		cexListed: null,
+		kycForMintRedeem: null,
+		kycAllowlistedWhitelistedToTransferHold: null,
+		transferable: null,
+		selfCustody: null,
+		stablecoin: null,
+		governance: null,
 		trueRWA: false,
 		onChainMcap: null,
 		activeMcap: null,
-		defiActiveTvl: null
-	},
-	{
+		defiActiveTvl: null,
+		...overrides
+	}
+}
+
+function createPerpsAsset(
+	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'perps' }>>
+): Extract<IRWAAssetsOverview['assets'][number], { kind: 'perps' }> {
+	return {
+		id: 'perps-1',
+		kind: 'perps',
+		detailHref: '/rwa/perps/contract/xyz%3Aalpha',
+		contract: 'xyz:alpha',
+		ticker: 'xyz:alpha',
+		assetName: 'Alpha Perp',
+		primaryChain: null,
+		chain: null,
+		price: 1,
+		openInterest: 1,
+		volume24h: 2,
+		volume30d: 3,
+		assetGroup: null,
+		parentPlatform: null,
+		category: null,
+		assetClass: null,
+		accessModel: null,
+		type: 'Perp',
+		rwaClassification: null,
+		issuer: null,
+		redeemable: null,
+		attestations: null,
+		cexListed: null,
+		kycForMintRedeem: null,
+		kycAllowlistedWhitelistedToTransferHold: null,
+		transferable: null,
+		selfCustody: null,
+		stablecoin: null,
+		governance: null,
+		trueRWA: false,
+		onChainMcap: null,
+		activeMcap: null,
+		defiActiveTvl: null,
+		...overrides
+	}
+}
+
+const assets: IRWAAssetsOverview['assets'] = [
+	createSpotAsset({ id: '1', category: ['Treasuries'], parentPlatform: 'Centrifuge' }),
+	createSpotAsset({
 		id: '2',
 		canonicalMarketId: 'superstate/ustb',
+		detailHref: '/rwa/asset/superstate%2Fustb',
 		ticker: 'BBB',
 		assetName: 'Beta',
 		category: ['Private Credit'],
-		parentPlatform: 'Maple',
-		trueRWA: false,
-		onChainMcap: null,
-		activeMcap: null,
-		defiActiveTvl: null
-	}
+		parentPlatform: 'Maple'
+	})
 ]
 
 function DatasetProbe({
@@ -110,6 +179,54 @@ function CategoryProbe({
 	})
 }
 
+function FilteredAssetsProbe({
+	chartAssets,
+	includeRwaPerps
+}: {
+	chartAssets: IRWAAssetsOverview['assets']
+	includeRwaPerps: boolean
+}) {
+	const result = useFilteredRwaAssets({
+		assets: chartAssets,
+		isPlatformMode: false,
+		selectedAssetNames: [],
+		selectedTypes: ['Unknown', 'Perp'],
+		selectedCategories: ['Treasuries'],
+		selectedPlatforms: ['Centrifuge'],
+		selectedAssetGroups: ['Unknown'],
+		selectedAssetClasses: [],
+		selectedRwaClassifications: [],
+		selectedAccessModels: [],
+		selectedIssuers: [],
+		selectedRedeemableStates: ['yes', 'no', 'unknown'],
+		selectedAttestationsStates: ['yes', 'no', 'unknown'],
+		selectedCexListedStates: ['yes', 'no', 'unknown'],
+		selectedKycForMintRedeemStates: ['yes', 'no', 'unknown'],
+		selectedKycAllowlistedWhitelistedToTransferHoldStates: ['yes', 'no', 'unknown'],
+		selectedTransferableStates: ['yes', 'no', 'unknown'],
+		selectedSelfCustodyStates: ['yes', 'no', 'unknown'],
+		includeStablecoins: true,
+		includeGovernance: true,
+		includeRwaPerps,
+		minDefiActiveTvlToOnChainMcapPct: null,
+		maxDefiActiveTvlToOnChainMcapPct: null,
+		minActiveMcapToOnChainMcapPct: null,
+		maxActiveMcapToOnChainMcapPct: null,
+		minDefiActiveTvlToActiveMcapPct: null,
+		maxDefiActiveTvlToActiveMcapPct: null
+	})
+
+	return React.createElement('script', {
+		type: 'application/json',
+		dangerouslySetInnerHTML: {
+			__html: JSON.stringify({
+				kinds: result.filteredAssets.map((asset) => asset.kind),
+				totalOpenInterest: result.totalOpenInterest
+			})
+		}
+	})
+}
+
 function readJsonMarkup(markup: string) {
 	const match = markup.match(/<script type="application\/json">([\s\S]*)<\/script>/)
 	expect(match?.[1]).toBeTruthy()
@@ -162,18 +279,10 @@ describe('useRwaChartDataset', () => {
 
 	it('uses the primary category when regrouping category chart rows', () => {
 		const multiCategoryAssets: IRWAAssetsOverview['assets'] = [
-			{
-				id: '1',
-				canonicalMarketId: 'ondo/usdy',
-				ticker: 'AAA',
-				assetName: 'Alpha',
+			createSpotAsset({
 				category: ['Treasuries', 'Private Credit'],
-				parentPlatform: 'Centrifuge',
-				trueRWA: false,
-				onChainMcap: null,
-				activeMcap: null,
-				defiActiveTvl: null
-			}
+				parentPlatform: 'Centrifuge'
+			})
 		]
 
 		useQueryMock.mockReturnValueOnce({
@@ -299,33 +408,49 @@ describe('hasActiveChartFilters', () => {
 	})
 })
 
+describe('useFilteredRwaAssets', () => {
+	it('filters perps rows when the RWA Perps toggle is disabled', () => {
+		const chartAssets: IRWAAssetsOverview['assets'] = [
+			createSpotAsset({ onChainMcap: { total: 100, breakdown: [] } }),
+			createPerpsAsset()
+		]
+
+		expect(
+			readJsonMarkup(
+				renderToStaticMarkup(React.createElement(FilteredAssetsProbe, { chartAssets, includeRwaPerps: true }))
+			)
+		).toEqual({ kinds: ['spot', 'perps'], totalOpenInterest: 1 })
+		expect(
+			readJsonMarkup(
+				renderToStaticMarkup(React.createElement(FilteredAssetsProbe, { chartAssets, includeRwaPerps: false }))
+			)
+		).toEqual({ kinds: ['spot'], totalOpenInterest: 0 })
+	})
+})
+
 describe('useRwaAssetGroupPieChartData', () => {
 	it('groups assets by normalized asset group and keeps Unknown', () => {
 		const chartAssets: IRWAAssetsOverview['assets'] = [
-			{
-				id: '1',
-				ticker: 'AAA',
-				assetName: 'Alpha',
+			createSpotAsset({
 				assetGroup: 'Stablecoins',
 				category: ['Treasuries'],
 				parentPlatform: 'Centrifuge',
-				trueRWA: false,
 				onChainMcap: { total: 100, breakdown: [] },
 				activeMcap: { total: 90, breakdown: [] },
 				defiActiveTvl: { total: 30, breakdown: [] }
-			},
-			{
+			}),
+			createSpotAsset({
 				id: '2',
+				canonicalMarketId: 'superstate/ustb',
+				detailHref: '/rwa/asset/superstate%2Fustb',
 				ticker: 'BBB',
 				assetName: 'Beta',
-				assetGroup: null,
 				category: ['Private Credit'],
 				parentPlatform: 'Maple',
-				trueRWA: false,
 				onChainMcap: { total: 50, breakdown: [] },
 				activeMcap: { total: 20, breakdown: [] },
 				defiActiveTvl: { total: 10, breakdown: [] }
-			}
+			})
 		]
 
 		const data = readJsonMarkup(
@@ -358,18 +483,13 @@ describe('useRwaAssetGroupPieChartData', () => {
 describe('useRWAAssetCategoryPieChartData', () => {
 	it('attributes category totals only to the primary category', () => {
 		const chartAssets: IRWAAssetsOverview['assets'] = [
-			{
-				id: '1',
-				canonicalMarketId: 'ondo/usdy',
-				ticker: 'AAA',
-				assetName: 'Alpha',
+			createSpotAsset({
 				category: ['Treasuries', 'Private Credit'],
 				parentPlatform: 'Centrifuge',
-				trueRWA: false,
 				onChainMcap: { total: 100, breakdown: [] },
 				activeMcap: { total: 90, breakdown: [] },
 				defiActiveTvl: { total: 30, breakdown: [] }
-			}
+			})
 		]
 
 		const data = readJsonMarkup(

--- a/src/containers/RWA/hooks.test.tsx
+++ b/src/containers/RWA/hooks.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { IRWAAssetsOverview, IRWAInitialChartDatasetRow } from './api.types'
+import { normalizeRwaAssetGroup } from './assetGroup'
 import type { RWAChartAggregationMode } from './chartAggregation'
 import {
 	getRwaAssetChartQueryKey,
@@ -195,14 +196,29 @@ function FilteredAssetsProbe({
 	chartAssets: IRWAAssetsOverview['assets']
 	includeRwaPerps: boolean
 }) {
+	const selectedCategories = Array.from(new Set(chartAssets.flatMap((asset) => asset.category ?? [])))
+	const selectedPlatforms = Array.from(
+		new Set(
+			chartAssets.flatMap((asset) => {
+				const platformRaw = asset.parentPlatform as unknown
+				const platformCandidates = Array.isArray(platformRaw) ? platformRaw : [platformRaw]
+
+				return platformCandidates.filter(
+					(platform): platform is string => typeof platform === 'string' && platform.length > 0
+				)
+			})
+		)
+	)
+	const selectedAssetGroups = Array.from(new Set(chartAssets.map((asset) => normalizeRwaAssetGroup(asset.assetGroup))))
+
 	const result = useFilteredRwaAssets({
 		assets: chartAssets,
 		isPlatformMode: false,
 		selectedAssetNames: [],
 		selectedTypes: ['Unknown', 'Perp'],
-		selectedCategories: ['Treasuries'],
-		selectedPlatforms: ['Centrifuge'],
-		selectedAssetGroups: ['Unknown'],
+		selectedCategories,
+		selectedPlatforms,
+		selectedAssetGroups,
 		selectedAssetClasses: [],
 		selectedRwaClassifications: [],
 		selectedAccessModels: [],

--- a/src/containers/RWA/hooks.test.tsx
+++ b/src/containers/RWA/hooks.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { IRWAAssetsOverview } from './api.types'
+import type { IRWAAssetsOverview, IRWAInitialChartDatasetRow } from './api.types'
 import type { RWAChartAggregationMode } from './chartAggregation'
 import {
 	getRwaAssetChartQueryKey,
@@ -26,7 +26,7 @@ vi.mock('~/utils/async', () => ({
 }))
 
 function createSpotAsset(
-	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }>>
+	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }>> = {}
 ): Extract<IRWAAssetsOverview['assets'][number], { kind: 'spot' }> {
 	return {
 		id: '1',
@@ -67,7 +67,7 @@ function createSpotAsset(
 }
 
 function createPerpsAsset(
-	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'perps' }>>
+	overrides: Partial<Extract<IRWAAssetsOverview['assets'][number], { kind: 'perps' }>> = {}
 ): Extract<IRWAAssetsOverview['assets'][number], { kind: 'perps' }> {
 	return {
 		id: 'perps-1',
@@ -133,8 +133,8 @@ function DatasetProbe({
 }: {
 	mode: RWAChartAggregationMode
 	chartAssets?: IRWAAssetsOverview['assets']
-	initialDataset?: { source: Array<{ timestamp: number }>; dimensions: string[] }
-	initialOpenInterestDataset?: { source: Array<{ timestamp: number }>; dimensions: string[] } | null
+	initialDataset?: { source: IRWAInitialChartDatasetRow[]; dimensions: string[] }
+	initialOpenInterestDataset?: { source: IRWAInitialChartDatasetRow[]; dimensions: string[] } | null
 	selectedMetric?: 'onChainMcap' | 'activeMcap' | 'defiActiveTvl'
 	includeStablecoins?: boolean
 	includeGovernance?: boolean

--- a/src/containers/RWA/hooks.tsx
+++ b/src/containers/RWA/hooks.tsx
@@ -157,6 +157,7 @@ export const useRWATableQueryParams = ({
 		maxDefiActiveTvlToActiveMcapPct: maxDefiActiveTvlToActiveMcapPctQ,
 		includeStablecoins: stablecoinsQ,
 		includeGovernance: governanceQ,
+		includeRwaPerps: rwaPerpsQ,
 		redeemableStates: redeemableStatesQ,
 		attestationsStates: attestationsStatesQ,
 		cexListedStates: cexListedStatesQ,
@@ -191,7 +192,8 @@ export const useRWATableQueryParams = ({
 		minDefiActiveTvlToActiveMcapPct,
 		maxDefiActiveTvlToActiveMcapPct,
 		includeStablecoins,
-		includeGovernance
+		includeGovernance,
+		includeRwaPerps
 	} = useMemo(() => {
 		// If query param is 'None', return empty array. If no param, return all (default). Otherwise parse the array.
 		const parseArrayParam = (
@@ -228,6 +230,7 @@ export const useRWATableQueryParams = ({
 
 		const includeStablecoins = resolveRWAOverviewInclusionFlag(stablecoinsQ, defaultInclusion.includeStablecoins)
 		const includeGovernance = resolveRWAOverviewInclusionFlag(governanceQ, defaultInclusion.includeGovernance)
+		const includeRwaPerps = resolveRWAOverviewInclusionFlag(rwaPerpsQ, true)
 
 		// Build selected arrays with correct "exclude" semantics:
 		// - if include param missing but exclude param exists, selection is (all - excluded), NOT "defaults - excluded"
@@ -350,7 +353,8 @@ export const useRWATableQueryParams = ({
 			minDefiActiveTvlToActiveMcapPct,
 			maxDefiActiveTvlToActiveMcapPct,
 			includeStablecoins,
-			includeGovernance
+			includeGovernance,
+			includeRwaPerps
 		}
 	}, [
 		assetNamesQ,
@@ -386,6 +390,7 @@ export const useRWATableQueryParams = ({
 		maxDefiActiveTvlToActiveMcapPctQ,
 		stablecoinsQ,
 		governanceQ,
+		rwaPerpsQ,
 		defaultInclusion.includeStablecoins,
 		defaultInclusion.includeGovernance,
 		assetNames,
@@ -432,6 +437,12 @@ export const useRWATableQueryParams = ({
 		})
 	}
 
+	const setIncludeRwaPerps = (value: boolean) => {
+		void pushShallowQuery(router, {
+			includeRwaPerps: value ? undefined : 'false'
+		})
+	}
+
 	const setRedeemableStates = (values: RWAAttributeFilterState[]) =>
 		updateAttributeFilterStatesQuery('redeemableStates', values, router)
 	const setAttestationsStates = (values: RWAAttributeFilterState[]) =>
@@ -472,6 +483,7 @@ export const useRWATableQueryParams = ({
 		maxDefiActiveTvlToActiveMcapPct,
 		includeStablecoins,
 		includeGovernance,
+		includeRwaPerps,
 		setRedeemableStates,
 		setAttestationsStates,
 		setCexListedStates,
@@ -483,7 +495,8 @@ export const useRWATableQueryParams = ({
 		setActiveMcapToOnChainMcapPctRange,
 		setDefiActiveTvlToActiveMcapPctRange,
 		setIncludeStablecoins,
-		setIncludeGovernance
+		setIncludeGovernance,
+		setIncludeRwaPerps
 	}
 }
 
@@ -529,6 +542,7 @@ export const useFilteredRwaAssets = ({
 	selectedSelfCustodyStates,
 	includeStablecoins,
 	includeGovernance,
+	includeRwaPerps,
 	minDefiActiveTvlToOnChainMcapPct,
 	maxDefiActiveTvlToOnChainMcapPct,
 	minActiveMcapToOnChainMcapPct,
@@ -556,6 +570,7 @@ export const useFilteredRwaAssets = ({
 	selectedSelfCustodyStates: RWAAttributeFilterState[]
 	includeStablecoins: boolean
 	includeGovernance: boolean
+	includeRwaPerps: boolean
 	minDefiActiveTvlToOnChainMcapPct: number | null
 	maxDefiActiveTvlToOnChainMcapPct: number | null
 	minActiveMcapToOnChainMcapPct: number | null
@@ -571,6 +586,7 @@ export const useFilteredRwaAssets = ({
 		let totalOnChainMcap = 0
 		let totalActiveMcap = 0
 		let totalOnChainDeFiActiveTvl = 0
+		let totalOpenInterest = 0
 		const totalIssuersSet = new Set<string>()
 
 		// In platform mode, allow selecting "None" to show no assets.
@@ -580,6 +596,7 @@ export const useFilteredRwaAssets = ({
 				totalOnChainMcap,
 				totalActiveMcap,
 				totalOnChainDeFiActiveTvl,
+				totalOpenInterest,
 				totalIssuersCount: totalIssuersSet.size
 			}
 
@@ -616,6 +633,9 @@ export const useFilteredRwaAssets = ({
 				continue
 			}
 			if (!includeGovernance && asset.governance) {
+				continue
+			}
+			if (!includeRwaPerps && asset.kind === 'perps') {
 				continue
 			}
 			if (
@@ -685,6 +705,7 @@ export const useFilteredRwaAssets = ({
 				totalOnChainMcap += onChainMcap
 				totalActiveMcap += activeMcap
 				totalOnChainDeFiActiveTvl += defiActiveTvl
+				totalOpenInterest += asset.openInterest ?? 0
 				if (asset.issuer) {
 					totalIssuersSet.add(asset.issuer)
 				}
@@ -696,6 +717,7 @@ export const useFilteredRwaAssets = ({
 			totalOnChainMcap,
 			totalActiveMcap,
 			totalOnChainDeFiActiveTvl,
+			totalOpenInterest,
 			totalIssuersCount: totalIssuersSet.size
 		}
 	}, [
@@ -719,6 +741,7 @@ export const useFilteredRwaAssets = ({
 		selectedSelfCustodyStates,
 		includeStablecoins,
 		includeGovernance,
+		includeRwaPerps,
 		minDefiActiveTvlToOnChainMcapPct,
 		maxDefiActiveTvlToOnChainMcapPct,
 		minActiveMcapToOnChainMcapPct,
@@ -1209,7 +1232,8 @@ const CHART_FILTER_QUERY_KEYS = new Set([
 	'minDefiActiveTvlToActiveMcapPct',
 	'maxDefiActiveTvlToActiveMcapPct',
 	'includeStablecoins',
-	'includeGovernance'
+	'includeGovernance',
+	'includeRwaPerps'
 ])
 
 export function hasActiveChartFilters(
@@ -1226,6 +1250,10 @@ export function hasActiveChartFilters(
 		}
 		if (key === 'includeGovernance') {
 			if (hasActiveInclusionOverride(query.includeGovernance, defaultInclusion.includeGovernance)) return true
+			continue
+		}
+		if (key === 'includeRwaPerps') {
+			if (hasActiveInclusionOverride(query.includeRwaPerps, true)) return true
 			continue
 		}
 		if (key in query) return true

--- a/src/containers/RWA/hooks.tsx
+++ b/src/containers/RWA/hooks.tsx
@@ -18,7 +18,10 @@ import { normalizeRwaAssetGroup } from './assetGroup'
 import {
 	aggregateRwaMetricData,
 	appendRwaChartDatasetTotal,
+	buildRwaOpenInterestDataset,
 	emptyChartDataset,
+	mergeRwaChartDatasets,
+	renameRwaChartDatasetTotal,
 	selectRwaChartDatasetSeries,
 	type RWAChartDataset,
 	type RWAChartAggregationMode
@@ -1253,7 +1256,6 @@ export function hasActiveChartFilters(
 			continue
 		}
 		if (key === 'includeRwaPerps') {
-			if (hasActiveInclusionOverride(query.includeRwaPerps, true)) return true
 			continue
 		}
 		if (key in query) return true
@@ -1275,6 +1277,10 @@ export function getRwaAssetChartQueryKey(
 		includeStablecoins,
 		includeGovernance
 	] as const
+}
+
+export function getRwaOpenInterestChartQueryKey() {
+	return ['rwa-perps-open-interest-chart'] as const
 }
 
 function assert(condition: unknown, message: string): asserts condition {
@@ -1319,23 +1325,31 @@ async function fetchRwaAssetChartData(params: {
 	return fetchJson<IRWAChartMetricRows>(`/api/rwa/asset-breakdown?${searchParams.toString()}`)
 }
 
+async function fetchRwaOpenInterestChartData(): Promise<RWAChartDataset> {
+	return fetchJson<RWAChartDataset>('/api/rwa/perps/contract-breakdown?key=openInterest')
+}
+
 export function useRwaChartDataset({
 	selectedMetric,
 	initialDataset,
+	initialOpenInterestDataset,
 	filteredAssets,
 	mode,
 	target,
 	includeStablecoins,
 	includeGovernance,
+	includeRwaPerps,
 	useInitialDataset
 }: {
 	selectedMetric: RWAChartMetricKey
 	initialDataset: RWAChartDataset
+	initialOpenInterestDataset: RWAChartDataset | null
 	filteredAssets: IRWAAssetsOverview['assets']
 	mode: RWAChartAggregationMode
 	target: RWAAssetChartTarget
 	includeStablecoins: boolean
 	includeGovernance: boolean
+	includeRwaPerps: boolean
 	useInitialDataset: boolean
 }): {
 	chartDataset: RWAChartDataset
@@ -1358,25 +1372,62 @@ export function useRwaChartDataset({
 		staleTime: 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
 		retry: 1,
-		enabled: !useInitialDataset
+		enabled: !useInitialDataset && filteredAssets.some((asset) => asset.kind === 'spot')
+	})
+	const {
+		data: openInterestRows,
+		isLoading: isOpenInterestLoading,
+		error: openInterestError
+	} = useQuery({
+		queryKey: getRwaOpenInterestChartQueryKey(),
+		queryFn: () => fetchRwaOpenInterestChartData(),
+		staleTime: 60 * 60 * 1000,
+		refetchOnWindowFocus: false,
+		retry: 1,
+		enabled: !useInitialDataset && includeRwaPerps && filteredAssets.some((asset) => asset.kind === 'perps')
 	})
 
 	assert(initialDataset.dimensions[0] === 'timestamp', 'Expected timestamp dimension')
 
 	const chartDataset = useMemo(() => {
-		if (useInitialDataset) {
-			return mode === 'total'
-				? selectRwaChartDatasetSeries(initialDataset, ['Total'])
-				: appendRwaChartDatasetTotal(initialDataset)
-		}
-		if (!assetRows) return emptyChartDataset()
-		const dataset = aggregateRwaMetricData(filteredAssets, assetRows, mode)
-		return mode === 'total' ? dataset : appendRwaChartDatasetTotal(dataset)
-	}, [useInitialDataset, initialDataset, assetRows, filteredAssets, mode])
+		const spotDataset = (() => {
+			if (useInitialDataset) {
+				const dataset =
+					mode === 'total'
+						? selectRwaChartDatasetSeries(initialDataset, ['Total'])
+						: appendRwaChartDatasetTotal(initialDataset)
+				return renameRwaChartDatasetTotal(dataset, selectedMetric)
+			}
+			if (!assetRows) return emptyChartDataset()
+			const dataset = aggregateRwaMetricData(filteredAssets, assetRows, mode)
+			const datasetWithTotal = mode === 'total' ? dataset : appendRwaChartDatasetTotal(dataset)
+			return renameRwaChartDatasetTotal(datasetWithTotal, selectedMetric)
+		})()
+
+		if (!includeRwaPerps) return spotDataset
+
+		const openInterestDataset = useInitialDataset
+			? (initialOpenInterestDataset ?? emptyChartDataset())
+			: openInterestRows
+				? buildRwaOpenInterestDataset(filteredAssets, openInterestRows)
+				: emptyChartDataset()
+
+		return mergeRwaChartDatasets(spotDataset, openInterestDataset)
+	}, [
+		useInitialDataset,
+		initialDataset,
+		initialOpenInterestDataset,
+		assetRows,
+		openInterestRows,
+		filteredAssets,
+		mode,
+		selectedMetric,
+		includeRwaPerps
+	])
 
 	return {
 		chartDataset,
-		isChartLoading: !useInitialDataset && isLoading,
-		chartError: error ? getErrorMessage(error) : null
+		isChartLoading: !useInitialDataset && (isLoading || isOpenInterestLoading),
+		chartError: error ? getErrorMessage(error) : openInterestError ? getErrorMessage(openInterestError) : null
 	}
 }

--- a/src/containers/RWA/index.tsx
+++ b/src/containers/RWA/index.tsx
@@ -193,11 +193,13 @@ export const RWAOverview = (props: IRWAAssetsOverview) => {
 	const { chartDataset, isChartLoading, chartError } = useRwaChartDataset({
 		selectedMetric: chartTypeKey,
 		initialDataset: initialChartDataset[chartTypeKey],
+		initialOpenInterestDataset: props.initialOpenInterestChartDataset,
 		filteredAssets,
 		mode: getRwaChartAggregationMode(timeSeriesBreakdown),
 		target: chartTarget,
 		includeStablecoins,
 		includeGovernance,
+		includeRwaPerps,
 		useInitialDataset:
 			!activeFilters &&
 			(timeSeriesBreakdown === getDefaultChartBreakdown(chartMode, 'timeSeries') || timeSeriesBreakdown === 'total')
@@ -815,10 +817,17 @@ function assertNever(value: never): never {
 }
 
 function buildRwaTimeSeriesCharts(dimensions: string[]): Array<MultiSeriesChart2SeriesConfig> {
-	const seriesDimensions = dimensions.filter((dimension) => dimension !== 'timestamp')
+	const seriesDimensions = dimensions
+		.filter((dimension) => dimension !== 'timestamp')
+		.sort((a, b) => {
+			const aRank = a.startsWith('Total ') ? 0 : a === 'RWA Perps OI' ? 1 : 2
+			const bRank = b.startsWith('Total ') ? 0 : b === 'RWA Perps OI' ? 1 : 2
+			if (aRank !== bRank) return aRank - bRank
+			return 0
+		})
 
 	return seriesDimensions.map((name, index) => {
-		const isTotalSeries = name === 'Total'
+		const isTotalSeries = name.startsWith('Total ') || name === 'RWA Perps OI'
 
 		return {
 			type: 'line',

--- a/src/containers/RWA/index.tsx
+++ b/src/containers/RWA/index.tsx
@@ -57,6 +57,7 @@ import {
 	useRwaChartDataset,
 	hasActiveChartFilters
 } from './hooks'
+import { perpsDefinitions } from './Perps/definitions'
 import { rwaSlug } from './rwaSlug'
 import { buildRwaNestedTreemapTreeData, buildRwaTreemapTreeData, canBuildRwaNestedTreemap } from './treemap'
 
@@ -121,11 +122,13 @@ export const RWAOverview = (props: IRWAAssetsOverview) => {
 		maxDefiActiveTvlToActiveMcapPct,
 		includeStablecoins,
 		includeGovernance,
+		includeRwaPerps,
 		setDefiActiveTvlToOnChainMcapPctRange,
 		setActiveMcapToOnChainMcapPctRange,
 		setDefiActiveTvlToActiveMcapPctRange,
 		setIncludeStablecoins,
 		setIncludeGovernance,
+		setIncludeRwaPerps,
 		setRedeemableStates,
 		setAttestationsStates,
 		setCexListedStates,
@@ -147,35 +150,42 @@ export const RWAOverview = (props: IRWAAssetsOverview) => {
 		mode
 	})
 
-	const { filteredAssets, totalOnChainMcap, totalActiveMcap, totalOnChainDeFiActiveTvl, totalIssuersCount } =
-		useFilteredRwaAssets({
-			assets: props.assets,
-			isPlatformMode,
-			selectedAssetNames,
-			selectedCategories,
-			selectedPlatforms,
-			selectedAssetGroups,
-			selectedAssetClasses,
-			selectedRwaClassifications,
-			selectedAccessModels,
-			selectedIssuers,
-			selectedTypes,
-			selectedRedeemableStates,
-			selectedAttestationsStates,
-			selectedCexListedStates,
-			selectedKycForMintRedeemStates,
-			selectedKycAllowlistedWhitelistedToTransferHoldStates,
-			selectedTransferableStates,
-			selectedSelfCustodyStates,
-			includeStablecoins,
-			includeGovernance,
-			minDefiActiveTvlToOnChainMcapPct,
-			maxDefiActiveTvlToOnChainMcapPct,
-			minActiveMcapToOnChainMcapPct,
-			maxActiveMcapToOnChainMcapPct,
-			minDefiActiveTvlToActiveMcapPct,
-			maxDefiActiveTvlToActiveMcapPct
-		})
+	const {
+		filteredAssets,
+		totalOnChainMcap,
+		totalActiveMcap,
+		totalOnChainDeFiActiveTvl,
+		totalOpenInterest,
+		totalIssuersCount
+	} = useFilteredRwaAssets({
+		assets: props.assets,
+		isPlatformMode,
+		selectedAssetNames,
+		selectedCategories,
+		selectedPlatforms,
+		selectedAssetGroups,
+		selectedAssetClasses,
+		selectedRwaClassifications,
+		selectedAccessModels,
+		selectedIssuers,
+		selectedTypes,
+		selectedRedeemableStates,
+		selectedAttestationsStates,
+		selectedCexListedStates,
+		selectedKycForMintRedeemStates,
+		selectedKycAllowlistedWhitelistedToTransferHoldStates,
+		selectedTransferableStates,
+		selectedSelfCustodyStates,
+		includeStablecoins,
+		includeGovernance,
+		includeRwaPerps,
+		minDefiActiveTvlToOnChainMcapPct,
+		maxDefiActiveTvlToOnChainMcapPct,
+		minActiveMcapToOnChainMcapPct,
+		maxActiveMcapToOnChainMcapPct,
+		minDefiActiveTvlToActiveMcapPct,
+		maxDefiActiveTvlToActiveMcapPct
+	})
 
 	const activeFilters = hasActiveChartFilters(router.query, mode, props.categorySlug)
 	const initialChartDataset = props.initialChartDataset ?? EMPTY_INITIAL_CHART_DATASET
@@ -631,7 +641,8 @@ export const RWAOverview = (props: IRWAAssetsOverview) => {
 					minDefiActiveTvlToActiveMcapPct,
 					maxDefiActiveTvlToActiveMcapPct,
 					includeStablecoins,
-					includeGovernance
+					includeGovernance,
+					includeRwaPerps
 				}}
 				actions={{
 					setDefiActiveTvlToOnChainMcapPctRange,
@@ -639,6 +650,7 @@ export const RWAOverview = (props: IRWAAssetsOverview) => {
 					setDefiActiveTvlToActiveMcapPctRange,
 					setIncludeStablecoins,
 					setIncludeGovernance,
+					setIncludeRwaPerps,
 					setRedeemableStates,
 					setAttestationsStates,
 					setCexListedStates,
@@ -676,6 +688,17 @@ export const RWAOverview = (props: IRWAAssetsOverview) => {
 					</Tooltip>
 					<span className="font-jetbrains text-2xl font-medium">{formattedNum(totalOnChainDeFiActiveTvl, true)}</span>
 				</p>
+				{includeRwaPerps ? (
+					<p className="flex flex-1 flex-col gap-1 rounded-md border border-(--cards-border) bg-(--cards-bg) p-4">
+						<Tooltip
+							content={perpsDefinitions.totalOpenInterest.description}
+							className="text-(--text-label) underline decoration-dotted"
+						>
+							RWA Perps OI
+						</Tooltip>
+						<span className="font-jetbrains text-2xl font-medium">{formattedNum(totalOpenInterest, true)}</span>
+					</p>
+				) : null}
 				<p className="flex flex-1 flex-col gap-1 rounded-md border border-(--cards-border) bg-(--cards-bg) p-4">
 					<Tooltip
 						content={definitions.totalAssetIssuers.description}
@@ -775,7 +798,7 @@ export const RWAOverview = (props: IRWAAssetsOverview) => {
 					) : null}
 				</>
 			) : null}
-			<RWAAssetsTable assets={filteredAssets} selectedChain={props.selectedChain} />
+			<RWAAssetsTable assets={filteredAssets} selectedChain={props.selectedChain} includeRwaPerps={includeRwaPerps} />
 		</>
 	)
 }

--- a/src/containers/RWA/queries.test.ts
+++ b/src/containers/RWA/queries.test.ts
@@ -10,6 +10,7 @@ const fetchRWAPlatformBreakdownChartDataMock = vi.fn()
 const fetchRWAAssetGroupBreakdownChartDataMock = vi.fn()
 const fetchRWAAssetDataByIdMock = vi.fn()
 const fetchRWAAssetChartDataMock = vi.fn()
+const fetchRWAPerpsCurrentMock = vi.fn()
 
 vi.mock('./api', () => ({
 	fetchRWAActiveTVLs: (...args: unknown[]) => fetchRWAActiveTVLsMock(...args),
@@ -24,6 +25,10 @@ vi.mock('./api', () => ({
 	toUnixMsTimestamp: (timestamp: number) => timestamp
 }))
 
+vi.mock('./Perps/api', () => ({
+	fetchRWAPerpsCurrent: (...args: unknown[]) => fetchRWAPerpsCurrentMock(...args)
+}))
+
 describe('rwa queries', () => {
 	beforeEach(() => {
 		fetchRWAActiveTVLsMock.mockReset()
@@ -35,6 +40,7 @@ describe('rwa queries', () => {
 		fetchRWAAssetGroupBreakdownChartDataMock.mockReset()
 		fetchRWAAssetDataByIdMock.mockReset()
 		fetchRWAAssetChartDataMock.mockReset()
+		fetchRWAPerpsCurrentMock.mockReset()
 		fetchRWAChartDataByAssetMock.mockResolvedValue(null)
 		fetchRWAChainBreakdownChartDataMock.mockResolvedValue([])
 		fetchRWACategoryBreakdownChartDataMock.mockResolvedValue([])
@@ -42,6 +48,7 @@ describe('rwa queries', () => {
 		fetchRWAAssetGroupBreakdownChartDataMock.mockResolvedValue([])
 		fetchRWAAssetDataByIdMock.mockResolvedValue(null)
 		fetchRWAAssetChartDataMock.mockResolvedValue(null)
+		fetchRWAPerpsCurrentMock.mockResolvedValue([])
 	})
 
 	it('excludes assets tagged as RWA Perps from the standard rwa overview', async () => {
@@ -88,6 +95,97 @@ describe('rwa queries', () => {
 		expect(result?.categories).toEqual(['Treasuries'])
 		expect(result?.categoryValues).toEqual([{ name: 'Treasuries', value: 100 }])
 		expect(result?.categoryLinks).toEqual([])
+	})
+
+	it('merges perps contracts into the overview rows', async () => {
+		fetchRWAActiveTVLsMock.mockResolvedValue([
+			{
+				id: 'treasury-1',
+				canonicalMarketId: 'ondo/usdy',
+				ticker: 'USDY',
+				assetName: 'Ondo USDY',
+				category: ['Treasuries'],
+				assetGroup: 'Treasuries',
+				parentPlatform: 'Ondo',
+				onChainMcap: { Ethereum: 100 },
+				activeMcap: { Ethereum: 90 },
+				defiActiveTvl: { Ethereum: { Aave: 20 } }
+			}
+		])
+		fetchRWAPerpsCurrentMock.mockResolvedValue([
+			{
+				id: 'perps-1',
+				timestamp: 1,
+				contract: 'xyz:usdy',
+				venue: 'xyz',
+				openInterest: 10,
+				volume24h: 20,
+				price: 1.01,
+				priceChange24h: 0,
+				fundingRate: 0,
+				premium: 0,
+				cumulativeFunding: 0,
+				referenceAsset: 'Ondo USDY',
+				referenceAssetGroup: 'Treasuries',
+				assetClass: ['Bonds'],
+				parentPlatform: 'Ondo',
+				pair: null,
+				marginAsset: null,
+				settlementAsset: null,
+				category: ['RWA Perps', 'Treasuries'],
+				issuer: 'Ondo',
+				website: null,
+				oracleProvider: null,
+				description: null,
+				accessModel: 'Permissioned',
+				rwaClassification: 'RWA',
+				makerFeeRate: 0,
+				takerFeeRate: 0,
+				deployerFeeShare: 0,
+				oraclePx: 0,
+				midPx: 0,
+				prevDayPx: 0,
+				maxLeverage: 0,
+				szDecimals: 0,
+				volume7d: 0,
+				volume30d: 0,
+				volumeAllTime: 0,
+				estimatedProtocolFees24h: 0,
+				estimatedProtocolFees7d: 0,
+				estimatedProtocolFees30d: 0,
+				estimatedProtocolFeesAllTime: 0
+			}
+		])
+
+		const result = await getRWAAssetsOverview({
+			rwaList: {
+				chains: ['Ethereum'],
+				categories: ['Treasuries', 'RWA Perps'],
+				platforms: ['Ondo'],
+				assetGroups: ['Treasuries']
+			} as never
+		})
+
+		expect(result?.assets.map((asset) => asset.kind)).toEqual(['spot', 'perps'])
+		expect(result?.assets[0]).toMatchObject({
+			kind: 'spot',
+			detailHref: '/rwa/asset/ondo%2Fusdy'
+		})
+		expect(result?.assets[1]).toMatchObject({
+			kind: 'perps',
+			detailHref: '/rwa/perps/contract/xyz%3Ausdy',
+			assetName: 'Ondo USDY',
+			category: ['Treasuries'],
+			openInterest: 10,
+			volume24h: 20,
+			volume30d: 0,
+			onChainMcap: null,
+			activeMcap: null,
+			defiActiveTvl: null
+		})
+		expect(result?.types).toContain('Perp')
+		expect(result?.platforms).toContain('Ondo')
+		expect(result?.assetGroups).toContain('Treasuries')
 	})
 
 	it('excludes the RWA Perps bucket from category overview rows', async () => {

--- a/src/containers/RWA/queries.test.ts
+++ b/src/containers/RWA/queries.test.ts
@@ -11,6 +11,7 @@ const fetchRWAAssetGroupBreakdownChartDataMock = vi.fn()
 const fetchRWAAssetDataByIdMock = vi.fn()
 const fetchRWAAssetChartDataMock = vi.fn()
 const fetchRWAPerpsCurrentMock = vi.fn()
+const fetchRWAPerpsContractBreakdownChartDataMock = vi.fn()
 
 vi.mock('./api', () => ({
 	fetchRWAActiveTVLs: (...args: unknown[]) => fetchRWAActiveTVLsMock(...args),
@@ -26,7 +27,8 @@ vi.mock('./api', () => ({
 }))
 
 vi.mock('./Perps/api', () => ({
-	fetchRWAPerpsCurrent: (...args: unknown[]) => fetchRWAPerpsCurrentMock(...args)
+	fetchRWAPerpsCurrent: (...args: unknown[]) => fetchRWAPerpsCurrentMock(...args),
+	fetchRWAPerpsContractBreakdownChartData: (...args: unknown[]) => fetchRWAPerpsContractBreakdownChartDataMock(...args)
 }))
 
 describe('rwa queries', () => {
@@ -41,6 +43,7 @@ describe('rwa queries', () => {
 		fetchRWAAssetDataByIdMock.mockReset()
 		fetchRWAAssetChartDataMock.mockReset()
 		fetchRWAPerpsCurrentMock.mockReset()
+		fetchRWAPerpsContractBreakdownChartDataMock.mockReset()
 		fetchRWAChartDataByAssetMock.mockResolvedValue(null)
 		fetchRWAChainBreakdownChartDataMock.mockResolvedValue([])
 		fetchRWACategoryBreakdownChartDataMock.mockResolvedValue([])
@@ -49,6 +52,7 @@ describe('rwa queries', () => {
 		fetchRWAAssetDataByIdMock.mockResolvedValue(null)
 		fetchRWAAssetChartDataMock.mockResolvedValue(null)
 		fetchRWAPerpsCurrentMock.mockResolvedValue([])
+		fetchRWAPerpsContractBreakdownChartDataMock.mockResolvedValue([])
 	})
 
 	it('excludes assets tagged as RWA Perps from the standard rwa overview', async () => {
@@ -156,6 +160,7 @@ describe('rwa queries', () => {
 				estimatedProtocolFeesAllTime: 0
 			}
 		])
+		fetchRWAPerpsContractBreakdownChartDataMock.mockResolvedValue([{ timestamp: 1_000, 'xyz:usdy': 10 }])
 
 		const result = await getRWAAssetsOverview({
 			rwaList: {
@@ -182,6 +187,10 @@ describe('rwa queries', () => {
 			onChainMcap: null,
 			activeMcap: null,
 			defiActiveTvl: null
+		})
+		expect(result?.initialOpenInterestChartDataset).toEqual({
+			source: [{ timestamp: 1_000_000, 'RWA Perps OI': 10 }],
+			dimensions: ['timestamp', 'RWA Perps OI']
 		})
 		expect(result?.types).toContain('Perp')
 		expect(result?.platforms).toContain('Ondo')

--- a/src/containers/RWA/queries.test.ts
+++ b/src/containers/RWA/queries.test.ts
@@ -197,6 +197,97 @@ describe('rwa queries', () => {
 		expect(result?.assetGroups).toContain('Treasuries')
 	})
 
+	it('falls back to the spot overview when the perps markets request fails', async () => {
+		fetchRWAActiveTVLsMock.mockResolvedValue([
+			{
+				id: 'treasury-1',
+				canonicalMarketId: 'ondo/usdy',
+				ticker: 'USDY',
+				assetName: 'Ondo USDY',
+				category: ['Treasuries'],
+				assetGroup: 'Treasuries',
+				parentPlatform: 'Ondo',
+				onChainMcap: { Ethereum: 100 },
+				activeMcap: { Ethereum: 90 },
+				defiActiveTvl: { Ethereum: { Aave: 20 } }
+			}
+		])
+		fetchRWAPerpsCurrentMock.mockRejectedValue(new Error('temporary outage'))
+
+		const result = await getRWAAssetsOverview({
+			rwaList: {
+				chains: ['Ethereum'],
+				categories: ['Treasuries'],
+				platforms: ['Ondo'],
+				assetGroups: ['Treasuries']
+			} as never
+		})
+
+		expect(result?.assets.map((asset) => asset.kind)).toEqual(['spot'])
+		expect(result?.platforms).toEqual(['Ondo'])
+	})
+
+	it('resolves perps-only platform slugs on platform overview routes', async () => {
+		fetchRWAActiveTVLsMock.mockResolvedValue([])
+		fetchRWAPerpsCurrentMock.mockResolvedValue([
+			{
+				id: 'perps-1',
+				timestamp: 1,
+				contract: 'xyz:gold',
+				venue: 'xyz',
+				openInterest: 10,
+				volume24h: 20,
+				price: 1.01,
+				priceChange24h: 0,
+				fundingRate: 0,
+				premium: 0,
+				cumulativeFunding: 0,
+				referenceAsset: 'Gold',
+				referenceAssetGroup: 'Commodities',
+				assetClass: ['Commodities'],
+				parentPlatform: 'Trade[XYZ]',
+				pair: null,
+				marginAsset: null,
+				settlementAsset: null,
+				category: ['Commodities'],
+				issuer: 'XYZ',
+				website: null,
+				oracleProvider: null,
+				description: null,
+				accessModel: 'Permissionless',
+				rwaClassification: 'RWA',
+				makerFeeRate: 0,
+				takerFeeRate: 0,
+				deployerFeeShare: 0,
+				oraclePx: 0,
+				midPx: 0,
+				prevDayPx: 0,
+				maxLeverage: 0,
+				szDecimals: 0,
+				volume7d: 0,
+				volume30d: 0,
+				volumeAllTime: 0,
+				estimatedProtocolFees24h: 0,
+				estimatedProtocolFees7d: 0,
+				estimatedProtocolFees30d: 0,
+				estimatedProtocolFeesAllTime: 0
+			}
+		])
+
+		const result = await getRWAAssetsOverview({
+			platform: 'trade-xyz',
+			rwaList: {
+				chains: ['Ethereum'],
+				categories: ['Commodities'],
+				platforms: [],
+				assetGroups: ['Commodities']
+			} as never
+		})
+
+		expect(result?.selectedPlatform).toBe('Trade[XYZ]')
+		expect(result?.assets.map((asset) => asset.kind)).toEqual(['perps'])
+	})
+
 	it('excludes the RWA Perps bucket from category overview rows', async () => {
 		fetchRWAStatsMock.mockResolvedValue({
 			byCategory: {

--- a/src/containers/RWA/queries.tsx
+++ b/src/containers/RWA/queries.tsx
@@ -37,6 +37,7 @@ import {
 	aggregateRwaMetricData,
 	appendRwaChartDatasetTotal,
 	applyDefaultAssetFilters,
+	buildRwaOpenInterestDataset,
 	type RWAChartAggregationMode
 } from './chartAggregation'
 import {
@@ -47,8 +48,9 @@ import {
 } from './constants'
 import { definitions } from './definitions'
 import { getPrimaryRwaCategory, getRwaPlatforms, UNKNOWN_PLATFORM } from './grouping'
-import { fetchRWAPerpsCurrent } from './Perps/api'
-import type { IRWAPerpsMarket } from './Perps/api.types'
+import { fetchRWAPerpsContractBreakdownChartData, fetchRWAPerpsCurrent } from './Perps/api'
+import type { IRWAPerpsBreakdownChartResponse, IRWAPerpsMarket } from './Perps/api.types'
+import { toRWAPerpsBreakdownChartDataset } from './Perps/breakdownDataset'
 import { rwaSlug } from './rwaSlug'
 
 type ChainMetricBreakdown = Record<string, number | string> | null
@@ -236,16 +238,21 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 					: 'chain'
 		const defaultInclusion = getDefaultRWAOverviewInclusion(mode, selectedCategory ?? null)
 
-		const [data, perpsMarkets, chartData]: [Array<IFetchedRWAProject>, IRWAPerpsMarket[], IRWAChartDataByAsset | null] =
-			await Promise.all([
-				fetchRWAActiveTVLs(),
-				fetchRWAPerpsCurrent(),
-				fetchRWAChartDataByAsset({
-					target,
-					includeStablecoins: defaultInclusion.includeStablecoins,
-					includeGovernance: defaultInclusion.includeGovernance
-				})
-			])
+		const [data, perpsMarkets, chartData, openInterestChartRows]: [
+			Array<IFetchedRWAProject>,
+			IRWAPerpsMarket[],
+			IRWAChartDataByAsset | null,
+			IRWAPerpsBreakdownChartResponse | null
+		] = await Promise.all([
+			fetchRWAActiveTVLs(),
+			fetchRWAPerpsCurrent(),
+			fetchRWAChartDataByAsset({
+				target,
+				includeStablecoins: defaultInclusion.includeStablecoins,
+				includeGovernance: defaultInclusion.includeGovernance
+			}),
+			selectedChain ? Promise.resolve(null) : fetchRWAPerpsContractBreakdownChartData({ key: 'openInterest' })
+		])
 
 		assert(data, 'Failed to get RWA assets list')
 		assert(perpsMarkets, 'Failed to get RWA perps markets')
@@ -730,6 +737,10 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 					)
 				}
 			: null
+		const initialOpenInterestChartDataset =
+			selectedChain || openInterestChartRows == null
+				? null
+				: buildRwaOpenInterestDataset(defaultFilteredAssets, toRWAPerpsBreakdownChartDataset(openInterestChartRows))
 
 		return {
 			assets: assets.sort((a, b) => (b.onChainMcap?.total ?? 0) - (a.onChainMcap?.total ?? 0)),
@@ -818,6 +829,7 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 				}
 			},
 			initialChartDataset,
+			initialOpenInterestChartDataset,
 			chainSlug: selectedChain ?? null,
 			categorySlug: selectedCategory ?? null,
 			platformSlug: selectedPlatform ?? null,

--- a/src/containers/RWA/queries.tsx
+++ b/src/containers/RWA/queries.tsx
@@ -245,7 +245,7 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 			IRWAPerpsBreakdownChartResponse | null
 		] = await Promise.all([
 			fetchRWAActiveTVLs(),
-			fetchRWAPerpsCurrent(),
+			fetchRWAPerpsCurrent().catch(() => []),
 			fetchRWAChartDataByAsset({
 				target,
 				includeStablecoins: defaultInclusion.includeStablecoins,
@@ -255,7 +255,6 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 		])
 
 		assert(data, 'Failed to get RWA assets list')
-		assert(perpsMarkets, 'Failed to get RWA perps markets')
 		const filteredData = data.filter(
 			(item) => !(item.category ?? []).some((category) => !isCategoryIncludedInStandardRwaOverview(category))
 		)
@@ -322,7 +321,14 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 
 		let actualPlatformName: string | null = null
 		if (selectedPlatform) {
-			for (const platform of params.rwaList.platforms) {
+			const platformCandidates = new Set(params.rwaList.platforms)
+			for (const market of filteredPerpsMarkets) {
+				for (const platform of getRealRwaPlatforms(market.parentPlatform)) {
+					platformCandidates.add(platform)
+				}
+			}
+
+			for (const platform of platformCandidates) {
 				if (rwaSlug(platform) === selectedPlatform) {
 					actualPlatformName = platform
 					break

--- a/src/containers/RWA/queries.tsx
+++ b/src/containers/RWA/queries.tsx
@@ -17,7 +17,6 @@ import {
 import type {
 	IFetchedRWAProject,
 	IRWAChartDataByAsset,
-	IRWAProject,
 	IRWAAssetsOverview,
 	IRWAAssetData,
 	IRWAChainsOverview,
@@ -28,6 +27,8 @@ import type {
 	IRWAPlatformsOverviewRow,
 	IRWAAssetGroupsOverview,
 	IRWAAssetGroupsOverviewRow,
+	RWAPerpsOverviewAsset,
+	RWASpotOverviewAsset,
 	RWAAssetChartTarget
 } from './api.types'
 import { UNKNOWN_RWA_ASSET_GROUP, appendUnknownRwaAssetGroup, normalizeRwaAssetGroup } from './assetGroup'
@@ -46,6 +47,8 @@ import {
 } from './constants'
 import { definitions } from './definitions'
 import { getPrimaryRwaCategory, getRwaPlatforms, UNKNOWN_PLATFORM } from './grouping'
+import { fetchRWAPerpsCurrent } from './Perps/api'
+import type { IRWAPerpsMarket } from './Perps/api.types'
 import { rwaSlug } from './rwaSlug'
 
 type ChainMetricBreakdown = Record<string, number | string> | null
@@ -233,19 +236,26 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 					: 'chain'
 		const defaultInclusion = getDefaultRWAOverviewInclusion(mode, selectedCategory ?? null)
 
-		const [data, chartData]: [Array<IFetchedRWAProject>, IRWAChartDataByAsset | null] = await Promise.all([
-			fetchRWAActiveTVLs(),
-			fetchRWAChartDataByAsset({
-				target,
-				includeStablecoins: defaultInclusion.includeStablecoins,
-				includeGovernance: defaultInclusion.includeGovernance
-			})
-		])
+		const [data, perpsMarkets, chartData]: [Array<IFetchedRWAProject>, IRWAPerpsMarket[], IRWAChartDataByAsset | null] =
+			await Promise.all([
+				fetchRWAActiveTVLs(),
+				fetchRWAPerpsCurrent(),
+				fetchRWAChartDataByAsset({
+					target,
+					includeStablecoins: defaultInclusion.includeStablecoins,
+					includeGovernance: defaultInclusion.includeGovernance
+				})
+			])
 
 		assert(data, 'Failed to get RWA assets list')
+		assert(perpsMarkets, 'Failed to get RWA perps markets')
 		const filteredData = data.filter(
 			(item) => !(item.category ?? []).some((category) => !isCategoryIncludedInStandardRwaOverview(category))
 		)
+		const filteredPerpsMarkets = perpsMarkets.map((market) => ({
+			...market,
+			category: (market.category ?? []).filter((category) => isCategoryIncludedInStandardRwaOverview(category))
+		}))
 		const hasUnknownAssetGroup = filteredData.some(
 			(item) => normalizeRwaAssetGroup(item.assetGroup) === UNKNOWN_RWA_ASSET_GROUP
 		)
@@ -292,16 +302,11 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 		// `selectedCategory` comes from the URL and is slugified; resolve a display name (original casing/spaces)
 		let actualCategoryName: string | null = null
 		if (selectedCategory) {
-			for (const item of filteredData) {
-				if (item.category) {
-					for (const c of item.category) {
-						if (rwaSlug(c) === selectedCategory) {
-							actualCategoryName = c
-							break
-						}
-					}
+			for (const category of filterCategoriesForStandardRwaOverview(params.rwaList.categories)) {
+				if (rwaSlug(category) === selectedCategory) {
+					actualCategoryName = category
+					break
 				}
-				if (actualCategoryName) break
 			}
 			if (!actualCategoryName) {
 				return null
@@ -310,9 +315,8 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 
 		let actualPlatformName: string | null = null
 		if (selectedPlatform) {
-			for (const item of filteredData) {
-				const platform = getRealRwaPlatforms(item.parentPlatform).find((value) => rwaSlug(value) === selectedPlatform)
-				if (platform) {
+			for (const platform of params.rwaList.platforms) {
+				if (rwaSlug(platform) === selectedPlatform) {
 					actualPlatformName = platform
 					break
 				}
@@ -338,7 +342,7 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 			}
 		}
 
-		const assets: Array<IRWAProject> = []
+		const assets: IRWAAssetsOverview['assets'] = []
 		const types = new Map<string, number>()
 		const assetClasses = new Map<string, number>()
 		const rwaClassifications = new Map<string, number>()
@@ -413,11 +417,37 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 							...item.category.filter((c) => c && rwaSlug(c) !== selectedCategory)
 						]
 					: (item.category ?? null)
-			const asset: IRWAProject = {
-				...item,
-				rwaClassification: isTrueRWA ? 'RWA' : (item.rwaClassification ?? null),
-				trueRWA: isTrueRWA,
+			const asset: RWASpotOverviewAsset = {
+				id: item.id,
+				kind: 'spot',
+				detailHref: item.canonicalMarketId ? `/rwa/asset/${encodeURIComponent(item.canonicalMarketId)}` : '',
+				canonicalMarketId: item.canonicalMarketId ?? '',
+				assetName: item.assetName ?? '',
+				ticker: item.ticker,
+				primaryChain: item.primaryChain ?? null,
+				chain: item.chain ?? null,
+				price: item.price ?? null,
+				openInterest: null,
+				volume24h: null,
+				volume30d: null,
+				assetGroup: item.assetGroup ?? null,
+				parentPlatform: item.parentPlatform ?? null,
 				category: sortedCategories,
+				assetClass: item.assetClass ?? null,
+				accessModel: item.accessModel ?? null,
+				type: item.type ?? null,
+				rwaClassification: isTrueRWA ? 'RWA' : (item.rwaClassification ?? null),
+				issuer: item.issuer ?? null,
+				redeemable: item.redeemable ?? null,
+				attestations: item.attestations ?? null,
+				cexListed: item.cexListed ?? null,
+				kycForMintRedeem: item.kycForMintRedeem ?? null,
+				kycAllowlistedWhitelistedToTransferHold: item.kycAllowlistedWhitelistedToTransferHold ?? null,
+				transferable: item.transferable ?? null,
+				selfCustody: item.selfCustody ?? null,
+				stablecoin: item.stablecoin ?? null,
+				governance: item.governance ?? null,
+				trueRWA: isTrueRWA,
 				onChainMcap: onChainMcapBreakdown
 					? {
 							total: effectiveOnChainMcap,
@@ -544,6 +574,92 @@ export async function getRWAAssetsOverview(params: RWAAssetsOverviewParams): Pro
 					}
 					issuers.set(asset.issuer, (issuers.get(asset.issuer) ?? 0) + effectiveOnChainMcap)
 				}
+			}
+		}
+
+		for (const market of filteredPerpsMarkets) {
+			if (selectedChain) {
+				continue
+			}
+
+			const asset: RWAPerpsOverviewAsset = {
+				id: market.id,
+				kind: 'perps',
+				detailHref: `/rwa/perps/contract/${encodeURIComponent(market.contract)}`,
+				contract: market.contract,
+				assetName: market.referenceAsset ?? market.contract,
+				ticker: market.contract,
+				primaryChain: null,
+				chain: null,
+				price: market.price,
+				openInterest: market.openInterest,
+				volume24h: market.volume24h,
+				volume30d: market.volume30d,
+				assetGroup: market.referenceAssetGroup,
+				parentPlatform: market.parentPlatform,
+				category: market.category,
+				assetClass: market.assetClass,
+				accessModel: market.accessModel,
+				type: 'Perp',
+				rwaClassification: market.rwaClassification,
+				issuer: market.issuer,
+				redeemable: null,
+				attestations: null,
+				cexListed: null,
+				kycForMintRedeem: null,
+				kycAllowlistedWhitelistedToTransferHold: null,
+				transferable: null,
+				selfCustody: null,
+				stablecoin: null,
+				governance: null,
+				trueRWA: false,
+				onChainMcap: null,
+				activeMcap: null,
+				defiActiveTvl: null,
+				defiActiveTvlByChain: null
+			}
+			const hasCategoryMatch = selectedCategory
+				? (asset.category ?? []).some((category) => rwaSlug(category) === selectedCategory)
+				: true
+			const hasPlatformMatch = selectedPlatform
+				? getRealRwaPlatforms(asset.parentPlatform).some((platform) => rwaSlug(platform) === selectedPlatform)
+				: true
+			const hasAssetGroupMatch = selectedAssetGroup
+				? rwaSlug(normalizeRwaAssetGroup(asset.assetGroup)) === selectedAssetGroup
+				: true
+
+			if (!hasCategoryMatch || !hasPlatformMatch || !hasAssetGroupMatch || ASSETS_TO_EXCLUDE.has(asset.assetName)) {
+				continue
+			}
+
+			assets.push(asset)
+			if (selectedPlatform) {
+				assetNames.set(asset.assetName, assetNames.get(asset.assetName) ?? 0)
+			}
+			if (asset.type) {
+				types.set(asset.type, types.get(asset.type) ?? 0)
+			}
+			for (const assetClass of asset.assetClass ?? []) {
+				assetClasses.set(assetClass, assetClasses.get(assetClass) ?? 0)
+			}
+			const primaryCategory = getPrimaryRwaCategory(asset.category)
+			if (primaryCategory) {
+				categories.set(primaryCategory, categories.get(primaryCategory) ?? 0)
+			}
+			for (const platform of getRwaPlatforms(asset.parentPlatform)) {
+				if (platform === UNKNOWN_PLATFORM) continue
+				platforms.set(platform, platforms.get(platform) ?? 0)
+			}
+			const assetGroup = normalizeRwaAssetGroup(asset.assetGroup)
+			assetGroups.set(assetGroup, assetGroups.get(assetGroup) ?? 0)
+			if (asset.rwaClassification) {
+				rwaClassifications.set(asset.rwaClassification, rwaClassifications.get(asset.rwaClassification) ?? 0)
+			}
+			if (asset.accessModel) {
+				accessModels.set(asset.accessModel, accessModels.get(asset.accessModel) ?? 0)
+			}
+			if (asset.issuer) {
+				issuers.set(asset.issuer, issuers.get(asset.issuer) ?? 0)
 			}
 		}
 

--- a/src/containers/RWA/treemap.ts
+++ b/src/containers/RWA/treemap.ts
@@ -1,5 +1,5 @@
 import { CHART_COLORS } from '~/constants/colors'
-import type { IRWAAssetsOverview, IRWAProject } from './api.types'
+import type { IRWAAssetsOverview } from './api.types'
 import { normalizeRwaAssetGroup } from './assetGroup'
 import type { RWAChartMetric, RwaTreemapNestedBy, RwaTreemapParentGrouping } from './chartState'
 import { computeWeightedGroups } from './grouping'
@@ -15,6 +15,7 @@ export type RwaTreemapNode = {
 }
 
 const TREEMAP_COLORS = CHART_COLORS
+type RWAAsset = IRWAAssetsOverview['assets'][number]
 
 export const buildRwaTreemapTreeData = (pieData: RwaPieChartDatum[], breakdownLabel: string): RwaTreemapNode[] => {
 	const totalsByLabel = new Map<string, number>()
@@ -62,7 +63,7 @@ export const canBuildRwaNestedTreemap = ({
 	return true
 }
 
-const getRwaMetricValue = (asset: IRWAProject, metric: RWAChartMetric): number => {
+const getRwaMetricValue = (asset: RWAAsset, metric: RWAChartMetric): number => {
 	if (metric === 'activeMcap') return asset.activeMcap?.total ?? 0
 	if (metric === 'defiActiveTvl') return asset.defiActiveTvl?.total ?? 0
 	return asset.onChainMcap?.total ?? 0
@@ -70,7 +71,7 @@ const getRwaMetricValue = (asset: IRWAProject, metric: RWAChartMetric): number =
 
 type RwaMetricByChainRow = { label: string; value: number }
 
-const getRwaMetricBreakdownByChain = (asset: IRWAProject, metric: RWAChartMetric): RwaMetricByChainRow[] => {
+const getRwaMetricBreakdownByChain = (asset: RWAAsset, metric: RWAChartMetric): RwaMetricByChainRow[] => {
 	const breakdown =
 		metric === 'activeMcap'
 			? asset.activeMcap?.breakdown
@@ -126,7 +127,7 @@ const normalizeLabelsBySlug = (values: Array<string | null | undefined>, fallbac
 }
 
 const getAssetGroupsByGrouping = (
-	asset: IRWAProject,
+	asset: RWAAsset,
 	grouping: RwaTreemapParentGrouping | RwaTreemapNestedBy
 ): string[] => {
 	switch (grouping) {
@@ -150,9 +151,11 @@ const getAssetGroupsByGrouping = (
 		}
 		case 'chain':
 		default: {
+			if (asset.kind === 'perps') return ['Unknown']
+
 			const chains = [
-				...(asset.chain ?? []),
-				typeof asset.primaryChain === 'string' ? asset.primaryChain : null
+				...(asset.kind === 'spot' ? (asset.chain ?? []) : []),
+				asset.kind === 'spot' && typeof asset.primaryChain === 'string' ? asset.primaryChain : null
 			] as Array<string | null | undefined>
 			return normalizeLabelsBySlug(chains, 'Unknown')
 		}
@@ -160,7 +163,7 @@ const getAssetGroupsByGrouping = (
 }
 
 const getWeightedAssetGroupsByGrouping = (
-	asset: IRWAProject,
+	asset: RWAAsset,
 	grouping: RwaTreemapParentGrouping | RwaTreemapNestedBy
 ): Array<{ label: string; weight: number }> => {
 	return computeWeightedGroups(getAssetGroupsByGrouping(asset, grouping)).map(({ value, weight }) => ({

--- a/src/pages/rwa/perps/index.tsx
+++ b/src/pages/rwa/perps/index.tsx
@@ -1,5 +1,5 @@
 import type { InferGetStaticPropsType } from 'next'
-import { DEFAULT_CHART_VIEW } from '~/containers/RWA/Perps/chartState'
+import { getDefaultRWAPerpsChartView } from '~/containers/RWA/Perps/chartState'
 import { RWAPerpsDashboard } from '~/containers/RWA/Perps/Dashboard'
 import { getRWAPerpsOverview } from '~/containers/RWA/Perps/queries'
 import { RWAPerpsTabNav } from '~/containers/RWA/Perps/TabNav'
@@ -8,7 +8,7 @@ import { maxAgeForNext } from '~/utils/maxAgeForNext'
 import { withPerformanceLogging } from '~/utils/perf'
 
 export const getStaticProps = withPerformanceLogging(`rwa/perps/index`, async () => {
-	const data = await getRWAPerpsOverview({ activeView: DEFAULT_CHART_VIEW })
+	const data = await getRWAPerpsOverview({ activeView: getDefaultRWAPerpsChartView('overview') })
 
 	return {
 		props: { data },


### PR DESCRIPTION
## Summary
- merge the main RWA current assets and RWA perps current contracts in the overview query
- add the RWA Perps filter toggle, filtered RWA OI stats card, and perp contract routing from the overview table
- update the overview table to support mixed spot and perps metric columns and add regression coverage for the merged behavior

## Testing
- bun run format
- bun run lint
- bun run ts
- bun test src/containers/RWA/queries.test.ts src/containers/RWA/hooks.test.tsx src/containers/RWA/chartAggregation.test.ts src/containers/RWA/AssetsTable.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add RWA perps support: optional toggle to include/exclude perps in tables, charts, and metric cards.
  * New "RWA Perps OI" metric card and perps-aware chart overlay.

* **Improvements**
  * Metrics and table columns adapt when perps are included; search now matches parent platform.
  * Charting merges perps open-interest into time-series with improved labeling and ordering.
  
* **Tests**
  * Expanded test coverage for perps, charting, and dataset behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->