### PR TITLE
Auto-fit line chart y-axes by default

### DIFF
--- a/src/components/ECharts/MultiSeriesChart2/index.tsx
+++ b/src/components/ECharts/MultiSeriesChart2/index.tsx
@@ -29,6 +29,11 @@ import { useChartResize } from '~/hooks/useChartResize'
 import { useGetChartInstance } from '~/hooks/useGetChartInstance'
 import { useMedia } from '~/hooks/useMedia'
 import { formatNum, formattedNum, slug } from '~/utils'
+import {
+	getDefaultYAxisMinForSeriesTypes,
+	getRenderedSeriesTypesByYAxisIndex,
+	getZeroBaselineYAxisMin
+} from '../axisMin'
 import { ChartContainer } from '../ChartContainer'
 import { ChartHeader } from '../ChartHeader'
 import { isTooltipDataRecord, formatChartEmphasisDate, formatTooltipChartDate } from '../formatters'
@@ -62,14 +67,6 @@ function formatAxisLabel(value: number, symbol: string): string {
 	}
 
 	return formatNum(value, 5, symbol || undefined)
-}
-
-type AxisExtent = {
-	min?: number
-}
-
-function getZeroBaselineYAxisMin(extent: AxisExtent) {
-	return typeof extent.min === 'number' && extent.min < 0 ? extent.min : 0
 }
 
 type GroupBy = NonNullable<IMultiSeriesChart2Props['groupBy']>
@@ -214,6 +211,7 @@ function buildMultiYAxis({
 	const yAxisIndexToColor = new Map<number, string | undefined>()
 	const yAxisIndexToExplicitColor = new Map<number, string | undefined>()
 	const yAxisIndexToSymbol = new Map<number, string | undefined>()
+	const seriesTypesByAxisIndex = getRenderedSeriesTypesByYAxisIndex(series)
 	let maxIndex = -1
 
 	for (const item of series) {
@@ -275,12 +273,14 @@ function buildMultiYAxis({
 		const axisColor = yAxisIndexToExplicitColor.get(i) ?? (isPrimary ? undefined : yAxisIndexToColor.get(i))
 		const axisSymbol = yAxisIndexToSymbol.get(i) ?? valueSymbol
 		const offset = noOffset || i < 2 ? 0 : prevOffset + 40
+		const min = baseAxis?.min ?? getDefaultYAxisMinForSeriesTypes(seriesTypesByAxisIndex.get(i))
 
 		out.push({
 			...baseAxis,
 			position: isPrimary ? 'left' : 'right',
 			alignTicks: true,
 			offset,
+			...(expandTo100Percent ? { max: 100, min: 0 } : { min }),
 			axisLine: {
 				...baseAxisLine,
 				show: !isPrimary,
@@ -295,8 +295,7 @@ function buildMultiYAxis({
 				...baseAxisLabel,
 				formatter: existingFormatter ?? ((value: number) => formatAxisLabel(value, axisSymbol)),
 				...(axisColor ? { color: axisColor } : {})
-			},
-			...(expandTo100Percent ? { max: 100, min: 0 } : {})
+			}
 		})
 
 		prevOffset = offset
@@ -918,7 +917,12 @@ export default function MultiSeriesChart2(props: IMultiSeriesChart2Props) {
 				: [
 						{
 							...yAxis,
-							...(expandTo100Percent ? { max: 100, min: 0 } : {})
+							...(expandTo100Percent
+								? { max: 100, min: 0 }
+								: {
+										min:
+											yAxis?.min ?? getDefaultYAxisMinForSeriesTypes(getRenderedSeriesTypesByYAxisIndex(series).get(0))
+									})
 						}
 					]
 		const eventStripYAxisIndex = finalYAxisBase.length

--- a/src/components/ECharts/axisMin.test.ts
+++ b/src/components/ECharts/axisMin.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+	getAutoFitYAxisMin,
+	getDefaultYAxisMinForSeriesTypes,
+	getRenderedSeriesTypesByYAxisIndex,
+	getZeroBaselineYAxisMin
+} from './axisMin'
+
+describe('axisMin helpers', () => {
+	it('returns a padded data min for positive finite ranges', () => {
+		expect(getAutoFitYAxisMin({ min: 4, max: 8 })).toBe(3.8)
+	})
+
+	it('falls back safely for flat or invalid ranges', () => {
+		expect(getAutoFitYAxisMin({ min: 4, max: 4 })).toBe(4)
+		expect(Number.isNaN(getAutoFitYAxisMin({ min: Number.NaN, max: 8 }))).toBe(true)
+	})
+
+	it('keeps zero baseline for any axis with a bar series', () => {
+		expect(getDefaultYAxisMinForSeriesTypes(['line', 'bar'])).toBe(getZeroBaselineYAxisMin)
+		expect(getDefaultYAxisMinForSeriesTypes(['bar'])).toBe(getZeroBaselineYAxisMin)
+	})
+
+	it('auto-fits line-only axes', () => {
+		expect(getDefaultYAxisMinForSeriesTypes(['line'])).toBe(getAutoFitYAxisMin)
+	})
+
+	it('groups rendered series types by y-axis index', () => {
+		const seriesTypesByAxis = getRenderedSeriesTypesByYAxisIndex([
+			{ type: 'line' as const },
+			{ type: 'bar' as const, yAxisIndex: 1 },
+			{ type: 'line' as const, yAxisIndex: 1 }
+		])
+
+		expect(Array.from(seriesTypesByAxis.get(0) ?? [])).toEqual(['line'])
+		expect(Array.from(seriesTypesByAxis.get(1) ?? []).sort()).toEqual(['bar', 'line'])
+	})
+})

--- a/src/components/ECharts/axisMin.ts
+++ b/src/components/ECharts/axisMin.ts
@@ -1,0 +1,47 @@
+export type AxisExtent = {
+	min?: number
+	max?: number
+}
+
+export type AxisSeriesType = 'line' | 'bar'
+
+export function getZeroBaselineYAxisMin(extent: AxisExtent) {
+	return typeof extent.min === 'number' && extent.min < 0 ? extent.min : 0
+}
+
+export function getAutoFitYAxisMin(extent: AxisExtent) {
+	if (!Number.isFinite(extent.min) || !Number.isFinite(extent.max)) return extent.min
+	const range = extent.max - extent.min
+	if (range <= 0) return extent.min
+	return extent.min - range * 0.05
+}
+
+export function getRenderedSeriesTypesByYAxisIndex(
+	series: ReadonlyArray<{
+		type: AxisSeriesType
+		yAxisIndex?: number | null
+	}>
+) {
+	const seriesTypesByAxisIndex = new Map<number, Set<AxisSeriesType>>()
+
+	for (const { type, yAxisIndex } of series) {
+		const axisIndex = yAxisIndex ?? 0
+		const axisSeriesTypes = seriesTypesByAxisIndex.get(axisIndex) ?? new Set<AxisSeriesType>()
+		axisSeriesTypes.add(type)
+		seriesTypesByAxisIndex.set(axisIndex, axisSeriesTypes)
+	}
+
+	return seriesTypesByAxisIndex
+}
+
+export function getDefaultYAxisMinForSeriesTypes(seriesTypes?: Iterable<AxisSeriesType>) {
+	if (!seriesTypes) return getZeroBaselineYAxisMin
+
+	let hasLine = false
+	for (const type of seriesTypes) {
+		if (type === 'bar') return getZeroBaselineYAxisMin
+		if (type === 'line') hasLine = true
+	}
+
+	return hasLine ? getAutoFitYAxisMin : getZeroBaselineYAxisMin
+}

--- a/src/containers/ChainOverview/Chart.tsx
+++ b/src/containers/ChainOverview/Chart.tsx
@@ -44,8 +44,9 @@ export default function ChainCoreChart({
 		groupBy: tooltipGroupBy
 	})
 
-	const { series, allYAxis } = useMemo(() => {
+	const { series, allYAxis, barAxisTypes } = useMemo(() => {
 		const uniqueYAxis = new Set<ChainChartLabels>()
+		const barAxisTypes = new Set<ChainChartLabels>()
 		const stacks: ChainChartLabels[] = []
 		for (const stack in chartData) {
 			const chartLabel = stack as ChainChartLabels
@@ -62,6 +63,9 @@ export default function ChainCoreChart({
 
 			let type = BAR_CHARTS.includes(stack) && !isCumulative ? 'bar' : 'line'
 			type = DISABLED_CUMULATIVE_CHARTS.includes(stack) ? 'bar' : type
+			if (type === 'bar') {
+				barAxisTypes.add(yAxisByChart[stack])
+			}
 
 			const options = {
 				yAxisIndex: indexByYAxis[yAxisByChart[stack]]
@@ -110,7 +114,8 @@ export default function ChainCoreChart({
 
 		return {
 			series,
-			allYAxis: Object.entries(indexByYAxis) as Array<[ChainChartLabels, number | undefined]>
+			allYAxis: Object.entries(indexByYAxis) as Array<[ChainChartLabels, number | undefined]>,
+			barAxisTypes
 		}
 	}, [chartData, isThemeDark, isCumulative])
 
@@ -151,6 +156,7 @@ export default function ChainCoreChart({
 		const finalYAxis = buildChainYAxis({
 			allYAxis,
 			baseYAxis: yAxis,
+			barAxisTypes,
 			chartColors: chainOverviewChartColors,
 			chartsInSeries,
 			isThemeDark
@@ -175,7 +181,7 @@ export default function ChainCoreChart({
 			},
 			{ notMerge: true, lazyUpdate: true }
 		)
-	}, [defaultChartSettings, series, chartOptions, allYAxis, isThemeDark, hideDataZoom])
+	}, [defaultChartSettings, series, chartOptions, allYAxis, barAxisTypes, isThemeDark, hideDataZoom])
 
 	return (
 		<div

--- a/src/containers/ChainOverview/chartYAxis.test.ts
+++ b/src/containers/ChainOverview/chartYAxis.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { buildChainYAxis } from './chartYAxis'
+import type { ChainChartLabels } from './constants'
+
+describe('buildChainYAxis', () => {
+	it('auto-fits line-only axes', () => {
+		const [axis] = buildChainYAxis({
+			allYAxis: [['TVL', undefined]],
+			baseYAxis: {},
+			barAxisTypes: new Set<ChainChartLabels>(),
+			chartColors: { TVL: '#fff' },
+			chartsInSeries: new Set(['TVL']),
+			isThemeDark: false
+		})
+
+		const min = axis.min as (extent: { min?: number; max?: number }) => number | undefined
+		expect(min({ min: 4, max: 8 })).toBe(3.8)
+	})
+
+	it('keeps zero baseline for bar-backed axes', () => {
+		const [axis] = buildChainYAxis({
+			allYAxis: [['DEXs Volume', undefined]],
+			baseYAxis: {},
+			barAxisTypes: new Set<ChainChartLabels>(['DEXs Volume']),
+			chartColors: { 'DEXs Volume': '#fff' },
+			chartsInSeries: new Set(['DEXs Volume']),
+			isThemeDark: false
+		})
+
+		const min = axis.min as (extent: { min?: number; max?: number }) => number | undefined
+		expect(min({ min: 4, max: 8 })).toBe(0)
+	})
+
+	it('keeps the empty fallback zero-based', () => {
+		const [axis] = buildChainYAxis({
+			allYAxis: [],
+			baseYAxis: {},
+			barAxisTypes: new Set<ChainChartLabels>(),
+			chartColors: {},
+			chartsInSeries: new Set(),
+			isThemeDark: false
+		})
+
+		const min = axis.min as (extent: { min?: number; max?: number }) => number | undefined
+		expect(min({ min: 4, max: 8 })).toBe(0)
+	})
+})

--- a/src/containers/ChainOverview/chartYAxis.ts
+++ b/src/containers/ChainOverview/chartYAxis.ts
@@ -1,10 +1,7 @@
+import { getAutoFitYAxisMin, getZeroBaselineYAxisMin } from '~/components/ECharts/axisMin'
 import { formatTooltipValue } from '~/components/ECharts/formatters'
 import { formattedNum } from '~/utils'
 import type { ChainChartLabels } from './constants'
-
-type AxisExtent = {
-	min?: number
-}
 
 type AxisBuilderContext = {
 	chartColors: Record<string, string>
@@ -24,10 +21,6 @@ const DASHED_AXIS_LINE_STYLE = {
 	type: [5, 10],
 	dashOffset: 5
 } as const
-
-function getZeroBaselineYAxisMin(extent: AxisExtent) {
-	return typeof extent.min === 'number' && extent.min < 0 ? extent.min : 0
-}
 
 const AXIS_CONFIG_BY_TYPE: Partial<Record<ChainChartLabels, AxisConfig>> = {
 	'Stablecoins Mcap': {
@@ -105,12 +98,14 @@ const AXIS_CONFIG_BY_TYPE: Partial<Record<ChainChartLabels, AxisConfig>> = {
 export function buildChainYAxis({
 	allYAxis,
 	baseYAxis,
+	barAxisTypes,
 	chartColors,
 	chartsInSeries,
 	isThemeDark
 }: {
 	allYAxis: Array<[ChainChartLabels, number | undefined]>
 	baseYAxis: Record<string, unknown>
+	barAxisTypes: ReadonlySet<ChainChartLabels>
 	chartColors: Record<string, string>
 	chartsInSeries: Set<string>
 	isThemeDark: boolean
@@ -120,10 +115,12 @@ export function buildChainYAxis({
 	const noOffset = allYAxis.length < 3
 
 	for (const [type, index] of allYAxis) {
+		const min = barAxisTypes.has(type) ? getZeroBaselineYAxisMin : getAutoFitYAxisMin
+
 		if (type === 'TVL') {
 			finalYAxis.push({
 				...baseYAxis,
-				min: getZeroBaselineYAxisMin
+				min
 			})
 			continue
 		}
@@ -133,7 +130,7 @@ export function buildChainYAxis({
 			...baseYAxis,
 			name: '',
 			type: 'value',
-			min: getZeroBaselineYAxisMin,
+			min,
 			alignTicks: true,
 			offset: noOffset || index == null || index < 2 ? 0 : prevOffset + (CUSTOM_OFFSETS[type] ?? 40)
 		}

--- a/src/containers/ProtocolOverview/Chart.tsx
+++ b/src/containers/ProtocolOverview/Chart.tsx
@@ -64,8 +64,9 @@ export default function ProtocolChart({
 		[hallmarks, rangeHallmarks, isThemeDark]
 	)
 
-	const { series, allYAxis } = useMemo(() => {
+	const { series, allYAxis, barAxisTypes } = useMemo(() => {
 		const uniqueYAxis = new Set()
+		const barAxisTypes = new Set<ProtocolChartsLabels>()
 		const stacks: ProtocolChartsLabels[] = []
 		for (const stack in chartData) {
 			stacks.push(stack as ProtocolChartsLabels)
@@ -82,6 +83,9 @@ export default function ProtocolChart({
 		const series = stacks.map((stack, index) => {
 			const stackColor = chartColors[stack]
 			const type = BAR_CHARTS.includes(stack) && !isCumulative ? 'bar' : 'line'
+			if (type === 'bar') {
+				barAxisTypes.add(yAxisByChart[stack])
+			}
 
 			const options = {
 				yAxisIndex: indexByYAxis[yAxisByChart[stack]]
@@ -153,7 +157,8 @@ export default function ProtocolChart({
 
 		return {
 			series,
-			allYAxis: Object.entries(indexByYAxis) as Array<[ProtocolChartsLabels, number | undefined]>
+			allYAxis: Object.entries(indexByYAxis) as Array<[ProtocolChartsLabels, number | undefined]>,
+			barAxisTypes
 		}
 	}, [chartData, chartColors, isThemeDark, isCumulative, rangeHallmarks])
 
@@ -199,6 +204,7 @@ export default function ProtocolChart({
 		const finalYAxis = buildProtocolYAxis({
 			allYAxis,
 			baseYAxis: yAxis,
+			barAxisTypes,
 			chartColors,
 			chartsInSeries,
 			unlockTokenSymbol
@@ -290,6 +296,7 @@ export default function ProtocolChart({
 		unlockTokenSymbol,
 		chartColors,
 		allYAxis,
+		barAxisTypes,
 		rangeHallmarks,
 		eventRailData,
 		isThemeDark,

--- a/src/containers/ProtocolOverview/chartYAxis.test.ts
+++ b/src/containers/ProtocolOverview/chartYAxis.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { buildProtocolYAxis } from './chartYAxis'
+import type { ProtocolChartsLabels } from './constants'
+
+describe('buildProtocolYAxis', () => {
+	it('auto-fits line-only axes', () => {
+		const [axis] = buildProtocolYAxis({
+			allYAxis: [['TVL', undefined]],
+			baseYAxis: {},
+			barAxisTypes: new Set<ProtocolChartsLabels>(),
+			chartColors: { TVL: '#fff' },
+			chartsInSeries: new Set(['TVL']),
+			unlockTokenSymbol: ''
+		})
+
+		const min = axis.min as (extent: { min?: number; max?: number }) => number | undefined
+		expect(min({ min: 4, max: 8 })).toBe(3.8)
+	})
+
+	it('keeps zero baseline for bar-backed axes', () => {
+		const [axis] = buildProtocolYAxis({
+			allYAxis: [['Fees', undefined]],
+			baseYAxis: {},
+			barAxisTypes: new Set<ProtocolChartsLabels>(['Fees']),
+			chartColors: { Fees: '#fff' },
+			chartsInSeries: new Set(['Fees']),
+			unlockTokenSymbol: ''
+		})
+
+		const min = axis.min as (extent: { min?: number; max?: number }) => number | undefined
+		expect(min({ min: 4, max: 8 })).toBe(0)
+	})
+
+	it('keeps the empty fallback zero-based', () => {
+		const [axis] = buildProtocolYAxis({
+			allYAxis: [],
+			baseYAxis: {},
+			barAxisTypes: new Set<ProtocolChartsLabels>(),
+			chartColors: {},
+			chartsInSeries: new Set(),
+			unlockTokenSymbol: ''
+		})
+
+		const min = axis.min as (extent: { min?: number; max?: number }) => number | undefined
+		expect(min({ min: 4, max: 8 })).toBe(0)
+	})
+})

--- a/src/containers/ProtocolOverview/chartYAxis.ts
+++ b/src/containers/ProtocolOverview/chartYAxis.ts
@@ -1,9 +1,6 @@
+import { getAutoFitYAxisMin, getZeroBaselineYAxisMin } from '~/components/ECharts/axisMin'
 import { formattedNum } from '~/utils'
 import type { ProtocolChartsLabels } from './constants'
-
-type AxisExtent = {
-	min?: number
-}
 
 type AxisBuilderContext = {
 	chartColors: Record<string, string>
@@ -27,10 +24,6 @@ const DASHED_AXIS_LINE_STYLE = {
 	type: [5, 10],
 	dashOffset: 5
 } as const
-
-function getZeroBaselineYAxisMin(extent: AxisExtent) {
-	return typeof extent.min === 'number' && extent.min < 0 ? extent.min : 0
-}
 
 const AXIS_CONFIG_BY_TYPE: Partial<Record<ProtocolChartsLabels, AxisConfig>> = {
 	'Token Price': {
@@ -125,12 +118,14 @@ const AXIS_CONFIG_BY_TYPE: Partial<Record<ProtocolChartsLabels, AxisConfig>> = {
 export function buildProtocolYAxis({
 	allYAxis,
 	baseYAxis,
+	barAxisTypes,
 	chartColors,
 	chartsInSeries,
 	unlockTokenSymbol
 }: {
 	allYAxis: Array<[ProtocolChartsLabels, number | undefined]>
 	baseYAxis: Record<string, unknown>
+	barAxisTypes: ReadonlySet<ProtocolChartsLabels>
 	chartColors: Record<string, string>
 	chartsInSeries: Set<string>
 	unlockTokenSymbol: string
@@ -140,10 +135,12 @@ export function buildProtocolYAxis({
 	const noOffset = allYAxis.length < 3
 
 	for (const [type, index] of allYAxis) {
+		const min = barAxisTypes.has(type) ? getZeroBaselineYAxisMin : getAutoFitYAxisMin
+
 		if (type === 'TVL') {
 			finalYAxis.push({
 				...baseYAxis,
-				min: getZeroBaselineYAxisMin
+				min
 			})
 			continue
 		}
@@ -153,7 +150,7 @@ export function buildProtocolYAxis({
 			...baseYAxis,
 			name: '',
 			type: 'value',
-			min: getZeroBaselineYAxisMin,
+			min,
 			alignTicks: true,
 			offset: noOffset || index == null || index < 2 ? 0 : prevOffset + (CUSTOM_OFFSETS[type] ?? 40)
 		}


### PR DESCRIPTION
## Summary
- auto-fit line-only y-axes by default in `MultiSeriesChart2`
- keep zero baselines for bar-backed axes and preserve existing `0..100` percent and dominance chart behavior
- apply the same rendered-series-driven y-axis logic to Chain Overview and Protocol Overview charts
- add focused unit tests for shared axis-min helpers and overview y-axis builders

## Why
Charts that render line series over a narrow range can look artificially flat when the y-axis is always anchored at zero. This keeps the existing bar-chart behavior while letting line charts scale to the data range by default.

## Validation
- `bun x vitest run src/components/ECharts/axisMin.test.ts src/containers/ChainOverview/chartYAxis.test.ts src/containers/ProtocolOverview/chartYAxis.test.ts`
- `bun run format`
- `bun run lint`
- `bun run ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced Y-axis scaling logic with optimized minimum value calculations. Bar charts now properly use zero baseline, while line charts employ auto-fit scaling for improved visual representation.

* **Tests**
  * Added comprehensive test coverage for Y-axis minimum calculations and scaling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->